### PR TITLE
Fix: IDM groups can not be deleted

### DIFF
--- a/cmd/ctl/cmd/user.go
+++ b/cmd/ctl/cmd/user.go
@@ -94,7 +94,7 @@ func searchUser(ctx context.Context, cli idm.UserServiceClient, login string) ([
 func deleteUser(ctx context.Context, login string) error {
 
 	singleQ := &idm.UserSingleQuery{}
-	if strings.HasSuffix(login, "%2F") {
+	if strings.HasSuffix(login, "%2F") || strings.HasSuffix(login, "/") {
 		// log.Logger(ctx).Debug("Received User.Delete API request (GROUP)", zap.String("login", login))
 		singleQ.GroupPath = login
 		singleQ.Recursive = true

--- a/idm/user/rest/rest.go
+++ b/idm/user/rest/rest.go
@@ -225,7 +225,7 @@ func (s *UserHandler) DeleteUser(req *restful.Request, rsp *restful.Response) {
 	ctx := req.Request.Context()
 	singleQ := &idm.UserSingleQuery{}
 	uName, claims := utils.FindUserNameInContext(ctx)
-	if strings.HasSuffix(req.Request.RequestURI, "%2F") {
+	if strings.HasSuffix(req.Request.RequestURI, "%2F") || strings.HasSuffix(req.Request.RequestURI, "/") {
 		log.Logger(req.Request.Context()).Info("Received User.Delete API request (GROUP)", zap.String("login", login), zap.String("crtGroup", claims.GroupPath), zap.String("request", req.Request.RequestURI))
 		if strings.HasPrefix(claims.GroupPath, "/"+login) {
 			service.RestError403(req, rsp, errors.Forbidden(common.SERVICE_USER, "You are about to delete your own group!"))


### PR DESCRIPTION
(see also: https://forum.pydio.com/t/unable-to-delete-user-groups-1-2-5-dev-head/2111)

This PR fixes (or works around?) an issue where IDM groups can not be deleted. In code a group deletion request gets differentiated from a user request by a request path suffix. In code the suffix "%2F" was required that for but during tests the browser used to append "/" (unencoded) instead causing group deletion requests to fail.

The only change made in this PR is to also allow "/" as request suffix ("/" is not allowed in group IDs).