### PR TITLE
Check to see if bucket is an existing localfolder

### DIFF
--- a/common/config/datasources.go
+++ b/common/config/datasources.go
@@ -255,7 +255,7 @@ func FactorizeMinioServers(existingConfigs map[string]*object.MinioConfig, newSo
 		dsDir, bucket := filepath.Split(newSource.StorageConfiguration["folder"])
 		peerAddress := newSource.PeerAddress
 		dsDir = strings.TrimRight(dsDir, "/")
-		if minioConfig, e := filterMiniosWithBaseFolder(existingConfigs, peerAddress, dsDir); e != nil {
+		if minioConfig, e := filterMiniosWithBaseFolder(existingConfigs, peerAddress, dsDir, bucket); e != nil {
 			return nil, e
 		} else if minioConfig != nil {
 			config = minioConfig
@@ -354,14 +354,14 @@ func filterGatewaysWithStorageConfigKey(configs map[string]*object.MinioConfig, 
 }
 
 // filterGatewaysWithKeys finds local folder configs that share the same base folder
-func filterMiniosWithBaseFolder(configs map[string]*object.MinioConfig, peerAddress string, folder string) (*object.MinioConfig, error) {
+func filterMiniosWithBaseFolder(configs map[string]*object.MinioConfig, peerAddress string, folder string, bucket string) (*object.MinioConfig, error) {
 
 	for _, source := range configs {
 		if source.StorageType == object.StorageType_LOCAL && net.PeerAddressesAreSameNode(source.PeerAddress, peerAddress) {
 			sep := string(os.PathSeparator)
 			if source.LocalFolder == folder {
 				return source, nil
-			} else if strings.HasPrefix(source.LocalFolder, strings.TrimRight(folder, sep)+sep) || strings.HasPrefix(folder, strings.TrimRight(source.LocalFolder, sep)+sep) {
+			} else if strings.HasPrefix(source.LocalFolder, strings.TrimRight(folder, sep)+sep) && strings.HasSuffix(source.LocalFolder, bucket) || strings.HasPrefix(folder, strings.TrimRight(source.LocalFolder, sep)+sep) {
 				return nil, errors.Conflict("datasource.nested.path", "object service %s is already pointing to %s, make sure to avoid using nested paths for different datasources", source.Name, source.LocalFolder)
 			}
 		}


### PR DESCRIPTION
Currently it is impossible to setup a bucket alongside a folder which contains other buckets.

For example if a user sets up their default data folder as `/home/user1/data/` this will create a bucket called `/home/user1/data/cellsdata` and a few others. This will make it so that the user cannot create a bucket called `/home/user1/otherdata` because of the constraints which restrict users from creating local folder configs with where a folder may be nested within another. 

I believe the motivation for this is sound since we would not want users to setup a folder with buckets in it as a bucket itself. However, the current restriction forces users to create counter intuitive folder setups as a workaround, namely by nesting folders in a way that makes logical sense according to the restriction but may not make sense from a user perspective.

This pull request adds a simple check to see if the bucket being added is a folder that contains other buckets based on the current Minio configuration. This solution preserves the intended functionality of preventing users from creating buckets within buckets while additionally allowing users to create buckets that exist alongside folders which contain other buckets. 