### PR TITLE
feat(meta): use json-schema required to display required fields

### DIFF
--- a/frontend/assets/__mocks__/cells-sdk.js
+++ b/frontend/assets/__mocks__/cells-sdk.js
@@ -1,0 +1,9 @@
+export const UserMetaServiceApi = function () {};
+export const IdmUpdateUserMetaRequest = function () {};
+export const RestPutUserMetaTagRequest = {
+    constructFromObject: () => ({}),
+};
+export const IdmUserMeta = function () {};
+export const ServiceResourcePolicy = {
+    constructFromObject: () => ({}),
+};

--- a/frontend/assets/__mocks__/pydio-http-api.js
+++ b/frontend/assets/__mocks__/pydio-http-api.js
@@ -1,0 +1,5 @@
+const api = {
+	getRestClient: () => ({}),
+};
+
+export default api;

--- a/frontend/assets/meta.user/res/js/MetaClient.js
+++ b/frontend/assets/meta.user/res/js/MetaClient.js
@@ -21,8 +21,6 @@ import PydioApi from 'pydio/http/api'
 
 import {UserMetaServiceApi, IdmUpdateUserMetaRequest, RestPutUserMetaTagRequest, IdmUserMeta, ServiceResourcePolicy} from 'cells-sdk'
 
-import mockUserMeta from './__fixtures__/usermeta-url.json'
-
 class MetaClient{
 
     static getInstance() {
@@ -100,14 +98,15 @@ class MetaClient{
         nss.map(ns => {
             const name = ns.Namespace;
 
+            const { JsonSchema = {} } = ns;
             let base = {
                 label: ns.Label,
                 indexable: ns.Indexable,
                 order: ns.Order,
                 visible: true,
                 readonly: !ns.PoliciesContextEditable,
-                jsonSchema: ns.JsonSchema,
-                required: ns.PromptOnUpload // FIXME: use ns.required.length > 0  and test
+                jsonSchema: JsonSchema,
+                required: JsonSchema.required && JsonSchema.required.length > 0
             };
             if (ns.JsonDefinition){
                 const jDef = JSON.parse(ns.JsonDefinition);

--- a/frontend/assets/meta.user/res/js/MetaClient.spec.js
+++ b/frontend/assets/meta.user/res/js/MetaClient.spec.js
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock external dependencies that are not available in the test env
+vi.mock('pydio/http/api', () => ({ default: { getRestClient: vi.fn() } }));
+vi.mock('cells-sdk', () => ({
+    UserMetaServiceApi: vi.fn(),
+    IdmUpdateUserMetaRequest: vi.fn(),
+    RestPutUserMetaTagRequest: { constructFromObject: vi.fn() },
+    IdmUserMeta: vi.fn(),
+    ServiceResourcePolicy: { constructFromObject: vi.fn() },
+}));
+
+import MetaClient from './MetaClient';
+
+const buildClient = () => Object.create(MetaClient.prototype);
+
+describe('MetaClient.namespacesAsPanelConfig', () => {
+    it('builds base config and sorts by order', () => {
+        const namespaces = [
+            {
+                Namespace: 'second',
+                Label: 'Second',
+                Indexable: true,
+                Order: 2,
+                PoliciesContextEditable: false,
+                JsonSchema: { required: ['field'] },
+            },
+            {
+                Namespace: 'first',
+                Label: 'First',
+                Indexable: false,
+                Order: 1,
+                PoliciesContextEditable: true,
+                JsonSchema: {},
+            },
+        ];
+
+        const configs = buildClient().namespacesAsPanelConfig(namespaces);
+        const entries = Array.from(configs.entries());
+
+        expect(entries.map(([ns]) => ns)).toEqual(['first', 'second']);
+        expect(entries[0][1]).toMatchObject({
+            label: 'First',
+            indexable: false,
+            order: 1,
+            visible: true,
+            readonly: false,
+            required: undefined,
+        });
+        expect(entries[1][1]).toMatchObject({
+            label: 'Second',
+            indexable: true,
+            order: 2,
+            visible: true,
+            readonly: true,
+            required: true,
+        });
+    });
+
+    it('merges JsonDefinition overrides and honors hide flag', () => {
+        const namespaces = [
+            {
+                Namespace: 'with-def',
+                Label: 'With Def',
+                Indexable: false,
+                Order: 0,
+                PoliciesContextEditable: true,
+                JsonSchema: {},
+                JsonDefinition: JSON.stringify({
+                    hide: true,
+                    type: 'text',
+                    placeholder: 'Enter value',
+                }),
+            },
+        ];
+
+        const cfg = buildClient().namespacesAsPanelConfig(namespaces).get('with-def');
+
+        expect(cfg.visible).toBe(false);
+        expect(cfg.type).toBe('text');
+        expect(cfg.placeholder).toBe('Enter value');
+    });
+
+    it('converts legacy choice data strings into items', () => {
+        const namespaces = [
+            {
+                Namespace: 'choices',
+                Label: 'Choices',
+                Indexable: false,
+                Order: 0,
+                PoliciesContextEditable: true,
+                JsonSchema: {},
+                JsonDefinition: JSON.stringify({
+                    type: 'choice',
+                    data: 'red|Red,blue|Blue',
+                }),
+            },
+        ];
+
+        const cfg = buildClient().namespacesAsPanelConfig(namespaces).get('choices');
+
+        expect(cfg.type).toBe('choice');
+        expect(cfg.data).toEqual({
+            items: [
+                { key: 'red', value: 'Red' },
+                { key: 'blue', value: 'Blue' },
+            ],
+        });
+    });
+});

--- a/frontend/assets/vitest.config.js
+++ b/frontend/assets/vitest.config.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// Custom plugin to handle pydio/http/api imports
 export default defineConfig({
 	plugins: [
 		react({
@@ -16,13 +17,13 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			'@mocks': path.resolve(__dirname, '__mocks__'),
-
-			// Provide a lightweight stub for the legacy global Pydio module in tests.
+			'pydio/http/api': path.resolve(__dirname, '__mocks__/pydio-http-api.js'),
 			pydio: path.resolve(__dirname, '__mocks__/pydio.js'),
 			'material-ui/styles': path.resolve(__dirname, '__mocks__/material-ui-styles.js'),
 			'material-ui': path.resolve(__dirname, '__mocks__/material-ui.js'),
 			'../hoc/asMetaField': path.resolve(__dirname, '__mocks__/hoc.js'),
 			'../hoc/asMetaForm': path.resolve(__dirname, '__mocks__/hoc.js'),
+			'cells-sdk': path.resolve(__dirname, '__mocks__/cells-sdk.js'),
 		},
 	},
 	test: {
@@ -30,6 +31,9 @@ export default defineConfig({
 		environment: 'jsdom',
 		// Discover both .js and .jsx test files under the repo.
 		include: ['**/*.{test,spec}.{js,jsx}'],
+		deps: {
+			inline: ['pydio/http/api', 'cells-sdk'],
+		},
     // Provide a custom vitest setup file.
 		setupFiles: ['./vitest-setup.js'],
 	},


### PR DESCRIPTION
This commit adds unit tests for the MetaClient's namespacesAsPanelConfig method and sets up mocking for external dependencies.

Detailed Changes:
 - Implementation:
   - Changed MetaClient to use JsonSchema.required for required field detection instead of PromptOnUpload.
 - Tests:
   - Added MetaClient.spec.js with tests for config building, JsonDefinition merging, and legacy choice data conversion.
   - Added __mocks__/cells-sdk.js and __mocks__/pydio-http-api.js to mock external dependencies.
   - Updated vitest.config.js to alias 'cells-sdk' and 'pydio/http/api' to mocks and inline them for tests.
