### PR TITLE
Remove `github.com/ghodss/yaml` dependency

### DIFF
--- a/common/auth/mapping-rule.go
+++ b/common/auth/mapping-rule.go
@@ -26,16 +26,16 @@ import (
 )
 
 type MappingRule struct {
-	RuleName string
+	RuleName string `yaml:"RuleName"`
 
 	// Left Attribute is attribute of external user (ldap, sql, api ...)
 	// For example: displayName, mail, memberOf
-	LeftAttribute string
+	LeftAttribute string `yaml:"LeftAttribute"`
 
 	// Right Attribute is attribute of standard user
 	// For example: displayName, email
 	// Two reserved attributes: Roles, GroupPath
-	RightAttribute string
+	RightAttribute string `yaml:"RightAttribute"`
 
 	// Attribute value type: single value or multiple values
 	// MultipleValueRightAttr bool `json:"MultipleValueRightAttr"`
@@ -45,11 +45,11 @@ type MappingRule struct {
 	// * Empty
 	// * A list of accepted values separated by comma , . For example: teacher,researcher,employee
 	// * preg string
-	RuleString string
+	RuleString string `yaml:"RuleString"`
 
 	// RolePrefix
 	// AuthSourceName_Prefix_RoleID
-	RolePrefix string
+	RolePrefix string `yaml:"RolePrefix"`
 }
 
 // IsDnFormat simply checks if the passed string is valid. See: https://www.ietf.org/rfc/rfc2253.txt

--- a/common/auth/mapping-rule_test.go
+++ b/common/auth/mapping-rule_test.go
@@ -24,11 +24,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kylelemons/godebug/pretty"
+	"gopkg.in/yaml.v2"
 )
-
-var _ = yaml.YAMLToJSON
 
 func TestUnmarshalMappingRuleConfig(t *testing.T) {
 	rawConfig := []byte(`

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/fatih/structs v1.1.0
 	github.com/gdamore/tcell/v2 v2.5.1
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/errors v0.20.3
 	github.com/go-openapi/loads v0.21.2
 	github.com/go-openapi/runtime v0.24.1


### PR DESCRIPTION
At the time of making this commit, the package `github.com/ghodss/yaml` is no longer actively maintained.

We are only using `github.com/ghodss/yaml` in `common/auth/mapping-rule.go`. We can use `gopkg.in/yaml.v2` instead.