### PR TITLE
fix(metadata): render URL as text for search options

### DIFF
--- a/frontend/assets/gui.ajax/res/js/ui/HOCs/search/withSearch.js
+++ b/frontend/assets/gui.ajax/res/js/ui/HOCs/search/withSearch.js
@@ -126,7 +126,8 @@ export default function withSearch(Component, historyIdentifier, defaultScope){
                                 v.blockRenderer = (value) => {
                                     const n = new Node()
                                     n.getMetadata().set(v.namespace, value)
-                                    return o.renderComponent(n, {name:v.namespace})
+                                    const context = { parent: 'search-options' }
+                                    return o.renderComponent(n, {name:v.namespace}, context)
                                 }
                             }
                             options.indexedMeta.push(v)

--- a/frontend/assets/meta.user/res/js/Renderer.js
+++ b/frontend/assets/meta.user/res/js/Renderer.js
@@ -31,7 +31,7 @@ import TagsCloud from "./fields/TagsCloud";
 import {DateTimeField, DateTimeForm} from "./fields/DateTime";
 import BooleanForm from "./fields/BooleanForm";
 import {IntegerField, IntegerForm} from "./fields/Integer";
-import {URLField, URLForm} from "./fields/URL";
+import {getURLDisplayByContext, URLForm} from "./fields/URL";
 
 export default class Renderer{
 
@@ -107,11 +107,12 @@ export default class Renderer{
         return <IntegerField node={node} column={column} inline={true}/>;
     }
 
-    static renderURL(node, column) {
+    static renderURL(node, column, ctx) {
         if(!node.getMetadata().get(column.name)){
             return null;
         }
-        return <URLField node={node} column={column}/>;
+        const UrlComponent = getURLDisplayByContext(ctx || {});
+        return <UrlComponent node={node} column={column}/>;
     }
 
     static formPanelStars(props){

--- a/frontend/assets/meta.user/res/js/fields/URL.jsx
+++ b/frontend/assets/meta.user/res/js/fields/URL.jsx
@@ -97,12 +97,7 @@ const URLLinkIcon = ({ fontSize, url, displayText, children }) => {
 
 }
 
-/**
- * @param {{getRealValue: () => string}} props
- * @returns {React.ReactElement}
- */
-const URLFieldBase = ({ getRealValue }) => {
-    const url = getRealValue();
+const formatURL = (url) => {
     if (!url || !String(url).trim()) {
         return <Fragment></Fragment>;
     }
@@ -114,16 +109,30 @@ const URLFieldBase = ({ getRealValue }) => {
     }
 
     // Validate URL format
-    let displayText = sanitizedURL;
+    let displayURL = sanitizedURL;
 
     // Extract display text (domain or full URL)
     try {
         const urlObj = new URL(sanitizedURL);
-        displayText = urlObj.hostname || sanitizedURL;
+        displayURL = urlObj.hostname || sanitizedURL;
     } catch (e) {
         // If URL parsing fails, use original value
-        displayText = sanitizedURL;
+        displayURL = sanitizedURL;
     }
+
+    return {
+        normalizedURL,
+        displayURL,
+    }
+}
+
+/**
+ * @param {{getRealValue: () => string}} props
+ * @returns {React.ReactElement}
+ */
+const URLFieldBase = ({ getRealValue }) => {
+    const url = getRealValue();
+    const { normalizedURL, displayURL: displayText } = formatURL(url);
 
     return <URLLinkIcon fontSize={14} url={normalizedURL} displayText={displayText} children={displayText} />;
 }
@@ -134,6 +143,38 @@ const URLFieldBase = ({ getRealValue }) => {
  */
 const URLField = asMetaField(muiThemeable()(URLFieldBase));
 export { URLField }
+
+/**
+ * @param {{
+ *   parent: string
+ * }} ctx
+ * @returns {typeof URLFieldBase|typeof URLSimpleTextBase}
+ **/
+export const getURLDisplayByContext = (ctx) => {
+    if (ctx.parent === 'search-options') {
+        return URLSimpleText;
+    }
+
+    return URLField;
+}
+
+/**
+ * @param {{getRealValue: () => string}} props
+ * @returns {React.ReactElement}
+ */
+const URLSimpleTextBase = ({ getRealValue }) => {
+    const url = getRealValue();
+    const { displayURL } = formatURL(url);
+
+    return <span data-testid="url-text">{displayURL}</span>;
+}
+
+/**
+ * URL field
+ * @type {typeof URLSimpleTextBase}
+ */
+const URLSimpleText = asMetaField(muiThemeable()(URLSimpleTextBase));
+export { URLSimpleText }
 
 /**
  * @param {{


### PR DESCRIPTION
This commit introduces a context-aware URL display system that selects different rendering components based on the parent context. It extracts URL formatting logic into a shared utility function.

Detailed Changes:
 - Implementation:
   - Added getURLDisplayByContext function to return URLField or URLSimpleText based on context.
   - Created URLSimpleText component for plain text display in search contexts.
   - Extracted URL formatting logic into reusable formatURL function.
   - Changed Renderer.renderURL to accept context parameter and use getURLDisplayByContext.
 - Documentation:
   - Updated JSDoc comments for new functions and components.

### Demo

https://github.com/user-attachments/assets/ff940c49-1415-4c4f-a095-8777322995af


