### PR TITLE
data race fixing.

### DIFF
--- a/common/broker/grpcpubsub/client.go
+++ b/common/broker/grpcpubsub/client.go
@@ -75,7 +75,9 @@ func (s *sharedSubscriber) Unsubscribe(subId string) {
 	delete(s.out, subId)
 	if len(s.out) == 0 && s.cancel != nil {
 		s.cancel()
+		subLock.Lock()
 		delete(subscribers, s.sharedKey)
+		subLock.Unlock()
 	}
 }
 


### PR DESCRIPTION
data race happens when stopping server.

```shell
2024-02-22T10:41:09.788+0800	INFO	pydio.grpc.activity	Stopping ACL Debouncer
2024-02-22T10:41:09.788+0800	ERROR	pydio.grpc.tasks	fatal error: concurrent map writes
2024-02-22T10:41:09.791+0800	ERROR	pydio.grpc.tasks
2024-02-22T10:41:09.791+0800	ERROR	pydio.grpc.tasks	goroutine 257 [running]:
2024-02-22T10:41:09.791+0800	ERROR	pydio.grpc.tasks	github.com/pydio/cells/v4/common/broker/grpcpubsub.(*sharedSubscriber).Unsubscribe(0xc001d5cd20, {0xc001d50600, 0x24})
2024-02-22T10:41:09.791+0800	ERROR	pydio.grpc.tasks		github.com/pydio/cells/v4/common/broker/grpcpubsub/client.go:78 +0xd7
2024-02-22T10:41:09.791+0800	ERROR	pydio.grpc.tasks	github.com/pydio/cells/v4/common/broker/grpcpubsub.NewSubscription.func1()
2024-02-22T10:41:09.791+0800	ERROR	pydio.grpc.tasks		github.com/pydio/cells/v4/common/broker/grpcpubsub/client.go:336 +0x1f
2024-02-22T10:41:09.791+0800	ERROR	pydio.grpc.tasks	github.com/pydio/cells/v4/common/broker/grpcpubsub.(*subscription).Close(0xc000ee1f28?)
2024-02-22T10:41:09.791+0800	ERROR	pydio.grpc.tasks		github.com/pydio/cells/v4/common/broker/grpcpubsub/client.go:421 +0x18
2024-02-22T10:41:09.791+0800	ERROR	pydio.grpc.tasks	gocloud.dev/pubsub.(*Subscription).Shutdown(0xc000202d20, {0x94994a0?, 0xc001e2a640?})
2024-02-22T10:41:09.791+0800	ERROR	pydio.grpc.tasks		gocloud.dev@v0.20.0/pubsub/pubsub.go:693 +0x297
2024-02-22T10:41:09.791+0800	ERROR	pydio.grpc.tasks	github.com/pydio/cells/v4/common/broker.(*broker).Subscribe.func3()
2024-02-22T10:41:09.791+0800	ERROR	pydio.grpc.tasks		github.com/pydio/cells/v4/common/broker/broker.go:313 +0x1f
2024-02-22T10:41:09.792+0800	ERROR	pydio.grpc.tasks	github.com/pydio/cells/v4/common/broker.SubscribeCancellable.func1()
2024-02-22T10:41:09.792+0800	ERROR	pydio.grpc.tasks		github.com/pydio/cells/v4/common/broker/broker.go:139 +0x36
2024-02-22T10:41:09.792+0800	ERROR	pydio.grpc.tasks	created by github.com/pydio/cells/v4/common/broker.SubscribeCancellable in goroutine 226
2024-02-22T10:41:09.792+0800	ERROR	pydio.grpc.tasks		github.com/pydio/cells/v4/common/broker/broker.go:137 +0xc5
2024-02-22T10:41:09.792+0800	ERROR	pydio.grpc.tasks
```