### PR TITLE
fix(jsonschema): remove format field from string schema

### DIFF
--- a/idm/meta/json_schema/json_schema.go
+++ b/idm/meta/json_schema/json_schema.go
@@ -287,7 +287,6 @@ func withStringSchema() map[string]interface{} {
 	// prop["minLength"] = withMin(0, "string")["minLength"]
 	// prop["maxLength"] = withMax(0, "string")["maxLength"]
 	// prop["pattern"] = ""
-	prop["format"] = ""
 	return prop
 }
 

--- a/idm/meta/json_schema/json_schema_test.go
+++ b/idm/meta/json_schema/json_schema_test.go
@@ -257,7 +257,7 @@ func TestJsonSchemaCoverage(t *testing.T) {
 	Convey("JSONSchemaFactory.BuildJsonSchema returns bytes and contains expected fields", t, func() {
 		f := NewJSONSchemaFactory("string")
 
-		bt, st := f.BuildJsonSchema("string")
+		bt, st := f.BuildJsonSchema("string", "")
 		So(bt, ShouldNotBeNil)
 
 		var m map[string]interface{}
@@ -274,14 +274,14 @@ func TestJsonSchemaCoverage(t *testing.T) {
 		}
 
 		// other labels
-		bt2, _ := f.BuildJsonSchema("textarea")
+		bt2, _ := f.BuildJsonSchema("textarea", "")
 		So(bt2, ShouldNotBeNil)
 		var mt map[string]interface{}
 		So(json.Unmarshal(bt2, &mt), ShouldBeNil)
 		So(mt["title"], ShouldEqual, "usermeta-long-text")
 		So(mt["properties"], ShouldNotBeNil)
 
-		bb, sb := f.BuildJsonSchema("boolean")
+		bb, sb := f.BuildJsonSchema("boolean", "")
 		So(bb, ShouldNotBeNil)
 		if sb == nil {
 			var tmp structpb.Struct


### PR DESCRIPTION
This commit removes the format field from the string schema in JSON Schema factory.

Detailed Changes:
 - Implementation:
   - Removed the format field from the string schema in json_schema.go.
   - Updated test calls in json_schema_test.go to include an empty string parameter for BuildJsonSchema.

(cherry picked from commit d2cc2043f8b41278cfa685eeea1ba7e57cc9d4b6)