### PR TITLE
feat(metadata): remove mock schema and definition from MetaClient

### DIFF
--- a/frontend/assets/meta.user/res/js/MetaClient.js
+++ b/frontend/assets/meta.user/res/js/MetaClient.js
@@ -85,18 +85,7 @@ class MetaClient{
 
     async getNamespaceSchema() {
         const api = new UserMetaServiceApi(this.client);
-        return api.getNamespaceSchema().then(ns => {
-            // TODO: remove this mock
-            ns.JsonSchema.properties = Object.entries(ns.JsonSchema.properties).reduce((acc, [key, val]) => {
-                if (key && key.includes('-url')) {
-                    const { properties } = mockUserMeta.JsonSchema;
-                    return ({ ...acc, [key]: properties["usermeta-url"] })
-                }
-                return ({ ...acc, [key]: val })
-            }, {});
-
-            return ns;
-        })
+        return api.getNamespaceSchema();
     }
 
     clearConfigs() {
@@ -110,13 +99,6 @@ class MetaClient{
 
         nss.map(ns => {
             const name = ns.Namespace;
-
-            // TODO: remove this mock
-            if (name.includes('-url')) {
-                const { JsonSchema, JsonDefinition } = mockUserMeta;
-                ns.JsonSchema = JsonSchema;
-                ns.JsonDefinition = JsonDefinition;
-            }
 
             let base = {
                 label: ns.Label,


### PR DESCRIPTION
Removed mock JSON schema and definition handling for namespaces containing '-url' in MetaClient.

Detailed Changes:
 - Implementation:
   - Removed mock schema transformation in getNamespaceSchema method.
   - Removed mock schema and definition assignment for '-url' namespaces in getNamespaceConfigs method.

(cherry picked from commit 81be58ae6d67bc3209477ccd316f74970961261f)