### PR TITLE
chore/add prettier config

### DIFF
--- a/frontend/assets/.prettierignore
+++ b/frontend/assets/.prettierignore
@@ -11,7 +11,11 @@ build/
 **/res/**/conf/
 **/*.xml
 **/*.json
-
+**/**/**/locale
+**/**/**/locale/
+*.less
+**/**/**/**/**/lang/
+*.css
 # Ignore HTML, plugin docs and webpack configs
 **/*.html
 **/plugin_doc.html

--- a/frontend/assets/.prettierignore
+++ b/frontend/assets/.prettierignore
@@ -1,0 +1,53 @@
+# Ignore node modules and build artifacts
+node_modules/
+dist/
+**/dist/
+build/
+
+
+# Ignore i18n / translations / conf / res xml/json
+**/i18n/
+**/res/**/i18n/
+**/res/**/conf/
+**/*.xml
+**/*.json
+
+# Ignore HTML, plugin docs and webpack configs
+**/*.html
+**/plugin_doc.html
+**/webpack.config.js
+**/webpack.config.*   # ts / mjs variants
+
+# Ignore markdown and the ignore file itself
+*.md
+**/*.md
+.prettierignore
+
+
+package.json
+**/package.json
+pnpm-lock.yaml
+**/pnpm-lock.yaml
+pnpm-workspace.yaml
+**/pnpm-workspace.yaml
+package-lock.json
+**/package-lock.json
+
+
+*.xsd
+**/*.xsd
+webpack-commons.js
+**/webpack-commons.js
+
+*.min.js
+**/*.min.js
+*.map
+**/*.map
+*.js.map
+**/*.js.map
+
+# Optional extras (vendor, compiled assets)
+vendor/
+**/vendor/
+lib/
+**/lib/

--- a/frontend/assets/.prettierrc
+++ b/frontend/assets/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/frontend/assets/.prettierrc
+++ b/frontend/assets/.prettierrc
@@ -1,3 +1,5 @@
 {
-  "singleQuote": true
+    "singleQuote": true,
+    "useTabs": false,
+    "tabWidth": 4
 }


### PR DESCRIPTION
Adding Prettier 

- The config formatting does not change the current spacing convention
- Run prettier per asset to avoid huge pull requests
- use prettier with npx `npx prettier <path> --check` or `npx prettier <path> --write` to fix problems