### PR TITLE
WIP refactor(rest): allow to predefined a request before signing the URL

### DIFF
--- a/gateway/restv2/presigner.go
+++ b/gateway/restv2/presigner.go
@@ -48,22 +48,28 @@ type Options struct {
 }
 
 type PresignParams struct {
-	req *http.Request
+	req       *http.Request
 	VersionID string
 }
 
-func (v *v4Signer) PreSignV4(ctx context.Context, bucket, key string, params PresignParams) (*http.Request, time.Time, error) {
-	var req *http.Request
-	if params.req != nil {
-		u := *v.endpoint
+func (p *PresignParams) GetRequest(endpoint *url.URL, bucket, key string) (*http.Request, error) {
+	if p.req == nil {
+		u := endpoint
 		u.Path = path.Join(bucket, key)
 		newReq, err := http.NewRequest(http.MethodGet, u.String(), nil)
 		if err != nil {
-			return nil, time.Now(), err
+			return nil, err
 		}
-		req = newReq
-	} else {
-		req = params.req
+		p.req = newReq
+	}
+
+	return p.req, nil
+}
+
+func (v *v4Signer) PreSignV4(ctx context.Context, bucket, key string, params PresignParams) (*http.Request, time.Time, error) {
+	req, err := params.GetRequest(v.endpoint, bucket, key)
+	if err != nil {
+		return nil, time.Now(), err
 	}
 
 	exp := time.Now().Add(time.Duration(v.opts.Expiration) * time.Second)

--- a/gateway/restv2/presigner.go
+++ b/gateway/restv2/presigner.go
@@ -48,16 +48,24 @@ type Options struct {
 }
 
 type PresignParams struct {
+	req *http.Request
 	VersionID string
 }
 
 func (v *v4Signer) PreSignV4(ctx context.Context, bucket, key string, params PresignParams) (*http.Request, time.Time, error) {
-	u := *v.endpoint
-	u.Path = path.Join(bucket, key)
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, time.Now(), err
+	var req *http.Request
+	if params.req != nil {
+		u := *v.endpoint
+		u.Path = path.Join(bucket, key)
+		newReq, err := http.NewRequest(http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, time.Now(), err
+		}
+		req = newReq
+	} else {
+		req = params.req
 	}
+
 	exp := time.Now().Add(time.Duration(v.opts.Expiration) * time.Second)
 
 	if params.VersionID != "" {


### PR DESCRIPTION
### Problem

The current presigner implementation don't allow extending it's logic because req isn't injected as a dependency. This change allow one to inject req during presigning logic an therefore extend its logic

#### Detailed changes

  - Added a new req field to PresignParams to store an HTTP request.
  - Modified the PreSignV4 function to check if a pre-existing request is provided, and use it if available, otherwise create a new one.

### Example of usage:

```go
// MyCustom implementation of PreSignV4 that adds a new query parameter.
func (v *v4SignerWithTenant) PreSignV4(ctx context.Context, bucket, key string, params restv2.PresignParams) (*http.Request, time.Time, error) {
	req, err := params.GetRequest(v.endpoint, bucket, key)
	if err != nil {
		return nil, time.Now(), err
	}

	// Insert a new param before pre signing...
	if myNewQuery := runtime.MultiContextManager().Current(ctx); myNewQuery != "" {
		q := req.URL.Query()
		q.Add("myparam", myNewQuery)
		req.URL.RawQuery = q.Encode()
	}

	return v.cellsPresigner.PreSignV4(ctx, bucket, key, params)
}

