### PR TITLE
fix(cmd): cells flag `--site_bind` ignored

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pydio/cells/v5/common/broker"
 	"github.com/pydio/cells/v5/common/client/grpc"
 	"github.com/pydio/cells/v5/common/config"
+	"github.com/pydio/cells/v5/common/config/routing"
 	"github.com/pydio/cells/v5/common/errors"
 	"github.com/pydio/cells/v5/common/proto/install"
 	"github.com/pydio/cells/v5/common/proto/service"
@@ -238,6 +239,11 @@ ENVIRONMENT
 			if !strings.Contains(installConf.DbManualDSN, "?") {
 				installConf.DbManualDSN += "?" // URL maybe appended with &key=value string
 			}
+		}
+
+		hasCustomBind := routing.EnvOverrideDefaultBind()
+		if hasCustomBind {
+			cmd.Printf("Binding service to '%s'\n", niBindUrl)
 		}
 
 		return nil


### PR DESCRIPTION
Refer to https://app.clickup.com/t/869atgymv

allow `--site-bind` on start command

How to check:  
- Compile the latest version of the binary
- Run ./cells start --site_bind site any port (eg --site_bind 0.0.0.0:8888)
- Try to access the service using that port that you defined

Expected behavior:
 - The service is running in the port binding correctly