### PR TITLE
chore: allow defining baseURL for Collabora integration

### DIFF
--- a/tools/kubernetes/cells/templates/_helpers_collabora.tpl
+++ b/tools/kubernetes/cells/templates/_helpers_collabora.tpl
@@ -71,6 +71,17 @@ COLLABORA ACTIVATION
 {{- end -}}
 
 {{/*
+COLLABORA BASE URL
+*/}}
+{{- define "cells.collabora.baseURL" -}}
+{{- if .Values.collabora.enabled -}}
+{{- .Values.collabora.baseURL | default "" -}}
+{{- else if .Values.externalCollabora.enabled -}}
+{{- .Values.externalCollabora.baseURL | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 COLLABORA CUSTOMCONFIGS
 Generates the customconfigs map for Cells to connect to Collabora
 Returns a YAML map that can be merged with existing customconfigs
@@ -89,7 +100,7 @@ Returns a YAML map that can be merged with existing customconfigs
   "frontend/plugin/editor.libreoffice/LIBREOFFICE_PORT" (include "cells.collabora.port" .)
   "frontend/plugin/editor.libreoffice/LIBREOFFICE_SSL" (eq (include "cells.collabora.scheme" .) "https")
   "frontend/plugin/editor.libreoffice/LIBREOFFICE_SSL_SKIP_VERIFY" (include "cells.collabora.sslSkipVerify" .)
-  "frontend/plugin/editor.libreoffice/LIBREOFFICE_CELLS_INTERNAL_BASE_URL" (printf "http://%s:%s" (include "cells.name" .) .Values.service.port)
+  "frontend/plugin/editor.libreoffice/LIBREOFFICE_INTERNAL_CELLS_BASE_URL" (include "cells.collabora.baseURL" .)
   "frontend/plugin/editor.libreoffice/PYDIO_PLUGIN_ENABLED" ($pluginEnabled | toString)
 -}}
 {{- toYaml $collaboraConfigs -}}


### PR DESCRIPTION
This change introduce a new `baseURL` property for the helm collabora config that allows setting the base URL to be used on the FE