### PR TITLE
Avoid unnecessary byte/string conversion

### DIFF
--- a/common/crypto/materials.go
+++ b/common/crypto/materials.go
@@ -344,29 +344,29 @@ func (h *EncryptedBlockHeader) GetDataLength() uint32 {
 
 func (h *EncryptedBlockHeader) String() string {
 	sb := strings.Builder{}
-	sb.Write([]byte("\n[Header:\n"))
+	sb.WriteString("\n[Header:\n")
 	if h.Options != nil {
-		sb.Write([]byte("\t[Options:\n"))
+		sb.WriteString("\t[Options:\n")
 		if h.Options.Key != nil {
-			sb.Write([]byte(fmt.Sprintf("\t\t Key  : %s\n", base64.StdEncoding.EncodeToString(h.Options.Key))))
+			sb.WriteString(fmt.Sprintf("\t\t Key  : %s\n", base64.StdEncoding.EncodeToString(h.Options.Key)))
 		}
 
 		if h.Options.UserId != "" {
-			sb.Write([]byte(fmt.Sprintf("\t\t Owner: %s\n", h.Options.UserId)))
+			sb.WriteString(fmt.Sprintf("\t\t Owner: %s\n", h.Options.UserId))
 		}
 
 		if h.Options.PartId > -1 {
-			sb.Write([]byte(fmt.Sprintf("\t\t Part : %d\n", h.Options.PartId)))
+			sb.WriteString(fmt.Sprintf("\t\t Part : %d\n", h.Options.PartId))
 		}
 
 		if h.Options.Position > -1 {
-			sb.Write([]byte(fmt.Sprintf("\t\t Pos  : %d\n", h.Options.Position)))
+			sb.WriteString(fmt.Sprintf("\t\t Pos  : %d\n", h.Options.Position))
 		}
-		sb.Write([]byte("\t]\n"))
+		sb.WriteString("\t]\n")
 	}
-	sb.Write([]byte(fmt.Sprintf("\tNonce : %s\n", base64.StdEncoding.EncodeToString(h.Nonce))))
-	sb.Write([]byte(fmt.Sprintf("\tLength: %d bytes\n", h.dataLength&dataLengthMask)))
-	sb.Write([]byte("]"))
+	sb.WriteString(fmt.Sprintf("\tNonce : %s\n", base64.StdEncoding.EncodeToString(h.Nonce)))
+	sb.WriteString(fmt.Sprintf("\tLength: %d bytes\n", h.dataLength&dataLengthMask))
+	sb.WriteString("]")
 	return sb.String()
 }
 

--- a/common/sql/index/cache.go
+++ b/common/sql/index/cache.go
@@ -700,7 +700,7 @@ func (d *daocache) GetNodeTree(ctx context.Context, path mtree.MPath, filter ...
 		// Looping
 		var keys []string
 		for k := range d.cache {
-			if childRegexp.Match([]byte(k)) {
+			if childRegexp.MatchString(k) {
 				keys = append(keys, k)
 			}
 		}

--- a/common/utils/filex/json.go
+++ b/common/utils/filex/json.go
@@ -70,7 +70,7 @@ func Save(filename string, b []byte) error {
 	}
 	defer f.Close()
 
-	if _, err := f.WriteString(string(b)); err != nil {
+	if _, err := f.Write(b); err != nil {
 		return err
 	}
 

--- a/data/source/index/sessions/benchmark.go
+++ b/data/source/index/sessions/benchmark.go
@@ -65,7 +65,7 @@ func (bb *BenchBatcher) Flush(ctx context.Context, dao index.DAO) {
 			for i := range benchMeasures {
 				m := benchMeasures[i]
 				d := m["duration"]
-				file.Write([]byte(fmt.Sprintf("%15d\n", d)))
+				file.WriteString(fmt.Sprintf("%15d\n", d))
 			}
 		} else {
 			log.Logger(ctx).Error("Failed to save benchmark results.")


### PR DESCRIPTION
We can use alternative functions to avoid unnecessary byte/string conversion calls and reduce allocations

1. `(*strings.Builder).Write` [^1] / `(*strings.Builder).WriteString` [^2]
2. `(*regexp.Regexp).Match` [^3] / `(*regexp.Regexp).MatchString` [^4]
3. `(*os.File).Write` [^5] / `(*os.File).WriteString` [^6]

[^1]: https://pkg.go.dev/strings#Builder.Write
[^2]: https://pkg.go.dev/strings#Builder.WriteString
[^3]: https://pkg.go.dev/regexp#Regexp.Match
[^4]: https://pkg.go.dev/regexp#Regexp.MatchString
[^5]: https://pkg.go.dev/os#File.Write
[^6]: https://pkg.go.dev/os#File.WriteString
