### PR TITLE
Eleminate use of depreciated tx_isolation for MySQL 5.7.20+ compatibility

### DIFF
--- a/vendor/github.com/coreos/dex/storage/sql/config.go
+++ b/vendor/github.com/coreos/dex/storage/sql/config.go
@@ -175,7 +175,6 @@ func (s *MySQL) open(logger logrus.FieldLogger) (*conn, error) {
 
 	params := make(map[string]string)
 	params["autocommit"] = "false"
-	params["tx_isolation"] = "SERIALIZABLE"
 	dexDSN.Params = params
 
 	db, err := sql.Open("mysql", dexDSN.FormatDSN())
@@ -198,6 +197,11 @@ func (s *MySQL) open(logger logrus.FieldLogger) (*conn, error) {
 	}
 
 	c := &conn{db, flavorMySQL, logger, errCheck}
+
+	if _, err := c.Exec("SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE"); err != nil {
+		return nil, fmt.Errorf("failed to set transaction isolation level: %v", err)
+	}
+
 	if _, err := c.migrate(); err != nil {
 		return nil, fmt.Errorf("failed to open migrations: %v", err)
 	}


### PR DESCRIPTION
Eleminate use of depreciated tx_isolation in favour of 'SET SESSION TRANSACTION ISOLATION LEVEL' for MySQL 5.7.20+ compatibility.

The system variable _tx_isolation_ has been marked depreciated in MySQL 5.7.20 and a new alias _transaction_isolation_ has been added. This will break cell for MySQL 5.7.20+.

To gain compatibility to pre 5.7.20 and 5.7.20+ the DSN parameter tx_isolation has been replaced by executing the SQL statement "SET SESSION TRANSACTION ISOLATION LEVEL" prior to calling migrate().