### PR TITLE
fix defunct processes and deregister server before it stops

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -24,16 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/manifoldco/promptui"
-	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-
 	"github.com/pydio/cells/v4/common"
 	"github.com/pydio/cells/v4/common/broker"
 	clientcontext "github.com/pydio/cells/v4/common/client/context"
@@ -49,6 +40,13 @@ import (
 	servercontext "github.com/pydio/cells/v4/common/server/context"
 	servicecontext "github.com/pydio/cells/v4/common/service/context"
 	"github.com/pydio/cells/v4/common/utils/filex"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
 var (
@@ -281,7 +279,9 @@ ENVIRONMENT
 			managerLogger.Info("Stopping discovery services now")
 			discovery.StopAll()
 		}
-
+		if !runtime.IsFork() {
+			managerLogger.Info("All servers stopped")
+		}
 		return nil
 	},
 }

--- a/common/runtime/manager/manager.go
+++ b/common/runtime/manager/manager.go
@@ -273,7 +273,7 @@ func (m *manager) ServeAll(oo ...server.ServeOption) {
 
 func (m *manager) StopAll() {
 	eg := &errgroup.Group{}
-	for _, srv := range m.serversWithStatus(registry.StatusReady) {
+	for _, srv := range m.servers {
 		func(sr server.Server) {
 			eg.Go(func() error {
 				if err := m.stopServer(sr, registry.WithDeregisterFull()); err != nil {

--- a/common/service/service.go
+++ b/common/service/service.go
@@ -262,17 +262,11 @@ func (s *service) Stop(oo ...registry.RegisterOption) error {
 		}
 	}
 
-	if s.Opts.serverStop != nil {
-		if err := s.Opts.serverStop(refCtx); err != nil {
-			return err
-		}
-	}
-
 	opts := &registry.RegisterOptions{}
 	for _, o := range oo {
 		o(opts)
 	}
-
+	// deregister before stop
 	if reg := s.Opts.GetRegistry(); reg != nil {
 		// Deregister to make sure to break existing links
 		if err := reg.Deregister(s, registry.WithRegisterFailFast()); err != nil {
@@ -285,7 +279,11 @@ func (s *service) Stop(oo ...registry.RegisterOption) error {
 		s.Opts.Logger().Warn("no registry attached")
 	}
 
-	s.Opts.Logger().Info("stopped")
+	if s.Opts.serverStop != nil {
+		if err := s.Opts.serverStop(refCtx); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/gateway/data/plugins.go
+++ b/gateway/data/plugins.go
@@ -24,6 +24,7 @@ package gateway
 import (
 	"context"
 	"fmt"
+	servicecontext "github.com/pydio/cells/v4/common/service/context"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -77,8 +78,9 @@ func init() {
 			service.Context(ctx),
 			service.Tag(common.ServiceTagGateway),
 			service.Description("S3 Gateway to tree service"),
+			service.Fork(true),
 			service.WithHTTP(func(c context.Context, mux server.HttpMux) error {
-
+				c = servicecontext.WithServiceName(ctx, common.ServiceGatewayData)
 				console.Printf = func(format string, data ...interface{}) {
 					if strings.HasPrefix(format, "WARNING: ") {
 						format = strings.TrimPrefix(format, "WARNING: ")


### PR DESCRIPTION

<img width="275" alt="图片" src="https://github.com/pydio/cells/assets/2631612/32f224da-16eb-4d0b-8fa1-e9fc8660305f">

as shown above, after stopping the master cells process, there might be some sub processes left defunct in random. 
two points in cells may lead to this problem.

1. The `Stop` method in main routine does not wait the `StartAndWait` method to complete waiting its sub process.
2. The `gateway.data` plugin , which uses the minio package, does not fork, so it still serves in the main process, while the minio's exit function will directly end the main process when stopping the pulgin. However the minio's exit function cannot be customized, so there's no way to tweak this behaviour from the minio side at present. Only the forking way may resolve it.

so whether there will be defunct processes depends on who (the main process and its sub processes) exits first in random.

another point, shall we deregister the server to notify the client-ends in advance before stopping the server to prevent unexpected future requests.