### PR TITLE
fix(api): accept any name for namespace schema property

### DIFF
--- a/idm/meta/json_schema/json_schema.go
+++ b/idm/meta/json_schema/json_schema.go
@@ -139,13 +139,13 @@ func BuildNamespacesJsonSchema(mns []NamespaceDescriptor) (*structpb.Struct, err
 			return nil, err
 		}
 
-		p := schema_props["properties"].(map[string]interface{})
+		props := schema_props["properties"].(map[string]interface{})
 		// NOTE: Should it ever happen?? Check the format in ./json_schema_test.go:75
-		if len(p) > 1 {
+		if len(props) > 1 {
 			return nil, fmt.Errorf("namespace property has more than one definition: %s", n.Namespace)
 		}
 
-		for _, v := range p {
+		for _, v := range props {
 			properties[n.Namespace] = v
 		}
 

--- a/idm/meta/json_schema/json_schema.go
+++ b/idm/meta/json_schema/json_schema.go
@@ -134,9 +134,19 @@ func BuildNamespacesJsonSchema(mns []NamespaceDescriptor) (*structpb.Struct, err
 		}
 
 		var schema_props map[string]interface{}
-		if err := json.Unmarshal([]byte(*n.JsonSchema), &schema_props); err == nil {
-			p := schema_props["properties"].(map[string]interface{})
-			properties[n.Namespace] = p[n.Namespace]
+		err := json.Unmarshal([]byte(*n.JsonSchema), &schema_props)
+		if err != nil {
+			return nil, err
+		}
+
+		p := schema_props["properties"].(map[string]interface{})
+		// NOTE: Should it ever happen?? Check the format in ./json_schema_test.go:75
+		if len(p) > 1 {
+			return nil, fmt.Errorf("namespace property has more than one definition: %s", n.Namespace)
+		}
+
+		for _, v := range p {
+			properties[n.Namespace] = v
 		}
 
 		if raw, ok := schema_props["required"]; ok && raw != nil {
@@ -179,7 +189,7 @@ func (f *JSONSchemaFactory) BuildJsonSchema(label string) ([]byte, error) {
 
 	case "textarea":
 		var t = fmt.Sprintf("%s-long-text", usermeta)
-		f.root["title"] = "Long Text"
+		f.root["title"] = t
 		props[t] = withStringSchema()
 
 	case "string":

--- a/idm/meta/json_schema/json_schema_test.go
+++ b/idm/meta/json_schema/json_schema_test.go
@@ -76,9 +76,11 @@ func TestJsonSchemaPackage(t *testing.T) {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "additionalProperties": false,
             "properties": {
-                "maxLength": 0,
-                "minLength": 0,
-                "type": "string"
+							  "usermeta-text": {
+									"maxLength": 0,
+									"minLength": 0,
+									"type": "string"
+								}
             },
             "required": ["usermeta-text"],
             "title": "usermeta-text",


### PR DESCRIPTION
This commit changes the JSON schema building logic to correctly handle namespace properties regardless of their key name in the source schema.

Detailed Changes:
 - Implementation:
   - Changed json_schema.go to iterate over properties map instead of assuming a specific key name, allowing any property name in the namespace schema.
   - Added validation to reject schemas with more than one property definition for a namespace.
   - Changed the title assignment for textarea fields to use the actual field name instead of a hardcoded string.
 - Tests:
   - Updated json_schema_test.go to match the new property structure in test expectations.
   
 