### PR TITLE
fix: quote database name to allow minus sign

### DIFF
--- a/common/dao/mysql.go
+++ b/common/dao/mysql.go
@@ -57,7 +57,7 @@ func (m *mysql) Open(dsn string) (Conn, error) {
 	if db, err = getSqlConnection("mysql", rootDSN); err != nil {
 		return nil, err
 	}
-	if _, err = db.Exec(fmt.Sprintf("create database if not exists %s", dbName)); err != nil {
+	if _, err = db.Exec(fmt.Sprintf("create database if not exists `%s`", dbName)); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
A minus sign in the database name causes the database connection to fail. With this fix the database name will be quoted in the 'create database ...' statement. (Tested agaist current head)