### PR TITLE
Corrected a translation error in "Japanese."

### DIFF
--- a/common/utils/i18n/i18n.go
+++ b/common/utils/i18n/i18n.go
@@ -47,7 +47,7 @@ var (
 		"it":    "Italiano",
 		"lv":    "Latv",
 		"pt-br": "Português do Brasil",
-		"ja":    "日本人",        // Japanese
+		"ja":    "日本語",        // Japanese
 		"ru":    "русский",    // Russian
 		"vi-vn": "Tiếng Việt", // Vietnamese
 		"zh-cn": "简体中文",       // Chinese simplified


### PR DESCRIPTION
"Japanese" in [common/utils/i18n/i18n.go](https://github.com/pydio/cells/blob/a0e30b5f1b5657e2d5b9badd81ad8740c7a38197/common/utils/i18n/i18n.go#L50) for "日本語", not "日本人".
"日本人" means people, but "日本語" means language.