### PR TITLE
fix(api): WPB-21375 correct namespace deletion query

### DIFF
--- a/idm/meta/dao/sql/ns-sql.go
+++ b/idm/meta/dao/sql/ns-sql.go
@@ -194,7 +194,16 @@ func (s *nsSqlImpl) Upsert(ctx context.Context, ns *idm.UserMetaNamespace) (erro
 
 // Del removes a namespace
 func (s *nsSqlImpl) Del(ctx context.Context, ns *idm.UserMetaNamespace) (e error) {
-	tx := s.Session(ctx).Where("namespace = ? AND label = ?", ns.Namespace, ns.Label).Delete(&MetaNamespace{})
+	namespaceToDelete := (&MetaNamespace{}).From(ns)
+
+	tx := s.Session(ctx).Where(&MetaNamespace{
+		Namespace:      namespaceToDelete.Namespace,
+		Label:          namespaceToDelete.Label,
+		Order:          namespaceToDelete.Order,
+		Definition:     namespaceToDelete.Definition,
+		PromptOnUpload: namespaceToDelete.PromptOnUpload,
+		EnforceDefault: namespaceToDelete.EnforceDefault,
+	}).Delete(&MetaNamespace{})
 	if tx.Error != nil {
 		return nsTag(tx.Error)
 	}

--- a/idm/meta/dao/sql/ns-sql.go
+++ b/idm/meta/dao/sql/ns-sql.go
@@ -194,16 +194,10 @@ func (s *nsSqlImpl) Upsert(ctx context.Context, ns *idm.UserMetaNamespace) (erro
 
 // Del removes a namespace
 func (s *nsSqlImpl) Del(ctx context.Context, ns *idm.UserMetaNamespace) (e error) {
-	namespaceToDelete := (&MetaNamespace{}).From(ns)
+	whereClause := (&MetaNamespace{}).From(ns)
+	whereClause.JsonSchema = nil
 
-	tx := s.Session(ctx).Where(&MetaNamespace{
-		Namespace:      namespaceToDelete.Namespace,
-		Label:          namespaceToDelete.Label,
-		Order:          namespaceToDelete.Order,
-		Definition:     namespaceToDelete.Definition,
-		PromptOnUpload: namespaceToDelete.PromptOnUpload,
-		EnforceDefault: namespaceToDelete.EnforceDefault,
-	}).Delete(&MetaNamespace{})
+	tx := s.Session(ctx).Where(whereClause).Delete(&MetaNamespace{})
 	if tx.Error != nil {
 		return nsTag(tx.Error)
 	}

--- a/idm/meta/dao/sql/ns-sql.go
+++ b/idm/meta/dao/sql/ns-sql.go
@@ -194,7 +194,7 @@ func (s *nsSqlImpl) Upsert(ctx context.Context, ns *idm.UserMetaNamespace) (erro
 
 // Del removes a namespace
 func (s *nsSqlImpl) Del(ctx context.Context, ns *idm.UserMetaNamespace) (e error) {
-	tx := s.Session(ctx).Where((&MetaNamespace{}).From(ns)).Delete(&MetaNamespace{})
+	tx := s.Session(ctx).Where("namespace = ? AND label = ?", ns.Namespace, ns.Label).Delete(&MetaNamespace{})
 	if tx.Error != nil {
 		return nsTag(tx.Error)
 	}

--- a/idm/meta/dao/sql/ns-sql_test.go
+++ b/idm/meta/dao/sql/ns-sql_test.go
@@ -89,7 +89,6 @@ func TestNSCrud(t *testing.T) {
 }
 
 func TestNSResourceRules(t *testing.T) {
-
 	test.RunStorageTests(nsTestcases, t, func(ctx context.Context) {
 		mockDAO, er := manager.Resolve[meta.NamespaceDAO](ctx)
 		if er != nil {
@@ -186,6 +185,52 @@ func TestNSNewFields(t *testing.T) {
 			// Cleanup
 			err4 := mockDAO.Del(ctx, &idm.UserMetaNamespace{Namespace: "namespace-newfields"})
 			So(err4, ShouldBeNil)
+		})
+	})
+}
+
+func TestNSDeleteWithJsonSchema(t *testing.T) {
+	test.RunStorageTests(nsTestcases, t, func(ctx context.Context) {
+		Convey("Delete namespace with JsonSchema", t, func() {
+			mockDAO, err := manager.Resolve[meta.NamespaceDAO](ctx)
+			So(err, ShouldBeNil)
+
+			beforeList, err := mockDAO.List(ctx)
+			So(err, ShouldBeNil)
+			beforeLen := len(beforeList)
+
+			nsKey := "namespace-delete-jsonschema"
+			nsLabel := "label-delete-jsonschema"
+
+			jsBytes, err := json_schema.GetJsonSchema(json_schema.LegacyTypeToLabel([]byte("{\"type\":\"string\"}")))
+			So(err, ShouldBeNil)
+			jsAsJSON := datatypes.JSON(jsBytes)
+			jsStruct, err := json_schema.JsonToProtoStruct(&jsAsJSON)
+			So(err, ShouldBeNil)
+
+			// Insert namespace with JsonSchema value
+			err, _ = mockDAO.Upsert(ctx, &idm.UserMetaNamespace{
+				Namespace:      nsKey,
+				Label:          nsLabel,
+				JsonDefinition: "{\"type\":\"string\"}",
+				JsonSchema:     jsStruct,
+			})
+			So(err, ShouldBeNil)
+
+			afterAdd, err := mockDAO.List(ctx)
+			So(err, ShouldBeNil)
+			So(afterAdd, ShouldHaveLength, beforeLen+1)
+			_, ok := afterAdd[nsKey]
+			So(ok, ShouldBeTrue)
+
+			err = mockDAO.Del(ctx, &idm.UserMetaNamespace{Namespace: nsKey, Label: nsLabel})
+			So(err, ShouldBeNil)
+
+			afterDelete, err := mockDAO.List(ctx)
+			So(err, ShouldBeNil)
+			So(afterDelete, ShouldHaveLength, beforeLen)
+			_, ok = afterDelete[nsKey]
+			So(ok, ShouldBeFalse)
 		})
 	})
 }


### PR DESCRIPTION
This commit fixes the namespace deletion query to use explicit column names instead of a struct-based condition, because it was failing to delete rows with complex JsonSchema

Detailed Changes:
 - Implementation:
   - Changed the WHERE clause in ns-sql.go to use explicit column less the jsonschema.
 - Tests:
   - Added a new test TestNSDeleteWithJsonSchema in ns-sql_test.go to verify deletion of namespaces with JsonSchema.


## To check this change
```bash
#!/bin/sh

token="$(curl -k "https://pydio.localhost/a/frontend/session" \
  -X POST \
  -H "Content-Type: application/json" \
  -d '{
    "AuthInfo": {
      "login":    "admin",
      "password": "admin",
      "type":     "credentials"
    }
  }' | jq -r .JWT)"

echo "Token: $token"

# Create
curl -k 'https://pydio.localhost/a/user-meta/namespace' \
  -X 'PUT' \
  -H 'accept: application/json' \
  -H "authorization: Bearer $token" \
  -H 'content-type: application/json' \
  --data-raw '{
    "Operation": "PUT",
    "Namespaces": [
      {
        "Indexable": true,
        "JsonDefinition": "{\"type\":\"integer\"}",
        "JsonSchema": {
          "$id": "https://pydio.com/integer",
          "additionalProperties": false,
          "properties": {
            "usermeta-number": {
              "maximum": 10,
              "minimum": 0,
              "type": "number"
            }
          },
          "required": ["usermeta-number"],
          "title": "t",
          "type": "object"
        },
        "Label": "number foo",
        "Namespace": "usermeta-number-foo",
        "Order": 4,
        "Policies": [
          {
            "Action": "READ",
            "Effect": "allow",
            "Resource": "usermeta-number",
            "Subject": "*",
            "id": "11"
          },
          {
            "Action": "WRITE",
            "Effect": "allow",
            "Resource": "usermeta-number",
            "Subject": "*",
            "id": "12"
          }
        ],
        "PoliciesContextEditable": true,
        "PromptOnUpload": true
      }
    ]
  }'

# AND THEN DELETE
curl -k 'https://pydio.localhost/a/user-meta/namespace' \
  -X 'PUT' \
  -H 'accept: application/json' \
  -H "authorization: Bearer $token" \
  -H 'content-type: application/json' \
  --data-raw '{
    "Operation": "DELETE",
    "Namespaces": [
      {
        "Indexable": true,
        "JsonDefinition": "{\"type\":\"integer\"}",
        "JsonSchema": {
          "$id": "https://pydio.com/integer",
          "additionalProperties": false,
          "properties": {
            "usermeta-number": {
              "maximum": 10,
              "minimum": 0,
              "type": "number"
            }
          },
          "required": ["usermeta-number"],
          "title": "t",
          "type": "object"
        },
        "Label": "number foo",
        "Namespace": "usermeta-number-foo",
        "Order": 4,
        "Policies": [
          {
            "Action": "READ",
            "Effect": "allow",
            "Resource": "usermeta-number",
            "Subject": "*",
            "id": "11"
          },
          {
            "Action": "WRITE",
            "Effect": "allow",
            "Resource": "usermeta-number",
            "Subject": "*",
            "id": "12"
          }
        ],
        "PoliciesContextEditable": true,
        "PromptOnUpload": true
      }
    ]
  }'

# Here the usermeta-number-foo should not be present!
curl -k 'https://pydio.localhost/a/user-meta/namespace/jsonschema' \
  -H 'accept: application/json' \
  -H 'accept-language: en-GB,en;q=0.9' \
  -H "authorization: Bearer $token" | jq .
```