### PR TITLE
feat(namespaces): Extend namespace grpc update handler for jsonschema updates

### DIFF
--- a/idm/meta/dao.go
+++ b/idm/meta/dao.go
@@ -55,7 +55,7 @@ const (
 type NamespaceDAO interface {
 	resources.DAO
 
-	Add(ctx context.Context, ns *idm.UserMetaNamespace) error
+	Upsert(ctx context.Context, ns *idm.UserMetaNamespace) (error, bool)
 	Del(ctx context.Context, ns *idm.UserMetaNamespace) (e error)
 	List(ctx context.Context) (map[string]*idm.UserMetaNamespace, error)
 	GetJSONSchema(ctx context.Context) (*structpb.Struct, error)

--- a/idm/meta/dao/sql/ns-sql.go
+++ b/idm/meta/dao/sql/ns-sql.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pydio/cells/v5/common/storage/sql/resources"
 	"github.com/pydio/cells/v5/common/telemetry/log"
 	"github.com/pydio/cells/v5/idm/meta"
-
 	"github.com/pydio/cells/v5/idm/meta/json_schema"
 )
 
@@ -88,7 +87,7 @@ func (u *MetaNamespace) From(res *idm.UserMetaNamespace) *MetaNamespace {
 	u.Definition = []byte(res.JsonDefinition)
 	u.EnforceDefault = res.EnforceDefault
 	u.PromptOnUpload = res.PromptOnUpload
-	s, _, err := json_schema.GetJsonSchema(json_schema.LegacyTypeToLabel(u.Definition))
+	s, err := json_schema.GetJsonSchema(json_schema.LegacyTypeToLabel(u.Definition))
 	if err == nil && s != nil {
 		schemaAsJson := datatypes.JSON(s)
 		u.JsonSchema = &schemaAsJson
@@ -96,7 +95,12 @@ func (u *MetaNamespace) From(res *idm.UserMetaNamespace) *MetaNamespace {
 	return u
 }
 
-func (u *MetaNamespace) FromExisting(res *idm.UserMetaNamespace) *MetaNamespace {
+func (u *MetaNamespace) FromExisting(res *idm.UserMetaNamespace) (*MetaNamespace, error) {
+	jssc := json_schema.ValidateSchemaFromPbStruct(res.JsonSchema)
+
+	if jssc != nil { // TODO move validation outside of DAO
+		return nil, jssc
+	}
 	u.Namespace = res.Namespace
 	u.Label = res.Label
 	u.Order = res.Order
@@ -106,7 +110,7 @@ func (u *MetaNamespace) FromExisting(res *idm.UserMetaNamespace) *MetaNamespace 
 	u.PromptOnUpload = res.PromptOnUpload
 	var js, _ = json_schema.ProtoStructToJson(res.JsonSchema)
 	u.JsonSchema = js
-	return u
+	return u, nil
 }
 
 func NewNSDAO(db *gorm.DB) meta.NamespaceDAO {
@@ -154,9 +158,28 @@ func (s *nsSqlImpl) Migrate(ctx context.Context) error {
 
 // Add inserts a namespace // Upsert
 func (s *nsSqlImpl) Add(ctx context.Context, ns *idm.UserMetaNamespace) error {
-	tx := s.Session(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create((&MetaNamespace{}).From(ns))
-	if tx.Error != nil {
-		return nsTag(tx.Error)
+	// Update existing
+	var ex *MetaNamespace
+	tx0 := s.Session(ctx).Where(&MetaNamespace{Namespace: string(ns.Namespace)}).First(&ex)
+	if tx0.Error != nil && !errors.Is(tx0.Error, gorm.ErrRecordNotFound) {
+		return nsTag(tx0.Error)
+	}
+	if tx0.Error == nil {
+		validNs, er := (&MetaNamespace{}).FromExisting(ns)
+		if er != nil {
+			return nsTag(er)
+		}
+
+		tx2 := s.Session(ctx).Where("namespace = ?", ns.Namespace).Updates(validNs)
+		if tx2.Error != nil {
+			return nsTag(tx2.Error)
+		}
+		return nil
+	}
+	// Insert
+	tx1 := s.Session(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create((&MetaNamespace{}).From(ns))
+	if tx1.Error != nil {
+		return nsTag(tx1.Error)
 	}
 
 	if len(ns.Policies) > 0 {

--- a/idm/meta/dao/sql/ns-sql.go
+++ b/idm/meta/dao/sql/ns-sql.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 	"gorm.io/gorm/schema"
 
 	"github.com/pydio/cells/v5/common/errors"
@@ -141,7 +140,7 @@ func (s *nsSqlImpl) Migrate(ctx context.Context) error {
 	tx := s.Where(&MetaNamespace{Namespace: meta.ReservedNamespaceBookmark}).First(&bm)
 	if tx.Error != nil && errors.Is(tx.Error, gorm.ErrRecordNotFound) {
 		log.Logger(ctx).Info("creating namespace bookmark")
-		if err := s.Add(ctx, &idm.UserMetaNamespace{
+		if err, _ := s.Upsert(ctx, &idm.UserMetaNamespace{
 			Namespace: meta.ReservedNamespaceBookmark,
 			Label:     "Bookmarks",
 			Policies: []*service.ResourcePolicy{
@@ -157,40 +156,40 @@ func (s *nsSqlImpl) Migrate(ctx context.Context) error {
 }
 
 // Add inserts a namespace // Upsert
-func (s *nsSqlImpl) Add(ctx context.Context, ns *idm.UserMetaNamespace) error {
+func (s *nsSqlImpl) Upsert(ctx context.Context, ns *idm.UserMetaNamespace) (error, bool) {
 	// Update existing
 	var ex *MetaNamespace
-	tx0 := s.Session(ctx).Where(&MetaNamespace{Namespace: string(ns.Namespace)}).First(&ex)
+	tx0 := s.Session(ctx).Where(&MetaNamespace{Namespace: ns.Namespace}).First(&ex)
 	if tx0.Error != nil && !errors.Is(tx0.Error, gorm.ErrRecordNotFound) {
-		return nsTag(tx0.Error)
+		return nsTag(tx0.Error), false
 	}
 	if tx0.Error == nil {
 		validNs, er := (&MetaNamespace{}).FromExisting(ns)
 		if er != nil {
-			return nsTag(er)
+			return nsTag(er), false
 		}
 
 		tx2 := s.Session(ctx).Where("namespace = ?", ns.Namespace).Updates(validNs)
 		if tx2.Error != nil {
-			return nsTag(tx2.Error)
+			return nsTag(tx2.Error), false
 		}
-		return nil
+		return nil, true
 	}
 	// Insert
-	tx1 := s.Session(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create((&MetaNamespace{}).From(ns))
+	tx1 := s.Session(ctx).Create((&MetaNamespace{}).From(ns))
 	if tx1.Error != nil {
-		return nsTag(tx1.Error)
+		return nsTag(tx1.Error), false
 	}
 
 	if len(ns.Policies) > 0 {
 		if pols, err := s.AddPolicies(ctx, false, ns.Namespace, ns.Policies); err != nil {
-			return nsTag(err)
+			return nsTag(err), false
 		} else {
 			ns.Policies = pols
 		}
 	}
 
-	return nil
+	return nil, false
 }
 
 // Del removes a namespace

--- a/idm/meta/dao/sql/ns-sql_test.go
+++ b/idm/meta/dao/sql/ns-sql_test.go
@@ -26,12 +26,17 @@ import (
 	"context"
 	"testing"
 
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+	"gorm.io/datatypes"
+
 	"github.com/pydio/cells/v5/common/proto/idm"
 	service "github.com/pydio/cells/v5/common/proto/service"
 	"github.com/pydio/cells/v5/common/runtime/manager"
 	"github.com/pydio/cells/v5/common/storage/test"
 	json "github.com/pydio/cells/v5/common/utils/jsonx"
 	"github.com/pydio/cells/v5/idm/meta"
+	"github.com/pydio/cells/v5/idm/meta/json_schema"
 
 	_ "github.com/pydio/cells/v5/common/utils/cache/gocache"
 
@@ -55,7 +60,7 @@ func TestNSCrud(t *testing.T) {
 				Namespace:      "namespace",
 				Label:          "label",
 				Order:          1,
-				JsonDefinition: "{\"test\":\"value\"}",
+				JsonDefinition: "{\"type\":\"string\"}",
 			})
 			So(err, ShouldBeNil)
 
@@ -69,7 +74,7 @@ func TestNSCrud(t *testing.T) {
 			var def map[string]string
 			er = json.Unmarshal([]byte(jsonDef), &def)
 			So(er, ShouldBeNil)
-			So(def["test"], ShouldEqual, "value")
+			So(def["type"], ShouldEqual, "string")
 
 			e := mockDAO.Del(ctx, &idm.UserMetaNamespace{Namespace: "namespace"})
 			So(e, ShouldBeNil)
@@ -141,62 +146,131 @@ func TestNSResourceRules(t *testing.T) {
 
 func TestNSNewFields(t *testing.T) {
 
-    test.RunStorageTests(nsTestcases, t, func(ctx context.Context) {
+	test.RunStorageTests(nsTestcases, t, func(ctx context.Context) {
 
-        Convey("Create Meta Namespace with new fields", t, func() {
-            mockDAO, er := manager.Resolve[meta.NamespaceDAO](ctx)
-            So(er, ShouldBeNil)
+		Convey("Create Meta Namespace with new fields", t, func() {
+			mockDAO, err0 := manager.Resolve[meta.NamespaceDAO](ctx)
+			So(err0, ShouldBeNil)
+			tv := json_schema.LegacyTypeToLabel([]byte("{\"type\":\"string\"}"))
+			jsb, err1 := json_schema.GetJsonSchema(tv)
+			So(err1, ShouldBeNil)
+			schemaAsJson := datatypes.JSON(jsb)
+			jsStruct, err := json_schema.JsonToProtoStruct(&schemaAsJson)
+			So(err, ShouldBeNil)
+			in := &idm.UserMetaNamespace{
+				Namespace:      "namespace-newfields",
+				Label:          "label-newfields",
+				Order:          2,
+				JsonDefinition: "{\"type\":\"string\"}",
+				JsonSchema:     jsStruct,
+				PromptOnUpload: true,
+			}
 
-            in := &idm.UserMetaNamespace{
-                Namespace:      "namespace-newfields",
-                Label:          "label-newfields",
-                Order:          2,
-                JsonDefinition: "{\"k\":\"v\"}",
-                JsonSchema:     `{"type":"object"}`,
-                PromptOptions: &idm.PromptOptions{
-                    OnUpload: true,
-                },
-            }
+			// Insert a meta with new fields
+			err2 := mockDAO.Add(ctx, in)
+			So(err2, ShouldBeNil)
 
-            // Insert a meta with new fields
-            err := mockDAO.Add(ctx, in)
-            So(err, ShouldBeNil)
+			// Assert
+			result, err2 := mockDAO.List(ctx)
+			So(err2, ShouldBeNil)
 
-            // Assert
-            result, er := mockDAO.List(ctx)
-            So(er, ShouldBeNil)
+			ns, ok := result["namespace-newfields"]
+			So(ok, ShouldBeTrue)
 
-            ns, ok := result["namespace-newfields"]
-            So(ok, ShouldBeTrue)
+			// Basic fields
+			So(ns.Label, ShouldEqual, "label-newfields")
 
-            // Basic fields
-            So(ns.Label, ShouldEqual, "label-newfields")
-            
-            So(ns.JsonSchema, ShouldEqual, `{"type":"object"}`)
-            So(ns.PromptOptions, ShouldNotBeNil)
-            So(ns.PromptOptions.OnUpload, ShouldBeTrue)
+			So(ns.JsonSchema, ShouldNotBeNil)
+			So(ns.PromptOnUpload, ShouldBeTrue)
 
-            // Cleanup
-            e := mockDAO.Del(ctx, &idm.UserMetaNamespace{Namespace: "namespace-newfields"})
-            So(e, ShouldBeNil)
-        })
-
-        Convey("List Meta Namespaces with new fields", t, func() {
-            mockDAO, er := manager.Resolve[meta.NamespaceDAO](ctx)
-            So(er, ShouldBeNil)
-
-            // List all namespaces
-            namespaces, err := mockDAO.List(ctx)
-            So(err, ShouldBeNil)
-
-            // Assert the new namespace is present
-            ns, ok := namespaces["namespace-newfields"]
-            So(ok, ShouldBeTrue)
-
-            So(ns.JsonSchema, ShouldEqual, `{"type":"object"}`)
-            So(ns.PromptOptions, ShouldNotBeNil)
-            So(ns.PromptOptions.OnUpload, ShouldBeTrue)
-        })
-    })
+			// Cleanup
+			err4 := mockDAO.Del(ctx, &idm.UserMetaNamespace{Namespace: "namespace-newfields"})
+			So(err4, ShouldBeNil)
+		})
+	})
 }
-// ...existing code...
+
+func TestNSAddUpdatesJsonSchema(t *testing.T) {
+	test.RunStorageTests(nsTestcases, t, func(ctx context.Context) {
+		Convey("Add should update JsonSchema when Namespace is stored in db before update", t, func() {
+			mockDAO, er := manager.Resolve[meta.NamespaceDAO](ctx)
+			So(er, ShouldBeNil)
+
+			nsKey := "namespace-jsonschema-update"
+
+			// Arrange create initial namespace
+			err := mockDAO.Add(ctx, &idm.UserMetaNamespace{
+				Namespace:      nsKey,
+				Label:          "label1",
+				Order:          1,
+				JsonDefinition: "{\"type\":\"string\"}",
+			})
+			So(err, ShouldBeNil)
+
+			// verify stored schema
+			result, er := mockDAO.List(ctx)
+			So(er, ShouldBeNil)
+			ns, ok := result[nsKey]
+			So(ok, ShouldBeTrue)
+			So(ns.JsonSchema, ShouldNotBeNil)
+
+			// update using Add
+			err1 := mockDAO.Add(ctx, &idm.UserMetaNamespace{
+				JsonDefinition: "{\"type\":\"textarea\"}",
+				Namespace:      nsKey,
+				Label:          "label2",
+				JsonSchema:     ns.JsonSchema,
+			})
+			So(err1, ShouldBeNil)
+
+			// verify stored schema
+			result2, er := mockDAO.List(ctx)
+			So(er, ShouldBeNil)
+			ns2, ok := result2[nsKey]
+			So(ok, ShouldBeTrue)
+			So(ns2.JsonSchema, ShouldNotBeNil)
+
+			// Arrange Update schema value
+			newSchemaMap := map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"newField": map[string]interface{}{
+						"type": "string",
+					},
+				},
+			}
+			newStruct, err := structpb.NewStruct(newSchemaMap)
+			So(err, ShouldBeNil)
+			ns.JsonSchema = newStruct
+			// Act - call Add to update JsonSchema
+			err2 := mockDAO.Add(ctx, &idm.UserMetaNamespace{
+				JsonDefinition: "{\"type\":\"object\"}",
+				Namespace:      nsKey,
+				Label:          "label3",
+				JsonSchema:     ns.JsonSchema,
+			})
+
+			So(err2, ShouldBeNil)
+
+			nss, err3 := mockDAO.List(ctx)
+			So(err3, ShouldBeNil)
+
+			// Assert
+			updated, ok := nss[nsKey]
+			So(ok, ShouldBeTrue)
+			So(updated.Namespace, ShouldEqual, nsKey)
+			So(updated.Label, ShouldEqual, "label3")
+			So(updated.JsonDefinition, ShouldEqual, "{\"type\":\"object\"}")
+			So(updated.Order, ShouldEqual, 1)
+
+			// Compare
+			expectedBytes, _ := protojson.Marshal(newStruct)
+			actualBytes, _ := protojson.Marshal(updated.JsonSchema)
+			So(string(actualBytes), ShouldEqual, string(expectedBytes))
+
+			// cleanup
+			e := mockDAO.Del(ctx, &idm.UserMetaNamespace{Namespace: nsKey})
+			So(e, ShouldBeNil)
+		})
+	})
+}

--- a/idm/meta/dao/sql/ns-sql_test.go
+++ b/idm/meta/dao/sql/ns-sql_test.go
@@ -56,7 +56,7 @@ func TestNSCrud(t *testing.T) {
 			So(er, ShouldBeNil)
 
 			// Insert a meta
-			err := mockDAO.Add(ctx, &idm.UserMetaNamespace{
+			err, _ := mockDAO.Upsert(ctx, &idm.UserMetaNamespace{
 				Namespace:      "namespace",
 				Label:          "label",
 				Order:          1,
@@ -167,7 +167,7 @@ func TestNSNewFields(t *testing.T) {
 			}
 
 			// Insert a meta with new fields
-			err2 := mockDAO.Add(ctx, in)
+			err2, _ := mockDAO.Upsert(ctx, in)
 			So(err2, ShouldBeNil)
 
 			// Assert
@@ -199,7 +199,7 @@ func TestNSAddUpdatesJsonSchema(t *testing.T) {
 			nsKey := "namespace-jsonschema-update"
 
 			// Arrange create initial namespace
-			err := mockDAO.Add(ctx, &idm.UserMetaNamespace{
+			err, _ := mockDAO.Upsert(ctx, &idm.UserMetaNamespace{
 				Namespace:      nsKey,
 				Label:          "label1",
 				Order:          1,
@@ -215,7 +215,7 @@ func TestNSAddUpdatesJsonSchema(t *testing.T) {
 			So(ns.JsonSchema, ShouldNotBeNil)
 
 			// update using Add
-			err1 := mockDAO.Add(ctx, &idm.UserMetaNamespace{
+			err1, _ := mockDAO.Upsert(ctx, &idm.UserMetaNamespace{
 				JsonDefinition: "{\"type\":\"textarea\"}",
 				Namespace:      nsKey,
 				Label:          "label2",
@@ -243,7 +243,7 @@ func TestNSAddUpdatesJsonSchema(t *testing.T) {
 			So(err, ShouldBeNil)
 			ns.JsonSchema = newStruct
 			// Act - call Add to update JsonSchema
-			err2 := mockDAO.Add(ctx, &idm.UserMetaNamespace{
+			err2, _ := mockDAO.Upsert(ctx, &idm.UserMetaNamespace{
 				JsonDefinition: "{\"type\":\"object\"}",
 				Namespace:      nsKey,
 				Label:          "label3",

--- a/idm/meta/grpc/handler.go
+++ b/idm/meta/grpc/handler.go
@@ -315,18 +315,25 @@ func (h *Handler) UpdateUserMetaNamespace(ctx context.Context, request *idm.Upda
 
 	response := &idm.UpdateUserMetaNamespaceResponse{}
 	namespaceDAO := dao.GetNamespaceDao()
-	for _, metaNameSpace := range request.Namespaces {
-		if err := namespaceDAO.Del(ctx, metaNameSpace); err != nil {
-			return nil, err
-		} else {
-			broker.MustPublish(ctx, common.TopicIdmEvent, &idm.ChangeEvent{
-				Type:          idm.ChangeEventType_DELETE,
-				MetaNamespace: metaNameSpace,
-			})
+	if request.Operation == idm.UpdateUserMetaNamespaceRequest_DELETE {
+		for _, metaNameSpace := range request.Namespaces {
+			if err := namespaceDAO.Del(ctx, metaNameSpace); err != nil {
+				return nil, err
+			} else {
+				broker.MustPublish(ctx, common.TopicIdmEvent, &idm.ChangeEvent{
+					Type:          idm.ChangeEventType_DELETE,
+					MetaNamespace: metaNameSpace,
+				})
+			}
 		}
 	}
 	if request.Operation == idm.UpdateUserMetaNamespaceRequest_PUT {
 		for _, metaNameSpace := range request.Namespaces {
+			broker.MustPublish(ctx, common.TopicIdmEvent, &idm.ChangeEvent{
+				Type:          idm.ChangeEventType_DELETE,
+				MetaNamespace: metaNameSpace,
+			})
+
 			if err := namespaceDAO.Add(ctx, metaNameSpace); err != nil {
 				return nil, err
 			} else {

--- a/idm/meta/grpc/handler.go
+++ b/idm/meta/grpc/handler.go
@@ -329,13 +329,14 @@ func (h *Handler) UpdateUserMetaNamespace(ctx context.Context, request *idm.Upda
 	}
 	if request.Operation == idm.UpdateUserMetaNamespaceRequest_PUT {
 		for _, metaNameSpace := range request.Namespaces {
-			broker.MustPublish(ctx, common.TopicIdmEvent, &idm.ChangeEvent{
-				Type:          idm.ChangeEventType_DELETE,
-				MetaNamespace: metaNameSpace,
-			})
 
-			if err := namespaceDAO.Add(ctx, metaNameSpace); err != nil {
+			if err, ups := namespaceDAO.Upsert(ctx, metaNameSpace); err != nil {
 				return nil, err
+			} else if ups {
+				broker.MustPublish(ctx, common.TopicIdmEvent, &idm.ChangeEvent{
+					Type:          idm.ChangeEventType_UPDATE,
+					MetaNamespace: metaNameSpace,
+				})
 			} else {
 				broker.MustPublish(ctx, common.TopicIdmEvent, &idm.ChangeEvent{
 					Type:          idm.ChangeEventType_CREATE,

--- a/idm/meta/grpc/service/service.go
+++ b/idm/meta/grpc/service/service.go
@@ -97,7 +97,7 @@ func init() {
 }
 
 func defaultMetas(ctx context.Context, dao meta.DAO) error {
-	err := dao.GetNamespaceDao().Add(ctx, &idm.UserMetaNamespace{
+	err, _ := dao.GetNamespaceDao().Upsert(ctx, &idm.UserMetaNamespace{
 		Namespace:      common.MetaNamespaceUserspacePrefix + "tags",
 		Label:          "Tags",
 		Indexable:      true,

--- a/idm/meta/json_schema/json_schema.go
+++ b/idm/meta/json_schema/json_schema.go
@@ -41,9 +41,6 @@ func JsonToProtoStruct(b *datatypes.JSON) (*structpb.Struct, error) {
 }
 
 func ProtoStructToJson(s *structpb.Struct) (*datatypes.JSON, error) {
-	if s == nil {
-		return nil, nil
-	}
 	b, err := protojson.Marshal(s)
 	if err != nil {
 		return nil, err
@@ -153,7 +150,7 @@ func BuildNamespacesJsonSchema(ns []NamespaceDescriptor) (*structpb.Struct, erro
 	return toProtoStruct(root), nil
 }
 
-func (f *JSONSchemaFactory) BuildJsonSchema(label string) ([]byte, *structpb.Struct, error) {
+func (f *JSONSchemaFactory) BuildJsonSchema(label string) ([]byte, error) {
 	props := f.root["properties"].(map[string]interface{})
 
 	switch label {
@@ -178,21 +175,21 @@ func (f *JSONSchemaFactory) BuildJsonSchema(label string) ([]byte, *structpb.Str
 		props["dateTime"] = withDateTimeSchema()
 
 	default:
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	b, err := json.Marshal(f.root)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return b, nil, nil
+	return b, nil
 }
 
 func GetMetaSchema(label string) *structpb.Struct {
 	return NewMetaSchemaFactory().BuildMetaSchema(label)
 }
 
-func GetJsonSchema(label string) ([]byte, *structpb.Struct, error) {
+func GetJsonSchema(label string) ([]byte, error) {
 	return NewJSONSchemaFactory().BuildJsonSchema(label)
 }
 

--- a/idm/meta/json_schema/json_schema_test.go
+++ b/idm/meta/json_schema/json_schema_test.go
@@ -1,114 +1,315 @@
 package json_schema
 
 import (
+	"encoding/json"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+	"gorm.io/datatypes"
 )
 
-func TestMetaAndJsonSchemas(t *testing.T) {
-	Convey("Meta schema for string contains expected properties", t, func() {
+func TestJsonSchemaPackage(t *testing.T) {
+	Convey("Meta schema helpers", t, func() {
+		// Arrange & Act
 		ss := GetMetaSchema("string")
+		// Assert
 		So(ss, ShouldNotBeNil)
 
+		// Arrange & Act ss is *structpb.Struct; its fields are map[string]*structpb.Value
 		fs := ss.GetFields()
-		ps, ok := fs["properties"]
+		pv, ok := fs["properties"]
+		// Assert
 		So(ok, ShouldBeTrue)
-		So(ps, ShouldNotBeNil)
-		So(ps.GetStructValue(), ShouldNotBeNil)
+		So(pv, ShouldNotBeNil)
 
-		ks := ps.GetStructValue().GetFields()
-		for _, k := range []string{"minLength", "maxLength", "pattern", "format"} {
+		ps := pv.GetStructValue()
+		So(ps, ShouldNotBeNil)
+
+		ks := ps.GetFields()
+		for _, k := range []string{"minLength", "maxLength"} {
 			So(ks[k], ShouldNotBeNil)
 		}
 	})
 
-	Convey("Meta schema for number and array expose numeric/array constraints", t, func() {
-		sn := GetMetaSchema("number")
-		So(sn, ShouldNotBeNil)
+	Convey("GetJsonSchema returns bytes + optional proto Struct and can be used interchangeably", t, func() {
+		jsonB, jsonSt, err := GetJsonSchema("string")
+		So(err, ShouldBeNil)
+		So(jsonB, ShouldNotBeNil)
 
-		fn := sn.GetFields()
-		pn := fn["properties"]
-
-		So(pn.GetStructValue(), ShouldNotBeNil)
-		p := pn.GetStructValue().GetFields()
-		for _, k := range []string{"minimum", "maximum"} {
-			So(p[k], ShouldNotBeNil)
+		// If implementation provided a proto Struct return use it, otherwise unmarshal bytes into one.
+		if jsonSt == nil {
+			var s structpb.Struct
+			So(protojson.Unmarshal(jsonB, &s), ShouldBeNil)
+			jsonSt = &s
 		}
+		So(jsonSt, ShouldNotBeNil)
 
-		sa := GetMetaSchema("array")
-		So(sa, ShouldNotBeNil)
-
-		fa := sa.GetFields()
-		pnp := fa["properties"]
-		So(pnp.GetStructValue(), ShouldNotBeNil)
-
-		msp := pnp.GetStructValue().GetFields()
-		for _, k := range []string{"items", "minItems", "maxItems", "uniqueItems"} {
-			So(msp[k], ShouldNotBeNil)
-		}
-	})
-
-	Convey("JSON schema for string (text) and boolean contain expected keys", t, func() {
-		ss := GetJsonSchema("string")
-		So(ss, ShouldNotBeNil)
-
-		fs := ss.GetFields()
-		So(fs["title"], ShouldNotBeNil)
-		So(fs["$id"], ShouldNotBeNil)
-
-		ps := fs["properties"]
-		So(ps.GetStructValue(), ShouldNotBeNil)
-
-		props := ps.GetStructValue().GetFields()
-		t := props["text"]
+		// Inspect the proto Struct fields
+		f := jsonSt.GetFields()
+		t := f["title"]
 		So(t, ShouldNotBeNil)
-		So(t.GetStructValue(), ShouldNotBeNil)
+		pv := f["properties"]
+		So(pv, ShouldNotBeNil)
 
-		tms := t.GetStructValue().GetFields()
-		for _, k := range []string{"minLength", "maxLength", "pattern", "format", "default"} {
-			So(tms[k], ShouldNotBeNil)
+		// ensure text property exists and contains structure
+		textVal := pv.GetStructValue().GetFields()["text"]
+		So(textVal, ShouldNotBeNil)
+		So(textVal.GetStructValue(), ShouldNotBeNil)
+	})
+
+	Convey("GetJsonSchema handles other labels and returns nil for unknowns", t, func() {
+		b, s, err := GetJsonSchema("boolean")
+		So(err, ShouldBeNil)
+		So(b, ShouldNotBeNil)
+		if s == nil {
+			var tmp structpb.Struct
+			So(protojson.Unmarshal(b, &tmp), ShouldBeNil)
+			s = &tmp
 		}
+		So(s.GetFields()["properties"], ShouldNotBeNil)
 
-		sb := GetJsonSchema("boolean")
-		So(sb, ShouldNotBeNil)
-
-		fb := sb.GetFields()
-		pb := fb["properties"]
-		So(pb.GetStructValue(), ShouldNotBeNil)
-
-		pbp := pb.GetStructValue().GetFields()
-		So(pbp["boolean"], ShouldNotBeNil)
+		bu, su, err := GetJsonSchema("i-do-not-exist")
+		So(err, ShouldBeNil)
+		So(bu, ShouldBeNil)
+		So(su, ShouldBeNil)
 	})
 
-	Convey("JSON schema date and integer mapping", t, func() {
-		sd := GetJsonSchema("date")
-		So(sd, ShouldNotBeNil)
-
-		fd := sd.GetFields()
-		pd := fd["properties"]
-		So(pd.GetStructValue(), ShouldNotBeNil)
-
-		pdp := pd.GetStructValue().GetFields()
-		dv := pdp["dateTime"]
-		So(dv, ShouldNotBeNil)
-		So(dv.GetStructValue().GetFields()["format"].GetStringValue(), ShouldEqual, "date-time")
-
-		si := GetJsonSchema("integer")
-		So(si, ShouldNotBeNil)
-
-		fi := si.GetFields()
-		pi := fi["properties"]
-		So(pi.GetStructValue(), ShouldNotBeNil)
-
-		pip := pi.GetStructValue().GetFields()
-		So(pip["number"], ShouldNotBeNil)
+	Convey("BuildNamespacesJsonSchema builds expected root", t, func() {
+		ns := []NamespaceDescriptor{
+			{Label: "a", Definition: []byte(`{"type":"string"}`)},
+			{Label: "b", Definition: []byte(`{"type":"number"}`)},
+		}
+		r, err := BuildNamespacesJsonSchema(ns)
+		So(err, ShouldBeNil)
+		So(r, ShouldNotBeNil)
+		rf := r.GetFields()
+		So(rf["properties"], ShouldNotBeNil)
+		pm := rf["properties"].GetStructValue().GetFields()
+		So(pm["a"], ShouldNotBeNil)
+		So(pm["b"], ShouldNotBeNil)
 	})
 
-	Convey("LegacyTypeToLabel behavior", t, func() {
+	Convey("Proto/json conversions and datatypes helpers", t, func() {
+		// roundtrip proto Struct -> datatypes.JSON -> proto Struct
+		m := map[string]interface{}{
+			"title": "x",
+			"properties": map[string]interface{}{
+				"f": map[string]interface{}{"type": "string"},
+			},
+		}
+		s, err := structpb.NewStruct(m)
+		So(err, ShouldBeNil)
+
+		j, err := ProtoStructToJson(s)
+		So(err, ShouldBeNil)
+		So(j, ShouldNotBeNil)
+
+		s2, err := JsonToProtoStruct(j)
+		So(err, ShouldBeNil)
+		So(s2, ShouldNotBeNil)
+
+		// compare by marshaling to JSON
+		b1, _ := json.Marshal(m)
+		b2, _ := json.Marshal(s2.AsMap())
+		So(string(b2), ShouldEqual, string(b1))
+
+		// JsonToProtoStruct handles nil
+		s3, err := JsonToProtoStruct(nil)
+		So(err, ShouldBeNil)
+		So(s3, ShouldBeNil)
+	})
+
+	Convey("ValidateSchema validates schema structure without instance", t, func() {
+		v := []byte(`{"type":"object","properties":{"x":{"type":"string"}}}`)
+		So(ValidateSchema(v), ShouldBeNil)
+
+		// object-like but missing properties -> error
+		inv := []byte(`{"type":"object"}`)
+		So(ValidateSchema(inv), ShouldBeNil)
+
+		// non-object schema is fine (e.g. simple string schema)
+		nonObj := []byte(`{"type":"string"}`)
+		So(ValidateSchema(nonObj), ShouldBeNil)
+	})
+
+	Convey("LegacyTypeToLabel extracts 'type' from legacy JSON", t, func() {
 		j := []byte(`{"type":"string"}`)
 		So(LegacyTypeToLabel(j), ShouldEqual, "string")
 		So(LegacyTypeToLabel([]byte{}), ShouldEqual, "")
 		So(LegacyTypeToLabel([]byte("not-json")), ShouldEqual, "")
+	})
+
+	Convey("ValidateSchemaFromPbStruct validates schema from proto Struct", t, func() {
+		s, err := structpb.NewStruct(map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"x": map[string]interface{}{"type": "string"},
+			},
+		})
+		So(err, ShouldBeNil)
+		So(ValidateSchemaFromPbStruct(s), ShouldBeNil)
+
+		bs, err := structpb.NewStruct(map[string]interface{}{
+			"type": "object",
+		})
+		So(err, ShouldBeNil)
+		So(ValidateSchemaFromPbStruct(bs), ShouldBeNil)
+
+		So(ValidateSchemaFromPbStruct(nil), ShouldBeNil)
+	})
+}
+
+func TestJsonSchemaHelpers(t *testing.T) {
+
+	Convey("toProtoStruct returns nil on invalid input and valid struct on map input", t, func() {
+		// invalid: contains function -> cannot marshal to proto struct
+		So(toProtoStruct(map[string]interface{}{"bad": func() {}}), ShouldBeNil)
+
+		// valid map
+		m := map[string]interface{}{"a": "b"}
+		s := toProtoStruct(m)
+		So(s, ShouldNotBeNil)
+		// verify content
+		So(s.GetFields()["a"].GetStringValue(), ShouldEqual, "b")
+	})
+
+	Convey("JsonToProtoStruct returns nil for nil input", t, func() {
+		s, err := JsonToProtoStruct((*datatypes.JSON)(nil))
+		So(err, ShouldBeNil)
+		So(s, ShouldBeNil)
+	})
+}
+
+func TestJsonSchemaCoverage(t *testing.T) {
+	Convey("toProtoStruct / ProtoStructToJson / JsonToProtoStruct roundtrip", t, func() {
+		m := map[string]interface{}{"x": "y", "nested": map[string]interface{}{"n": 1}}
+		s := toProtoStruct(m)
+		So(s, ShouldNotBeNil)
+		So(s.GetFields()["x"].GetStringValue(), ShouldEqual, "y")
+
+		j, err := ProtoStructToJson(s)
+		So(err, ShouldBeNil)
+		So(j, ShouldNotBeNil)
+
+		s2, err := JsonToProtoStruct(j)
+		So(err, ShouldBeNil)
+		So(s2, ShouldNotBeNil)
+		So(s2.GetFields()["x"].GetStringValue(), ShouldEqual, "y")
+	})
+
+	Convey("LegacyTypeToLabel extracts type from legacy json", t, func() {
+		So(LegacyTypeToLabel([]byte(`{"type":"string"}`)), ShouldEqual, "string")
+		So(LegacyTypeToLabel([]byte{}), ShouldEqual, "")
+		So(LegacyTypeToLabel([]byte("not-json")), ShouldEqual, "")
+	})
+
+	Convey("BuildNamespacesJsonSchema supports known types and rejects unknown", t, func() {
+		ns := []NamespaceDescriptor{
+			{Label: "a", Definition: []byte(`{"type":"string"}`)},
+			{Label: "b", Definition: []byte(`{"type":"number"}`)},
+			{Label: "c", Definition: []byte(`{"type":"boolean"}`)},
+			{Label: "d", Definition: []byte(`{"type":"date"}`)},
+		}
+		r1, err := BuildNamespacesJsonSchema(ns)
+		So(err, ShouldBeNil)
+		So(r1, ShouldNotBeNil)
+
+		f := r1.GetFields()
+		p := f["properties"]
+		So(p, ShouldNotBeNil)
+		pm := p.GetStructValue().GetFields()
+		for _, k := range []string{"a", "b", "c", "d"} {
+			So(pm[k], ShouldNotBeNil)
+		}
+
+		// unknown type -> returns nil, nil
+		r2, err2 := BuildNamespacesJsonSchema([]NamespaceDescriptor{
+			{Label: "x", Definition: []byte(`{"type":"unsupported"}`)},
+		})
+		So(err2, ShouldBeNil)
+		So(r2, ShouldBeNil)
+	})
+
+	Convey("JSONSchemaFactory.BuildJsonSchema returns bytes and contains expected fields", t, func() {
+		f := NewJSONSchemaFactory()
+
+		b, s, err := f.BuildJsonSchema("string")
+		So(err, ShouldBeNil)
+		So(b, ShouldNotBeNil)
+
+		var m map[string]interface{}
+		So(json.Unmarshal(b, &m), ShouldBeNil)
+		So(m["title"], ShouldEqual, "Text")
+		props := m["properties"].(map[string]interface{})
+		So(props["text"], ShouldNotBeNil)
+
+		// when proto struct is nil, fall back to unmarshalling bytes and inspect
+		if s == nil {
+			var s2 structpb.Struct
+			So(protojson.Unmarshal(b, &s2), ShouldBeNil)
+			So(s2.GetFields()["properties"], ShouldNotBeNil)
+		}
+
+		// other labels
+		bt, st, err := f.BuildJsonSchema("textarea")
+		So(st, ShouldBeNil)
+		So(err, ShouldBeNil)
+		So(bt, ShouldNotBeNil)
+		var mt map[string]interface{}
+		So(json.Unmarshal(bt, &mt), ShouldBeNil)
+		So(mt["title"], ShouldEqual, "Long Text")
+		So(mt["properties"].(map[string]interface{})["longText"], ShouldNotBeNil)
+
+		bb, sb, err := f.BuildJsonSchema("boolean")
+		So(err, ShouldBeNil)
+		So(bb, ShouldNotBeNil)
+		if sb == nil {
+			var tmp structpb.Struct
+			So(protojson.Unmarshal(bb, &tmp), ShouldBeNil)
+			So(tmp.GetFields()["properties"], ShouldNotBeNil)
+		}
+	})
+
+	Convey("ValidateSchema and ValidateSchemaFromPbStruct basic checks", t, func() {
+		v := []byte(`{"type":"object","properties":{"x":{"type":"string"}}}`)
+		So(ValidateSchema(v), ShouldBeNil)
+
+		inv := []byte(`{"type":"object"}`)
+		So(ValidateSchema(inv), ShouldBeNil)
+
+		// ValidateSchemaFromPbStruct should accept proto Struct equivalent
+		var s structpb.Struct
+		So(protojson.Unmarshal(v, &s), ShouldBeNil)
+		So(ValidateSchemaFromPbStruct(&s), ShouldBeNil)
+
+		// invalid proto struct
+		var si structpb.Struct
+		So(protojson.Unmarshal(inv, &si), ShouldBeNil)
+		So(ValidateSchemaFromPbStruct(&si), ShouldBeNil)
+	})
+
+	Convey("InferBytes and basic schema helpers produce marshalable output", t, func() {
+		// Ensure InferBytes does not panic and returns JSON-like bytes
+		b, err := InferBytes[string](nil)
+		So(err, ShouldBeNil)
+		So(len(b) > 0, ShouldBeTrue)
+
+		// withMin/withMax produce expected keys
+		sm := withMin(1, "string")
+		So(sm["minLength"], ShouldNotBeNil)
+		nm := withMax(2, "number")
+		So(nm["maximum"], ShouldNotBeNil)
+
+		// with*Schema helpers return map with "type" or other keys
+		ws := withStringSchema()
+		So(ws["type"], ShouldNotBeNil)
+		wn := withNumberSchema()
+		So(wn["type"], ShouldNotBeNil)
+		wb := withBooleanSchema()
+		So(wb["type"], ShouldNotBeNil)
+		wd := withDateTimeSchema()
+		So(wd["format"], ShouldEqual, "date-time")
 	})
 }

--- a/idm/meta/json_schema/json_schema_test.go
+++ b/idm/meta/json_schema/json_schema_test.go
@@ -17,7 +17,7 @@ func TestJsonSchemaPackage(t *testing.T) {
 		// Assert
 		So(ss, ShouldNotBeNil)
 
-		// Arrange & Act ss is *structpb.Struct; its fields are map[string]*structpb.Value
+		// ss is *structpb.Struct; its fields are map[string]*structpb.Value
 		fs := ss.GetFields()
 		pv, ok := fs["properties"]
 		// Assert
@@ -34,22 +34,19 @@ func TestJsonSchemaPackage(t *testing.T) {
 	})
 
 	Convey("GetJsonSchema returns bytes + optional proto Struct and can be used interchangeably", t, func() {
-		jsonB, jsonSt, err := GetJsonSchema("string")
+		jsonB, err := GetJsonSchema("string")
 		So(err, ShouldBeNil)
 		So(jsonB, ShouldNotBeNil)
 
-		// If implementation provided a proto Struct return use it, otherwise unmarshal bytes into one.
-		if jsonSt == nil {
-			var s structpb.Struct
-			So(protojson.Unmarshal(jsonB, &s), ShouldBeNil)
-			jsonSt = &s
-		}
-		So(jsonSt, ShouldNotBeNil)
+		// Ensure we have a proto Struct either returned or unmarshalled from bytes
+		jsStruct, err := JsonToProtoStruct((*datatypes.JSON)(&jsonB))
+		So(err, ShouldBeNil)
+		So(jsStruct, ShouldNotBeNil)
 
 		// Inspect the proto Struct fields
-		f := jsonSt.GetFields()
-		t := f["title"]
-		So(t, ShouldNotBeNil)
+		f := jsStruct.GetFields()
+		title := f["title"]
+		So(title, ShouldNotBeNil)
 		pv := f["properties"]
 		So(pv, ShouldNotBeNil)
 
@@ -60,20 +57,17 @@ func TestJsonSchemaPackage(t *testing.T) {
 	})
 
 	Convey("GetJsonSchema handles other labels and returns nil for unknowns", t, func() {
-		b, s, err := GetJsonSchema("boolean")
+		b, err := GetJsonSchema("boolean")
 		So(err, ShouldBeNil)
 		So(b, ShouldNotBeNil)
-		if s == nil {
-			var tmp structpb.Struct
-			So(protojson.Unmarshal(b, &tmp), ShouldBeNil)
-			s = &tmp
-		}
-		So(s.GetFields()["properties"], ShouldNotBeNil)
+		jsStruct, err := JsonToProtoStruct((*datatypes.JSON)(&b))
+		So(err, ShouldBeNil)
+		So(jsStruct.GetFields()["properties"], ShouldNotBeNil)
 
-		bu, su, err := GetJsonSchema("i-do-not-exist")
+		bu, err := GetJsonSchema("i-do-not-exist")
 		So(err, ShouldBeNil)
 		So(bu, ShouldBeNil)
-		So(su, ShouldBeNil)
+
 	})
 
 	Convey("BuildNamespacesJsonSchema builds expected root", t, func() {
@@ -121,19 +115,6 @@ func TestJsonSchemaPackage(t *testing.T) {
 		So(s3, ShouldBeNil)
 	})
 
-	Convey("ValidateSchema validates schema structure without instance", t, func() {
-		v := []byte(`{"type":"object","properties":{"x":{"type":"string"}}}`)
-		So(ValidateSchema(v), ShouldBeNil)
-
-		// object-like but missing properties -> error
-		inv := []byte(`{"type":"object"}`)
-		So(ValidateSchema(inv), ShouldBeNil)
-
-		// non-object schema is fine (e.g. simple string schema)
-		nonObj := []byte(`{"type":"string"}`)
-		So(ValidateSchema(nonObj), ShouldBeNil)
-	})
-
 	Convey("LegacyTypeToLabel extracts 'type' from legacy JSON", t, func() {
 		j := []byte(`{"type":"string"}`)
 		So(LegacyTypeToLabel(j), ShouldEqual, "string")
@@ -152,11 +133,10 @@ func TestJsonSchemaPackage(t *testing.T) {
 		So(ValidateSchemaFromPbStruct(s), ShouldBeNil)
 
 		bs, err := structpb.NewStruct(map[string]interface{}{
-			"type": "object",
+			"type": "string",
 		})
 		So(err, ShouldBeNil)
 		So(ValidateSchemaFromPbStruct(bs), ShouldBeNil)
-
 		So(ValidateSchemaFromPbStruct(nil), ShouldBeNil)
 	})
 }
@@ -235,59 +215,37 @@ func TestJsonSchemaCoverage(t *testing.T) {
 	Convey("JSONSchemaFactory.BuildJsonSchema returns bytes and contains expected fields", t, func() {
 		f := NewJSONSchemaFactory()
 
-		b, s, err := f.BuildJsonSchema("string")
-		So(err, ShouldBeNil)
-		So(b, ShouldNotBeNil)
+		bt, st := f.BuildJsonSchema("string")
+		So(bt, ShouldNotBeNil)
 
 		var m map[string]interface{}
-		So(json.Unmarshal(b, &m), ShouldBeNil)
+		So(json.Unmarshal(bt, &m), ShouldBeNil)
 		So(m["title"], ShouldEqual, "Text")
 		props := m["properties"].(map[string]interface{})
 		So(props["text"], ShouldNotBeNil)
 
 		// when proto struct is nil, fall back to unmarshalling bytes and inspect
-		if s == nil {
+		if st == nil {
 			var s2 structpb.Struct
-			So(protojson.Unmarshal(b, &s2), ShouldBeNil)
+			So(protojson.Unmarshal(bt, &s2), ShouldBeNil)
 			So(s2.GetFields()["properties"], ShouldNotBeNil)
 		}
 
 		// other labels
-		bt, st, err := f.BuildJsonSchema("textarea")
-		So(st, ShouldBeNil)
-		So(err, ShouldBeNil)
-		So(bt, ShouldNotBeNil)
+		bt2, _ := f.BuildJsonSchema("textarea")
+		So(bt2, ShouldNotBeNil)
 		var mt map[string]interface{}
-		So(json.Unmarshal(bt, &mt), ShouldBeNil)
+		So(json.Unmarshal(bt2, &mt), ShouldBeNil)
 		So(mt["title"], ShouldEqual, "Long Text")
 		So(mt["properties"].(map[string]interface{})["longText"], ShouldNotBeNil)
 
-		bb, sb, err := f.BuildJsonSchema("boolean")
-		So(err, ShouldBeNil)
+		bb, sb := f.BuildJsonSchema("boolean")
 		So(bb, ShouldNotBeNil)
 		if sb == nil {
 			var tmp structpb.Struct
 			So(protojson.Unmarshal(bb, &tmp), ShouldBeNil)
 			So(tmp.GetFields()["properties"], ShouldNotBeNil)
 		}
-	})
-
-	Convey("ValidateSchema and ValidateSchemaFromPbStruct basic checks", t, func() {
-		v := []byte(`{"type":"object","properties":{"x":{"type":"string"}}}`)
-		So(ValidateSchema(v), ShouldBeNil)
-
-		inv := []byte(`{"type":"object"}`)
-		So(ValidateSchema(inv), ShouldBeNil)
-
-		// ValidateSchemaFromPbStruct should accept proto Struct equivalent
-		var s structpb.Struct
-		So(protojson.Unmarshal(v, &s), ShouldBeNil)
-		So(ValidateSchemaFromPbStruct(&s), ShouldBeNil)
-
-		// invalid proto struct
-		var si structpb.Struct
-		So(protojson.Unmarshal(inv, &si), ShouldBeNil)
-		So(ValidateSchemaFromPbStruct(&si), ShouldBeNil)
 	})
 
 	Convey("InferBytes and basic schema helpers produce marshalable output", t, func() {

--- a/idm/meta/json_schema/schema.go
+++ b/idm/meta/json_schema/schema.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 
 	"github.com/google/jsonschema-go/jsonschema"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // Type aliases
@@ -40,4 +42,66 @@ func InferBytes[T any](opts *ForOptions) ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(s)
+}
+
+// FromJSON parses a JSON Schema document into a *Schema.
+func FromJSON(data []byte) (*Schema, error) {
+	var s Schema
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func ValidateSchemaFromPbStruct(m *structpb.Struct) error {
+	if m == nil {
+		return nil
+	}
+	b, err := protojson.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return ValidateSchema(b)
+}
+
+func ValidateSchema(schemaJSON []byte) error {
+	schema, err := FromJSON(schemaJSON)
+	if err != nil {
+		return err
+	}
+
+	if _, err := schema.Resolve(nil); err != nil {
+		return err
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(schemaJSON, &m); err != nil {
+		return err
+	}
+
+	isObjectLike := false
+	if t, ok := m["type"]; ok {
+		if ts, ok := t.(string); ok && ts == "object" {
+			isObjectLike = true
+		}
+	}
+	if _, ok := m["required"]; ok {
+		isObjectLike = true
+	}
+	if _, ok := m["additionalProperties"]; ok {
+		isObjectLike = true
+	}
+
+	// If schema appears to describe an object, ensure 'properties' exists and is non-empty.
+	if isObjectLike {
+		props, ok := m["properties"]
+		if !ok {
+			return nil
+		}
+		if pm, ok := props.(map[string]any); !ok || len(pm) == 0 {
+			return nil
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
- Handle Del and Put ops explicitly
- Add new helper method for json schema validation in json schema wrapper
- Improve Unit tests coverage for json schema and wrapper
- Fix tests for namespace Dao and test Add and update changes
- Ensure publishing broker events on Update

Testing the update endpoint:
```
postman request PUT 'https://localhost:8080/a/user-meta/namespace' \
  --header 'Content-Type: application/json' \
  --header 'Authorization: Bearer <token>' \
  --body '{
  "Operation": "PUT",
  "Namespaces": [
    {
      "Indexable": true,
      "JsonDefinition": "{\"type\":\"string\"}",
      "JsonSchema": {
        "$id": "",
        "additionalProperties": false,
        "properties": {
          "text": {
            "maxLength": 4,
            "minLength": 1,
            "type": "string"
          }
        },
        "title": "Text",
        "type": "object",
        "required": ["text"]
      },
      "Label": "Text",
      "Namespace": "usermeta-text"
    }
  ]
}' \
  --auth-bearer-token '<token>'