### PR TITLE
chore(openapi): checks for openapi-generator-cli existence on generation 

### DIFF
--- a/common/proto/rest/swagger.sh
+++ b/common/proto/rest/swagger.sh
@@ -25,9 +25,17 @@ if ! command -v openapi-generator &> /dev/null
 then
     echo "ERROR: openapi-generator not found."
     echo "Please install it from https://openapi-generator.tech/docs/installation"
-    echo "Required version is 7.12.0 or higher."
+    echo "Required version is 7.12.0"
     exit
+else 
+    OAG_VERSION=$(openapi-generator version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+    if [[ "$OAG_VERSION" != "7.12.0" ]]; then
+        echo "ERROR: openapi-generator version is $OAG_VERSION but 7.12.0 is required."
+        echo "Please install the correct version from https://openapi-generator.tech/docs/installation"
+        exit
+    fi
 fi
+
 
 if [[ -n "${GENERATE_SDKS_V2}" ]]; then
 

--- a/common/proto/rest/swagger.sh
+++ b/common/proto/rest/swagger.sh
@@ -19,6 +19,16 @@
 #
 # The latest code can be found at <https://pydio.com>.
 #
+
+# Check for missing openapi-generator-cli
+if ! command -v openapi-generator &> /dev/null
+then
+    echo "ERROR: openapi-generator not found."
+    echo "Please install it from https://openapi-generator.tech/docs/installation"
+    echo "Required version is 7.12.0 or higher."
+    exit
+fi
+
 if [[ -n "${GENERATE_SDKS_V2}" ]]; then
 
 #  echo "Generate TS version with fetch"

--- a/common/proto/rest/swagger.sh
+++ b/common/proto/rest/swagger.sh
@@ -38,7 +38,7 @@ if [[ -n "${GENERATE_SDKS_V2}" ]]; then
 
   openapi-generator generate -i ./cellsapi-rest-v2.swagger.json -g typescript-axios -c swagger-ts-axios.json -o $GENERATE_SDKS_V2/cells-sdk-ts
   cd $GENERATE_SDKS_V2/cells-sdk-ts || exit
-  npm run build
+  npm install && npm run build
   cd - || exit
 
   echo "Generate Swift version"


### PR DESCRIPTION
This commit adds a check in the swagger.sh script to ensure that openapi-generator-cli is installed before proceeding. It also show instructions on how to install.

