### PR TITLE
feat(metadata): add URL metadata type support Admin & Backend

### DIFF
--- a/frontend/assets/access.settings/res/i18n/admin/en-us.all.json
+++ b/frontend/assets/access.settings/res/i18n/admin/en-us.all.json
@@ -872,6 +872,9 @@
   "metadata.type.json": {
     "other": "JSON (internal format)"
   },
+  "metadata.type.url": {
+    "other": "URL"
+  },
   "metadata.type.date.format": {
     "other": "Format"
   },

--- a/frontend/assets/access.settings/res/js/AdminWorkspaces/model/Metadata.js
+++ b/frontend/assets/access.settings/res/js/AdminWorkspaces/model/Metadata.js
@@ -90,7 +90,8 @@ Metadata.MetaTypes = {
     "tags": "Extensible Tags",
     "stars_rate": "Stars Rating",
     "css_label": "Color Labels",
-    "json": "JSON"
+    "json": "JSON",
+    "url": "URL"
 };
 
 export { Metadata as default }

--- a/frontend/assets/access.settings/res/js/AdminWorkspaces/model/Metadata.js
+++ b/frontend/assets/access.settings/res/js/AdminWorkspaces/model/Metadata.js
@@ -91,7 +91,7 @@ Metadata.MetaTypes = {
     "stars_rate": "Stars Rating",
     "css_label": "Color Labels",
     "json": "JSON",
-    "url": "URL"
+    "url": "External URL"
 };
 
 export { Metadata as default }

--- a/frontend/assets/meta.user/res/js/TypeEditor.js
+++ b/frontend/assets/meta.user/res/js/TypeEditor.js
@@ -37,7 +37,7 @@ const MetaTypes = {
     "stars_rate":   "Stars Rating",
     "css_label":    "Color Labels",
     "json":         "JSON",
-    "url":          "URL",
+    "url":          "External URL"
 }
 
 class TypeEditor extends React.Component {

--- a/frontend/assets/meta.user/res/js/TypeEditor.js
+++ b/frontend/assets/meta.user/res/js/TypeEditor.js
@@ -36,7 +36,8 @@ const MetaTypes = {
     "tags":         "Extensible Tags",
     "stars_rate":   "Stars Rating",
     "css_label":    "Color Labels",
-    "json":         "JSON"
+    "json":         "JSON",
+    "url":          "URL",
 }
 
 class TypeEditor extends React.Component {

--- a/idm/meta/json_schema/json_schema.go
+++ b/idm/meta/json_schema/json_schema.go
@@ -73,6 +73,10 @@ func (f *MetaSchemaFactory) BuildMetaSchema(label string) *structpb.Struct {
 		props["required"] = withBooleanType()
 		return toProtoStruct(f.root)
 
+	case "url":
+		props["required"] = withBooleanType()
+		return toProtoStruct(f.root)
+
 	case "integer":
 		props["minimum"] = withNumberType()
 		props["maximum"] = withNumberType()
@@ -228,6 +232,14 @@ func (f *JSONSchemaFactory) BuildJsonSchema(label string, name string) ([]byte, 
 		f.root["title"] = t
 		props[t] = withDateTimeSchema()
 
+	case "url":
+		var t = fmt.Sprintf("%s-url", usermeta)
+		if name != "" {
+			t = fmt.Sprintf("usermeta-%s", name)
+		}
+		f.root["title"] = t
+		props[t] = withUrlSchema()
+
 	default:
 		return nil, nil
 	}
@@ -296,6 +308,13 @@ func withNumberSchema() map[string]interface{} {
 	// prop["minimum"] = withMin(0, "number")["minimum"]
 	// prop["maximum"] = withMax(0, "number")["maximum"]
 	// prop["format"] = ""
+	return prop
+}
+
+func withUrlSchema() map[string]interface{} {
+	s, _ := Infer[string](nil)
+	prop := marshalSchema(s)
+	prop["format"] = "uri"
 	return prop
 }
 

--- a/idm/meta/json_schema/json_schema_test.go
+++ b/idm/meta/json_schema/json_schema_test.go
@@ -288,6 +288,13 @@ func TestJsonSchemaCoverage(t *testing.T) {
 			So(protojson.Unmarshal(bb, &tmp), ShouldBeNil)
 			So(tmp.GetFields()["properties"], ShouldNotBeNil)
 		}
+
+		urlSchema, _ := f.BuildJsonSchema("url", "")
+		So(bt2, ShouldNotBeNil)
+		var mapURL map[string]interface{}
+		So(json.Unmarshal(urlSchema, &mapURL), ShouldBeNil)
+		So(mapURL["title"], ShouldEqual, "usermeta-url")
+		So(mapURL["properties"], ShouldNotBeNil)
 	})
 
 	Convey("InferBytes and basic schema helpers produce marshalable output", t, func() {


### PR DESCRIPTION
This commit adds support for a new URL metadata type in the admin console and user metadata editor.

Detailed Changes:
 - Implementation:
   - Added URL type to metadata type definitions in AdminWorkspaces model and user TypeEditor.
   - Extended JSON schema factory to generate URL schema with URI format validation.
   - Added English translation for the new URL metadata type in admin i18n file.
