### PR TITLE
webpack5 arrow function arguments compatibility of gui/core module.

### DIFF
--- a/frontend/front-srv/assets/gui.ajax/res/js/core/index.js
+++ b/frontend/front-srv/assets/gui.ajax/res/js/core/index.js
@@ -175,8 +175,7 @@ if(originalRequire) {
                 break;
         }
 
-        return originalRequire.apply(this, arguments);
+        return originalRequire.apply(this, libName);
     }
 }
-
 Object.assign(window, {...namespace, PydioCore: namespace});


### PR DESCRIPTION
after rebuild of gui.ajax core module `pnpm run build-core-prod`, the page will end up with the errors below:

<img width="413" alt="图片" src="https://github.com/pydio/cells/assets/2631612/b680b718-d89e-420a-870e-8bcf523e3b7a">

<img width="1463" alt="图片" src="https://github.com/pydio/cells/assets/2631612/d6973ee9-f663-4462-974c-1ba388481fff">
maybe it's the same issue as of #493.     

there're some explanations on https://www.ginkonote.com/users/flo/articles/migration-guide-to-webpack-5@javascript

the cause might be  "arguments objects is not available in arrow function after Webpack 5+",  
the packed `frontend/front-srv/assets/gui.ajax/res/js/core/index.js` is not evalable, so the loading of pydio.min.js by pydio.boot.in.js fails.