### PR TITLE
feat(namespace): Entity values integration

### DIFF
--- a/common/proto/idm/cells-idm.pb.go
+++ b/common/proto/idm/cells-idm.pb.go
@@ -329,7 +329,7 @@ func (x UpdateUserMetaRequest_UserMetaOp) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use UpdateUserMetaRequest_UserMetaOp.Descriptor instead.
 func (UpdateUserMetaRequest_UserMetaOp) EnumDescriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{46, 0}
+	return file_cells_idm_proto_rawDescGZIP(), []int{53, 0}
 }
 
 type UpdateUserMetaEvent_UserMetaOp int32
@@ -375,7 +375,7 @@ func (x UpdateUserMetaEvent_UserMetaOp) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use UpdateUserMetaEvent_UserMetaOp.Descriptor instead.
 func (UpdateUserMetaEvent_UserMetaOp) EnumDescriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{48, 0}
+	return file_cells_idm_proto_rawDescGZIP(), []int{55, 0}
 }
 
 type UpdateUserMetaNamespaceRequest_UserMetaNsOp int32
@@ -421,7 +421,7 @@ func (x UpdateUserMetaNamespaceRequest_UserMetaNsOp) Number() protoreflect.EnumN
 
 // Deprecated: Use UpdateUserMetaNamespaceRequest_UserMetaNsOp.Descriptor instead.
 func (UpdateUserMetaNamespaceRequest_UserMetaNsOp) EnumDescriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{51, 0}
+	return file_cells_idm_proto_rawDescGZIP(), []int{58, 0}
 }
 
 // *****************************************************************************
@@ -3014,6 +3014,314 @@ func (x *ACLSingleQuery) GetNot() bool {
 	return false
 }
 
+type CreateEntityValueRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EntityValue   []*EntityValue         `protobuf:"bytes,1,rep,name=EntityValue,proto3" json:"EntityValue,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateEntityValueRequest) Reset() {
+	*x = CreateEntityValueRequest{}
+	mi := &file_cells_idm_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateEntityValueRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateEntityValueRequest) ProtoMessage() {}
+
+func (x *CreateEntityValueRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateEntityValueRequest.ProtoReflect.Descriptor instead.
+func (*CreateEntityValueRequest) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *CreateEntityValueRequest) GetEntityValue() []*EntityValue {
+	if x != nil {
+		return x.EntityValue
+	}
+	return nil
+}
+
+type CreateEntityValueResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EntityValue   []*EntityValue         `protobuf:"bytes,1,rep,name=EntityValue,proto3" json:"EntityValue,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateEntityValueResponse) Reset() {
+	*x = CreateEntityValueResponse{}
+	mi := &file_cells_idm_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateEntityValueResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateEntityValueResponse) ProtoMessage() {}
+
+func (x *CreateEntityValueResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateEntityValueResponse.ProtoReflect.Descriptor instead.
+func (*CreateEntityValueResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *CreateEntityValueResponse) GetEntityValue() []*EntityValue {
+	if x != nil {
+		return x.EntityValue
+	}
+	return nil
+}
+
+type CreateEntityRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entity        *MetaEntity            `protobuf:"bytes,1,opt,name=Entity,proto3" json:"Entity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateEntityRequest) Reset() {
+	*x = CreateEntityRequest{}
+	mi := &file_cells_idm_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateEntityRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateEntityRequest) ProtoMessage() {}
+
+func (x *CreateEntityRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateEntityRequest.ProtoReflect.Descriptor instead.
+func (*CreateEntityRequest) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *CreateEntityRequest) GetEntity() *MetaEntity {
+	if x != nil {
+		return x.Entity
+	}
+	return nil
+}
+
+type CreateEntityResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entity        *MetaEntity            `protobuf:"bytes,1,opt,name=Entity,proto3" json:"Entity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateEntityResponse) Reset() {
+	*x = CreateEntityResponse{}
+	mi := &file_cells_idm_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateEntityResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateEntityResponse) ProtoMessage() {}
+
+func (x *CreateEntityResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateEntityResponse.ProtoReflect.Descriptor instead.
+func (*CreateEntityResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *CreateEntityResponse) GetEntity() *MetaEntity {
+	if x != nil {
+		return x.Entity
+	}
+	return nil
+}
+
+type DeleteEntityValuesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RowsDeleted   int64                  `protobuf:"varint,1,opt,name=RowsDeleted,proto3" json:"RowsDeleted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteEntityValuesResponse) Reset() {
+	*x = DeleteEntityValuesResponse{}
+	mi := &file_cells_idm_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteEntityValuesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteEntityValuesResponse) ProtoMessage() {}
+
+func (x *DeleteEntityValuesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteEntityValuesResponse.ProtoReflect.Descriptor instead.
+func (*DeleteEntityValuesResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *DeleteEntityValuesResponse) GetRowsDeleted() int64 {
+	if x != nil {
+		return x.RowsDeleted
+	}
+	return 0
+}
+
+type GetMetaEntityValuesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EntityUuid    string                 `protobuf:"bytes,1,opt,name=EntityUuid,proto3" json:"EntityUuid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMetaEntityValuesRequest) Reset() {
+	*x = GetMetaEntityValuesRequest{}
+	mi := &file_cells_idm_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMetaEntityValuesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMetaEntityValuesRequest) ProtoMessage() {}
+
+func (x *GetMetaEntityValuesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMetaEntityValuesRequest.ProtoReflect.Descriptor instead.
+func (*GetMetaEntityValuesRequest) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *GetMetaEntityValuesRequest) GetEntityUuid() string {
+	if x != nil {
+		return x.EntityUuid
+	}
+	return ""
+}
+
+type MetaEntityValueResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EntityValue   []*EntityValue         `protobuf:"bytes,1,rep,name=EntityValue,proto3" json:"EntityValue,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MetaEntityValueResponse) Reset() {
+	*x = MetaEntityValueResponse{}
+	mi := &file_cells_idm_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MetaEntityValueResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MetaEntityValueResponse) ProtoMessage() {}
+
+func (x *MetaEntityValueResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MetaEntityValueResponse.ProtoReflect.Descriptor instead.
+func (*MetaEntityValueResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{48}
+}
+
+func (x *MetaEntityValueResponse) GetEntityValue() []*EntityValue {
+	if x != nil {
+		return x.EntityValue
+	}
+	return nil
+}
+
 // Piece of metadata attached to a node
 type UserMeta struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -3037,7 +3345,7 @@ type UserMeta struct {
 
 func (x *UserMeta) Reset() {
 	*x = UserMeta{}
-	mi := &file_cells_idm_proto_msgTypes[42]
+	mi := &file_cells_idm_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3049,7 +3357,7 @@ func (x *UserMeta) String() string {
 func (*UserMeta) ProtoMessage() {}
 
 func (x *UserMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[42]
+	mi := &file_cells_idm_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3062,7 +3370,7 @@ func (x *UserMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserMeta.ProtoReflect.Descriptor instead.
 func (*UserMeta) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{42}
+	return file_cells_idm_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *UserMeta) GetUuid() string {
@@ -3147,7 +3455,7 @@ type UserMetaNamespace struct {
 
 func (x *UserMetaNamespace) Reset() {
 	*x = UserMetaNamespace{}
-	mi := &file_cells_idm_proto_msgTypes[43]
+	mi := &file_cells_idm_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3159,7 +3467,7 @@ func (x *UserMetaNamespace) String() string {
 func (*UserMetaNamespace) ProtoMessage() {}
 
 func (x *UserMetaNamespace) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[43]
+	mi := &file_cells_idm_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3172,7 +3480,7 @@ func (x *UserMetaNamespace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserMetaNamespace.ProtoReflect.Descriptor instead.
 func (*UserMetaNamespace) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{43}
+	return file_cells_idm_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *UserMetaNamespace) GetNamespace() string {
@@ -3271,7 +3579,7 @@ type MetaEntity struct {
 
 func (x *MetaEntity) Reset() {
 	*x = MetaEntity{}
-	mi := &file_cells_idm_proto_msgTypes[44]
+	mi := &file_cells_idm_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3283,7 +3591,7 @@ func (x *MetaEntity) String() string {
 func (*MetaEntity) ProtoMessage() {}
 
 func (x *MetaEntity) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[44]
+	mi := &file_cells_idm_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3296,7 +3604,7 @@ func (x *MetaEntity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetaEntity.ProtoReflect.Descriptor instead.
 func (*MetaEntity) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{44}
+	return file_cells_idm_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *MetaEntity) GetUuid() string {
@@ -3332,7 +3640,7 @@ type EntityValue struct {
 
 func (x *EntityValue) Reset() {
 	*x = EntityValue{}
-	mi := &file_cells_idm_proto_msgTypes[45]
+	mi := &file_cells_idm_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3344,7 +3652,7 @@ func (x *EntityValue) String() string {
 func (*EntityValue) ProtoMessage() {}
 
 func (x *EntityValue) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[45]
+	mi := &file_cells_idm_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3357,7 +3665,7 @@ func (x *EntityValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EntityValue.ProtoReflect.Descriptor instead.
 func (*EntityValue) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{45}
+	return file_cells_idm_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *EntityValue) GetUuid() string {
@@ -3394,7 +3702,7 @@ type UpdateUserMetaRequest struct {
 
 func (x *UpdateUserMetaRequest) Reset() {
 	*x = UpdateUserMetaRequest{}
-	mi := &file_cells_idm_proto_msgTypes[46]
+	mi := &file_cells_idm_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3406,7 +3714,7 @@ func (x *UpdateUserMetaRequest) String() string {
 func (*UpdateUserMetaRequest) ProtoMessage() {}
 
 func (x *UpdateUserMetaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[46]
+	mi := &file_cells_idm_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3419,7 +3727,7 @@ func (x *UpdateUserMetaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaRequest.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{46}
+	return file_cells_idm_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *UpdateUserMetaRequest) GetOperation() UpdateUserMetaRequest_UserMetaOp {
@@ -3447,7 +3755,7 @@ type UpdateUserMetaResponse struct {
 
 func (x *UpdateUserMetaResponse) Reset() {
 	*x = UpdateUserMetaResponse{}
-	mi := &file_cells_idm_proto_msgTypes[47]
+	mi := &file_cells_idm_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3459,7 +3767,7 @@ func (x *UpdateUserMetaResponse) String() string {
 func (*UpdateUserMetaResponse) ProtoMessage() {}
 
 func (x *UpdateUserMetaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[47]
+	mi := &file_cells_idm_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3472,7 +3780,7 @@ func (x *UpdateUserMetaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaResponse.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{47}
+	return file_cells_idm_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *UpdateUserMetaResponse) GetMetaDatas() []*UserMeta {
@@ -3497,7 +3805,7 @@ type UpdateUserMetaEvent struct {
 
 func (x *UpdateUserMetaEvent) Reset() {
 	*x = UpdateUserMetaEvent{}
-	mi := &file_cells_idm_proto_msgTypes[48]
+	mi := &file_cells_idm_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3509,7 +3817,7 @@ func (x *UpdateUserMetaEvent) String() string {
 func (*UpdateUserMetaEvent) ProtoMessage() {}
 
 func (x *UpdateUserMetaEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[48]
+	mi := &file_cells_idm_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3522,7 +3830,7 @@ func (x *UpdateUserMetaEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaEvent.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaEvent) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{48}
+	return file_cells_idm_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *UpdateUserMetaEvent) GetEventMetadata() map[string]string {
@@ -3565,7 +3873,7 @@ type SearchUserMetaRequest struct {
 
 func (x *SearchUserMetaRequest) Reset() {
 	*x = SearchUserMetaRequest{}
-	mi := &file_cells_idm_proto_msgTypes[49]
+	mi := &file_cells_idm_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3577,7 +3885,7 @@ func (x *SearchUserMetaRequest) String() string {
 func (*SearchUserMetaRequest) ProtoMessage() {}
 
 func (x *SearchUserMetaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[49]
+	mi := &file_cells_idm_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3590,7 +3898,7 @@ func (x *SearchUserMetaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchUserMetaRequest.ProtoReflect.Descriptor instead.
 func (*SearchUserMetaRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{49}
+	return file_cells_idm_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *SearchUserMetaRequest) GetMetaUuids() []string {
@@ -3638,7 +3946,7 @@ type SearchUserMetaResponse struct {
 
 func (x *SearchUserMetaResponse) Reset() {
 	*x = SearchUserMetaResponse{}
-	mi := &file_cells_idm_proto_msgTypes[50]
+	mi := &file_cells_idm_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3650,7 +3958,7 @@ func (x *SearchUserMetaResponse) String() string {
 func (*SearchUserMetaResponse) ProtoMessage() {}
 
 func (x *SearchUserMetaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[50]
+	mi := &file_cells_idm_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3663,7 +3971,7 @@ func (x *SearchUserMetaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchUserMetaResponse.ProtoReflect.Descriptor instead.
 func (*SearchUserMetaResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{50}
+	return file_cells_idm_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *SearchUserMetaResponse) GetUserMeta() *UserMeta {
@@ -3684,7 +3992,7 @@ type UpdateUserMetaNamespaceRequest struct {
 
 func (x *UpdateUserMetaNamespaceRequest) Reset() {
 	*x = UpdateUserMetaNamespaceRequest{}
-	mi := &file_cells_idm_proto_msgTypes[51]
+	mi := &file_cells_idm_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3696,7 +4004,7 @@ func (x *UpdateUserMetaNamespaceRequest) String() string {
 func (*UpdateUserMetaNamespaceRequest) ProtoMessage() {}
 
 func (x *UpdateUserMetaNamespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[51]
+	mi := &file_cells_idm_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3709,7 +4017,7 @@ func (x *UpdateUserMetaNamespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaNamespaceRequest.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaNamespaceRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{51}
+	return file_cells_idm_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *UpdateUserMetaNamespaceRequest) GetOperation() UpdateUserMetaNamespaceRequest_UserMetaNsOp {
@@ -3736,7 +4044,7 @@ type UpdateUserMetaNamespaceResponse struct {
 
 func (x *UpdateUserMetaNamespaceResponse) Reset() {
 	*x = UpdateUserMetaNamespaceResponse{}
-	mi := &file_cells_idm_proto_msgTypes[52]
+	mi := &file_cells_idm_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3748,7 +4056,7 @@ func (x *UpdateUserMetaNamespaceResponse) String() string {
 func (*UpdateUserMetaNamespaceResponse) ProtoMessage() {}
 
 func (x *UpdateUserMetaNamespaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[52]
+	mi := &file_cells_idm_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3761,7 +4069,7 @@ func (x *UpdateUserMetaNamespaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaNamespaceResponse.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaNamespaceResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{52}
+	return file_cells_idm_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *UpdateUserMetaNamespaceResponse) GetNamespaces() []*UserMetaNamespace {
@@ -3780,7 +4088,7 @@ type ListUserMetaNamespaceRequest struct {
 
 func (x *ListUserMetaNamespaceRequest) Reset() {
 	*x = ListUserMetaNamespaceRequest{}
-	mi := &file_cells_idm_proto_msgTypes[53]
+	mi := &file_cells_idm_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3792,7 +4100,7 @@ func (x *ListUserMetaNamespaceRequest) String() string {
 func (*ListUserMetaNamespaceRequest) ProtoMessage() {}
 
 func (x *ListUserMetaNamespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[53]
+	mi := &file_cells_idm_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3805,7 +4113,7 @@ func (x *ListUserMetaNamespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUserMetaNamespaceRequest.ProtoReflect.Descriptor instead.
 func (*ListUserMetaNamespaceRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{53}
+	return file_cells_idm_proto_rawDescGZIP(), []int{60}
 }
 
 // Collection of results
@@ -3818,7 +4126,7 @@ type ListUserMetaNamespaceResponse struct {
 
 func (x *ListUserMetaNamespaceResponse) Reset() {
 	*x = ListUserMetaNamespaceResponse{}
-	mi := &file_cells_idm_proto_msgTypes[54]
+	mi := &file_cells_idm_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3830,7 +4138,7 @@ func (x *ListUserMetaNamespaceResponse) String() string {
 func (*ListUserMetaNamespaceResponse) ProtoMessage() {}
 
 func (x *ListUserMetaNamespaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[54]
+	mi := &file_cells_idm_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3843,7 +4151,7 @@ func (x *ListUserMetaNamespaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUserMetaNamespaceResponse.ProtoReflect.Descriptor instead.
 func (*ListUserMetaNamespaceResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{54}
+	return file_cells_idm_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *ListUserMetaNamespaceResponse) GetUserMetaNamespace() *UserMetaNamespace {
@@ -3862,7 +4170,7 @@ type GetFieldSchemaRequest struct {
 
 func (x *GetFieldSchemaRequest) Reset() {
 	*x = GetFieldSchemaRequest{}
-	mi := &file_cells_idm_proto_msgTypes[55]
+	mi := &file_cells_idm_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3874,7 +4182,7 @@ func (x *GetFieldSchemaRequest) String() string {
 func (*GetFieldSchemaRequest) ProtoMessage() {}
 
 func (x *GetFieldSchemaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[55]
+	mi := &file_cells_idm_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3887,7 +4195,7 @@ func (x *GetFieldSchemaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFieldSchemaRequest.ProtoReflect.Descriptor instead.
 func (*GetFieldSchemaRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{55}
+	return file_cells_idm_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *GetFieldSchemaRequest) GetFieldType() string {
@@ -3906,7 +4214,7 @@ type JsonSchemaResponse struct {
 
 func (x *JsonSchemaResponse) Reset() {
 	*x = JsonSchemaResponse{}
-	mi := &file_cells_idm_proto_msgTypes[56]
+	mi := &file_cells_idm_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3918,7 +4226,7 @@ func (x *JsonSchemaResponse) String() string {
 func (*JsonSchemaResponse) ProtoMessage() {}
 
 func (x *JsonSchemaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[56]
+	mi := &file_cells_idm_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3931,7 +4239,7 @@ func (x *JsonSchemaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JsonSchemaResponse.ProtoReflect.Descriptor instead.
 func (*JsonSchemaResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{56}
+	return file_cells_idm_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *JsonSchemaResponse) GetJsonSchema() *structpb.Struct {
@@ -3952,7 +4260,7 @@ type GetNamespaceSchemaRequest struct {
 
 func (x *GetNamespaceSchemaRequest) Reset() {
 	*x = GetNamespaceSchemaRequest{}
-	mi := &file_cells_idm_proto_msgTypes[57]
+	mi := &file_cells_idm_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3964,7 +4272,7 @@ func (x *GetNamespaceSchemaRequest) String() string {
 func (*GetNamespaceSchemaRequest) ProtoMessage() {}
 
 func (x *GetNamespaceSchemaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[57]
+	mi := &file_cells_idm_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3977,7 +4285,7 @@ func (x *GetNamespaceSchemaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNamespaceSchemaRequest.ProtoReflect.Descriptor instead.
 func (*GetNamespaceSchemaRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{57}
+	return file_cells_idm_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *GetNamespaceSchemaRequest) GetFieldType() string {
@@ -4018,7 +4326,7 @@ type ChangeEvent struct {
 
 func (x *ChangeEvent) Reset() {
 	*x = ChangeEvent{}
-	mi := &file_cells_idm_proto_msgTypes[58]
+	mi := &file_cells_idm_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4030,7 +4338,7 @@ func (x *ChangeEvent) String() string {
 func (*ChangeEvent) ProtoMessage() {}
 
 func (x *ChangeEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[58]
+	mi := &file_cells_idm_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4043,7 +4351,7 @@ func (x *ChangeEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeEvent.ProtoReflect.Descriptor instead.
 func (*ChangeEvent) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{58}
+	return file_cells_idm_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ChangeEvent) GetJsonType() string {
@@ -4117,7 +4425,7 @@ type PolicyEngineRequest struct {
 
 func (x *PolicyEngineRequest) Reset() {
 	*x = PolicyEngineRequest{}
-	mi := &file_cells_idm_proto_msgTypes[59]
+	mi := &file_cells_idm_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4129,7 +4437,7 @@ func (x *PolicyEngineRequest) String() string {
 func (*PolicyEngineRequest) ProtoMessage() {}
 
 func (x *PolicyEngineRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[59]
+	mi := &file_cells_idm_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4142,7 +4450,7 @@ func (x *PolicyEngineRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyEngineRequest.ProtoReflect.Descriptor instead.
 func (*PolicyEngineRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{59}
+	return file_cells_idm_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *PolicyEngineRequest) GetResource() string {
@@ -4184,7 +4492,7 @@ type PolicyEngineResponse struct {
 
 func (x *PolicyEngineResponse) Reset() {
 	*x = PolicyEngineResponse{}
-	mi := &file_cells_idm_proto_msgTypes[60]
+	mi := &file_cells_idm_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4196,7 +4504,7 @@ func (x *PolicyEngineResponse) String() string {
 func (*PolicyEngineResponse) ProtoMessage() {}
 
 func (x *PolicyEngineResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[60]
+	mi := &file_cells_idm_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4209,7 +4517,7 @@ func (x *PolicyEngineResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyEngineResponse.ProtoReflect.Descriptor instead.
 func (*PolicyEngineResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{60}
+	return file_cells_idm_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *PolicyEngineResponse) GetAllowed() bool {
@@ -4243,7 +4551,7 @@ type PolicyCondition struct {
 
 func (x *PolicyCondition) Reset() {
 	*x = PolicyCondition{}
-	mi := &file_cells_idm_proto_msgTypes[61]
+	mi := &file_cells_idm_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4255,7 +4563,7 @@ func (x *PolicyCondition) String() string {
 func (*PolicyCondition) ProtoMessage() {}
 
 func (x *PolicyCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[61]
+	mi := &file_cells_idm_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4268,7 +4576,7 @@ func (x *PolicyCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyCondition.ProtoReflect.Descriptor instead.
 func (*PolicyCondition) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{61}
+	return file_cells_idm_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *PolicyCondition) GetType() string {
@@ -4303,7 +4611,7 @@ type Policy struct {
 
 func (x *Policy) Reset() {
 	*x = Policy{}
-	mi := &file_cells_idm_proto_msgTypes[62]
+	mi := &file_cells_idm_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4315,7 +4623,7 @@ func (x *Policy) String() string {
 func (*Policy) ProtoMessage() {}
 
 func (x *Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[62]
+	mi := &file_cells_idm_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4328,7 +4636,7 @@ func (x *Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy.ProtoReflect.Descriptor instead.
 func (*Policy) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{62}
+	return file_cells_idm_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *Policy) GetID() string {
@@ -4413,7 +4721,7 @@ type PolicySubject struct {
 
 func (x *PolicySubject) Reset() {
 	*x = PolicySubject{}
-	mi := &file_cells_idm_proto_msgTypes[63]
+	mi := &file_cells_idm_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4425,7 +4733,7 @@ func (x *PolicySubject) String() string {
 func (*PolicySubject) ProtoMessage() {}
 
 func (x *PolicySubject) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[63]
+	mi := &file_cells_idm_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4438,7 +4746,7 @@ func (x *PolicySubject) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySubject.ProtoReflect.Descriptor instead.
 func (*PolicySubject) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{63}
+	return file_cells_idm_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *PolicySubject) GetID() string {
@@ -4481,7 +4789,7 @@ type PolicyResource struct {
 
 func (x *PolicyResource) Reset() {
 	*x = PolicyResource{}
-	mi := &file_cells_idm_proto_msgTypes[64]
+	mi := &file_cells_idm_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4493,7 +4801,7 @@ func (x *PolicyResource) String() string {
 func (*PolicyResource) ProtoMessage() {}
 
 func (x *PolicyResource) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[64]
+	mi := &file_cells_idm_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4506,7 +4814,7 @@ func (x *PolicyResource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyResource.ProtoReflect.Descriptor instead.
 func (*PolicyResource) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{64}
+	return file_cells_idm_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *PolicyResource) GetID() string {
@@ -4549,7 +4857,7 @@ type PolicyAction struct {
 
 func (x *PolicyAction) Reset() {
 	*x = PolicyAction{}
-	mi := &file_cells_idm_proto_msgTypes[65]
+	mi := &file_cells_idm_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4561,7 +4869,7 @@ func (x *PolicyAction) String() string {
 func (*PolicyAction) ProtoMessage() {}
 
 func (x *PolicyAction) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[65]
+	mi := &file_cells_idm_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4574,7 +4882,7 @@ func (x *PolicyAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyAction.ProtoReflect.Descriptor instead.
 func (*PolicyAction) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{65}
+	return file_cells_idm_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *PolicyAction) GetID() string {
@@ -4615,7 +4923,7 @@ type PolicyResourceRel struct {
 
 func (x *PolicyResourceRel) Reset() {
 	*x = PolicyResourceRel{}
-	mi := &file_cells_idm_proto_msgTypes[66]
+	mi := &file_cells_idm_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4627,7 +4935,7 @@ func (x *PolicyResourceRel) String() string {
 func (*PolicyResourceRel) ProtoMessage() {}
 
 func (x *PolicyResourceRel) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[66]
+	mi := &file_cells_idm_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4640,7 +4948,7 @@ func (x *PolicyResourceRel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyResourceRel.ProtoReflect.Descriptor instead.
 func (*PolicyResourceRel) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{66}
+	return file_cells_idm_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *PolicyResourceRel) GetPolicy() string {
@@ -4667,7 +4975,7 @@ type PolicySubjectRel struct {
 
 func (x *PolicySubjectRel) Reset() {
 	*x = PolicySubjectRel{}
-	mi := &file_cells_idm_proto_msgTypes[67]
+	mi := &file_cells_idm_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4679,7 +4987,7 @@ func (x *PolicySubjectRel) String() string {
 func (*PolicySubjectRel) ProtoMessage() {}
 
 func (x *PolicySubjectRel) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[67]
+	mi := &file_cells_idm_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4692,7 +5000,7 @@ func (x *PolicySubjectRel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySubjectRel.ProtoReflect.Descriptor instead.
 func (*PolicySubjectRel) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{67}
+	return file_cells_idm_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *PolicySubjectRel) GetPolicy() string {
@@ -4719,7 +5027,7 @@ type PolicyActionRel struct {
 
 func (x *PolicyActionRel) Reset() {
 	*x = PolicyActionRel{}
-	mi := &file_cells_idm_proto_msgTypes[68]
+	mi := &file_cells_idm_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4731,7 +5039,7 @@ func (x *PolicyActionRel) String() string {
 func (*PolicyActionRel) ProtoMessage() {}
 
 func (x *PolicyActionRel) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[68]
+	mi := &file_cells_idm_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4744,7 +5052,7 @@ func (x *PolicyActionRel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyActionRel.ProtoReflect.Descriptor instead.
 func (*PolicyActionRel) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{68}
+	return file_cells_idm_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *PolicyActionRel) GetPolicy() string {
@@ -4772,7 +5080,7 @@ type PolicyRel struct {
 
 func (x *PolicyRel) Reset() {
 	*x = PolicyRel{}
-	mi := &file_cells_idm_proto_msgTypes[69]
+	mi := &file_cells_idm_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4784,7 +5092,7 @@ func (x *PolicyRel) String() string {
 func (*PolicyRel) ProtoMessage() {}
 
 func (x *PolicyRel) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[69]
+	mi := &file_cells_idm_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4797,7 +5105,7 @@ func (x *PolicyRel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyRel.ProtoReflect.Descriptor instead.
 func (*PolicyRel) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{69}
+	return file_cells_idm_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *PolicyRel) GetID() int64 {
@@ -4836,7 +5144,7 @@ type PolicyGroup struct {
 
 func (x *PolicyGroup) Reset() {
 	*x = PolicyGroup{}
-	mi := &file_cells_idm_proto_msgTypes[70]
+	mi := &file_cells_idm_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4848,7 +5156,7 @@ func (x *PolicyGroup) String() string {
 func (*PolicyGroup) ProtoMessage() {}
 
 func (x *PolicyGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[70]
+	mi := &file_cells_idm_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4861,7 +5169,7 @@ func (x *PolicyGroup) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyGroup.ProtoReflect.Descriptor instead.
 func (*PolicyGroup) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{70}
+	return file_cells_idm_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *PolicyGroup) GetUuid() string {
@@ -4923,7 +5231,7 @@ type StorePolicyGroupRequest struct {
 
 func (x *StorePolicyGroupRequest) Reset() {
 	*x = StorePolicyGroupRequest{}
-	mi := &file_cells_idm_proto_msgTypes[71]
+	mi := &file_cells_idm_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4935,7 +5243,7 @@ func (x *StorePolicyGroupRequest) String() string {
 func (*StorePolicyGroupRequest) ProtoMessage() {}
 
 func (x *StorePolicyGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[71]
+	mi := &file_cells_idm_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4948,7 +5256,7 @@ func (x *StorePolicyGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorePolicyGroupRequest.ProtoReflect.Descriptor instead.
 func (*StorePolicyGroupRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{71}
+	return file_cells_idm_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *StorePolicyGroupRequest) GetPolicyGroup() *PolicyGroup {
@@ -4967,7 +5275,7 @@ type StorePolicyGroupResponse struct {
 
 func (x *StorePolicyGroupResponse) Reset() {
 	*x = StorePolicyGroupResponse{}
-	mi := &file_cells_idm_proto_msgTypes[72]
+	mi := &file_cells_idm_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4979,7 +5287,7 @@ func (x *StorePolicyGroupResponse) String() string {
 func (*StorePolicyGroupResponse) ProtoMessage() {}
 
 func (x *StorePolicyGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[72]
+	mi := &file_cells_idm_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4992,7 +5300,7 @@ func (x *StorePolicyGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorePolicyGroupResponse.ProtoReflect.Descriptor instead.
 func (*StorePolicyGroupResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{72}
+	return file_cells_idm_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *StorePolicyGroupResponse) GetPolicyGroup() *PolicyGroup {
@@ -5011,7 +5319,7 @@ type DeletePolicyGroupRequest struct {
 
 func (x *DeletePolicyGroupRequest) Reset() {
 	*x = DeletePolicyGroupRequest{}
-	mi := &file_cells_idm_proto_msgTypes[73]
+	mi := &file_cells_idm_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5023,7 +5331,7 @@ func (x *DeletePolicyGroupRequest) String() string {
 func (*DeletePolicyGroupRequest) ProtoMessage() {}
 
 func (x *DeletePolicyGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[73]
+	mi := &file_cells_idm_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5036,7 +5344,7 @@ func (x *DeletePolicyGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeletePolicyGroupRequest.ProtoReflect.Descriptor instead.
 func (*DeletePolicyGroupRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{73}
+	return file_cells_idm_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *DeletePolicyGroupRequest) GetPolicyGroup() *PolicyGroup {
@@ -5055,7 +5363,7 @@ type DeletePolicyGroupResponse struct {
 
 func (x *DeletePolicyGroupResponse) Reset() {
 	*x = DeletePolicyGroupResponse{}
-	mi := &file_cells_idm_proto_msgTypes[74]
+	mi := &file_cells_idm_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5067,7 +5375,7 @@ func (x *DeletePolicyGroupResponse) String() string {
 func (*DeletePolicyGroupResponse) ProtoMessage() {}
 
 func (x *DeletePolicyGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[74]
+	mi := &file_cells_idm_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5080,7 +5388,7 @@ func (x *DeletePolicyGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeletePolicyGroupResponse.ProtoReflect.Descriptor instead.
 func (*DeletePolicyGroupResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{74}
+	return file_cells_idm_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *DeletePolicyGroupResponse) GetSuccess() bool {
@@ -5102,7 +5410,7 @@ type ListPolicyGroupsRequest struct {
 
 func (x *ListPolicyGroupsRequest) Reset() {
 	*x = ListPolicyGroupsRequest{}
-	mi := &file_cells_idm_proto_msgTypes[75]
+	mi := &file_cells_idm_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5114,7 +5422,7 @@ func (x *ListPolicyGroupsRequest) String() string {
 func (*ListPolicyGroupsRequest) ProtoMessage() {}
 
 func (x *ListPolicyGroupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[75]
+	mi := &file_cells_idm_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5127,7 +5435,7 @@ func (x *ListPolicyGroupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPolicyGroupsRequest.ProtoReflect.Descriptor instead.
 func (*ListPolicyGroupsRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{75}
+	return file_cells_idm_proto_rawDescGZIP(), []int{82}
 }
 
 // Deprecated: Marked as deprecated in cells-idm.proto.
@@ -5155,7 +5463,7 @@ type ListPolicyGroupsResponse struct {
 
 func (x *ListPolicyGroupsResponse) Reset() {
 	*x = ListPolicyGroupsResponse{}
-	mi := &file_cells_idm_proto_msgTypes[76]
+	mi := &file_cells_idm_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5167,7 +5475,7 @@ func (x *ListPolicyGroupsResponse) String() string {
 func (*ListPolicyGroupsResponse) ProtoMessage() {}
 
 func (x *ListPolicyGroupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[76]
+	mi := &file_cells_idm_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5180,7 +5488,7 @@ func (x *ListPolicyGroupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPolicyGroupsResponse.ProtoReflect.Descriptor instead.
 func (*ListPolicyGroupsResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{76}
+	return file_cells_idm_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *ListPolicyGroupsResponse) GetPolicyGroups() []*PolicyGroup {
@@ -5216,7 +5524,7 @@ type PolicyGroupSingleQuery struct {
 
 func (x *PolicyGroupSingleQuery) Reset() {
 	*x = PolicyGroupSingleQuery{}
-	mi := &file_cells_idm_proto_msgTypes[77]
+	mi := &file_cells_idm_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5228,7 +5536,7 @@ func (x *PolicyGroupSingleQuery) String() string {
 func (*PolicyGroupSingleQuery) ProtoMessage() {}
 
 func (x *PolicyGroupSingleQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[77]
+	mi := &file_cells_idm_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5241,7 +5549,7 @@ func (x *PolicyGroupSingleQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyGroupSingleQuery.ProtoReflect.Descriptor instead.
 func (*PolicyGroupSingleQuery) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{77}
+	return file_cells_idm_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *PolicyGroupSingleQuery) GetResourceGroup() string {
@@ -5529,7 +5837,23 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\aRoleIDs\x18\x02 \x03(\tR\aRoleIDs\x12\"\n" +
 	"\fWorkspaceIDs\x18\x03 \x03(\tR\fWorkspaceIDs\x12\x18\n" +
 	"\aNodeIDs\x18\x04 \x03(\tR\aNodeIDs\x12\x10\n" +
-	"\x03not\x18\x05 \x01(\bR\x03not\"\x95\x02\n" +
+	"\x03not\x18\x05 \x01(\bR\x03not\"N\n" +
+	"\x18CreateEntityValueRequest\x122\n" +
+	"\vEntityValue\x18\x01 \x03(\v2\x10.idm.EntityValueR\vEntityValue\"O\n" +
+	"\x19CreateEntityValueResponse\x122\n" +
+	"\vEntityValue\x18\x01 \x03(\v2\x10.idm.EntityValueR\vEntityValue\">\n" +
+	"\x13CreateEntityRequest\x12'\n" +
+	"\x06Entity\x18\x01 \x01(\v2\x0f.idm.MetaEntityR\x06Entity\"?\n" +
+	"\x14CreateEntityResponse\x12'\n" +
+	"\x06Entity\x18\x01 \x01(\v2\x0f.idm.MetaEntityR\x06Entity\">\n" +
+	"\x1aDeleteEntityValuesResponse\x12 \n" +
+	"\vRowsDeleted\x18\x01 \x01(\x03R\vRowsDeleted\"<\n" +
+	"\x1aGetMetaEntityValuesRequest\x12\x1e\n" +
+	"\n" +
+	"EntityUuid\x18\x01 \x01(\tR\n" +
+	"EntityUuid\"M\n" +
+	"\x17MetaEntityValueResponse\x122\n" +
+	"\vEntityValue\x18\x01 \x03(\v2\x10.idm.EntityValueR\vEntityValue\"\x95\x02\n" +
 	"\bUserMeta\x12\x12\n" +
 	"\x04Uuid\x18\x01 \x01(\tR\x04Uuid\x12\x1a\n" +
 	"\bNodeUuid\x18\x02 \x01(\tR\bNodeUuid\x12\x1c\n" +
@@ -5869,14 +6193,18 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\tSearchACL\x12\x15.idm.SearchACLRequest\x1a\x16.idm.SearchACLResponse\"\x000\x01\x12@\n" +
 	"\tStreamACL\x12\x15.idm.SearchACLRequest\x1a\x16.idm.SearchACLResponse\"\x00(\x010\x01\x12?\n" +
 	"\n" +
-	"RestoreACL\x12\x16.idm.RestoreACLRequest\x1a\x17.idm.RestoreACLResponse\"\x002\x93\x04\n" +
+	"RestoreACL\x12\x16.idm.RestoreACLRequest\x1a\x17.idm.RestoreACLResponse\"\x002\xdf\x06\n" +
 	"\x0fUserMetaService\x12K\n" +
 	"\x0eUpdateUserMeta\x12\x1a.idm.UpdateUserMetaRequest\x1a\x1b.idm.UpdateUserMetaResponse\"\x00\x12M\n" +
 	"\x0eSearchUserMeta\x12\x1a.idm.SearchUserMetaRequest\x1a\x1b.idm.SearchUserMetaResponse\"\x000\x01\x12f\n" +
 	"\x17UpdateUserMetaNamespace\x12#.idm.UpdateUserMetaNamespaceRequest\x1a$.idm.UpdateUserMetaNamespaceResponse\"\x00\x12b\n" +
 	"\x15ListUserMetaNamespace\x12!.idm.ListUserMetaNamespaceRequest\x1a\".idm.ListUserMetaNamespaceResponse\"\x000\x01\x12G\n" +
 	"\x0eGetFieldSchema\x12\x1a.idm.GetFieldSchemaRequest\x1a\x17.idm.JsonSchemaResponse\"\x00\x12O\n" +
-	"\x12GetNamespaceSchema\x12\x1e.idm.GetNamespaceSchemaRequest\x1a\x17.idm.JsonSchemaResponse\"\x002\x9f\x03\n" +
+	"\x12GetNamespaceSchema\x12\x1e.idm.GetNamespaceSchemaRequest\x1a\x17.idm.JsonSchemaResponse\"\x00\x12R\n" +
+	"\x0fGetEntityValues\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1c.idm.MetaEntityValueResponse\"\x00\x12X\n" +
+	"\x12DeleteEntityValues\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1f.idm.DeleteEntityValuesResponse\"\x00\x12E\n" +
+	"\fCreateEntity\x12\x18.idm.CreateEntityRequest\x1a\x19.idm.CreateEntityResponse\"\x00\x12U\n" +
+	"\x12CreateEntityValues\x12\x1d.idm.CreateEntityValueRequest\x1a\x1e.idm.CreateEntityValueResponse\"\x002\x9f\x03\n" +
 	"\x13PolicyEngineService\x12B\n" +
 	"\tIsAllowed\x12\x18.idm.PolicyEngineRequest\x1a\x19.idm.PolicyEngineResponse\"\x00\x12Q\n" +
 	"\x10StorePolicyGroup\x12\x1c.idm.StorePolicyGroupRequest\x1a\x1d.idm.StorePolicyGroupResponse\"\x00\x12Q\n" +
@@ -5897,7 +6225,7 @@ func file_cells_idm_proto_rawDescGZIP() []byte {
 }
 
 var file_cells_idm_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_cells_idm_proto_msgTypes = make([]protoimpl.MessageInfo, 84)
+var file_cells_idm_proto_msgTypes = make([]protoimpl.MessageInfo, 91)
 var file_cells_idm_proto_goTypes = []any{
 	(NodeType)(0),                                    // 0: idm.NodeType
 	(WorkspaceScope)(0),                              // 1: idm.WorkspaceScope
@@ -5949,204 +6277,224 @@ var file_cells_idm_proto_goTypes = []any{
 	(*ACLAction)(nil),                                // 47: idm.ACLAction
 	(*ACL)(nil),                                      // 48: idm.ACL
 	(*ACLSingleQuery)(nil),                           // 49: idm.ACLSingleQuery
-	(*UserMeta)(nil),                                 // 50: idm.UserMeta
-	(*UserMetaNamespace)(nil),                        // 51: idm.UserMetaNamespace
-	(*MetaEntity)(nil),                               // 52: idm.MetaEntity
-	(*EntityValue)(nil),                              // 53: idm.EntityValue
-	(*UpdateUserMetaRequest)(nil),                    // 54: idm.UpdateUserMetaRequest
-	(*UpdateUserMetaResponse)(nil),                   // 55: idm.UpdateUserMetaResponse
-	(*UpdateUserMetaEvent)(nil),                      // 56: idm.UpdateUserMetaEvent
-	(*SearchUserMetaRequest)(nil),                    // 57: idm.SearchUserMetaRequest
-	(*SearchUserMetaResponse)(nil),                   // 58: idm.SearchUserMetaResponse
-	(*UpdateUserMetaNamespaceRequest)(nil),           // 59: idm.UpdateUserMetaNamespaceRequest
-	(*UpdateUserMetaNamespaceResponse)(nil),          // 60: idm.UpdateUserMetaNamespaceResponse
-	(*ListUserMetaNamespaceRequest)(nil),             // 61: idm.ListUserMetaNamespaceRequest
-	(*ListUserMetaNamespaceResponse)(nil),            // 62: idm.ListUserMetaNamespaceResponse
-	(*GetFieldSchemaRequest)(nil),                    // 63: idm.GetFieldSchemaRequest
-	(*JsonSchemaResponse)(nil),                       // 64: idm.JsonSchemaResponse
-	(*GetNamespaceSchemaRequest)(nil),                // 65: idm.GetNamespaceSchemaRequest
-	(*ChangeEvent)(nil),                              // 66: idm.ChangeEvent
-	(*PolicyEngineRequest)(nil),                      // 67: idm.PolicyEngineRequest
-	(*PolicyEngineResponse)(nil),                     // 68: idm.PolicyEngineResponse
-	(*PolicyCondition)(nil),                          // 69: idm.PolicyCondition
-	(*Policy)(nil),                                   // 70: idm.Policy
-	(*PolicySubject)(nil),                            // 71: idm.PolicySubject
-	(*PolicyResource)(nil),                           // 72: idm.PolicyResource
-	(*PolicyAction)(nil),                             // 73: idm.PolicyAction
-	(*PolicyResourceRel)(nil),                        // 74: idm.PolicyResourceRel
-	(*PolicySubjectRel)(nil),                         // 75: idm.PolicySubjectRel
-	(*PolicyActionRel)(nil),                          // 76: idm.PolicyActionRel
-	(*PolicyRel)(nil),                                // 77: idm.PolicyRel
-	(*PolicyGroup)(nil),                              // 78: idm.PolicyGroup
-	(*StorePolicyGroupRequest)(nil),                  // 79: idm.StorePolicyGroupRequest
-	(*StorePolicyGroupResponse)(nil),                 // 80: idm.StorePolicyGroupResponse
-	(*DeletePolicyGroupRequest)(nil),                 // 81: idm.DeletePolicyGroupRequest
-	(*DeletePolicyGroupResponse)(nil),                // 82: idm.DeletePolicyGroupResponse
-	(*ListPolicyGroupsRequest)(nil),                  // 83: idm.ListPolicyGroupsRequest
-	(*ListPolicyGroupsResponse)(nil),                 // 84: idm.ListPolicyGroupsResponse
-	(*PolicyGroupSingleQuery)(nil),                   // 85: idm.PolicyGroupSingleQuery
-	nil,                                              // 86: idm.User.AttributesEntry
-	nil,                                              // 87: idm.Workspace.RootNodesEntry
-	nil,                                              // 88: idm.UpdateUserMetaEvent.EventMetadataEntry
-	nil,                                              // 89: idm.ChangeEvent.AttributesEntry
-	nil,                                              // 90: idm.PolicyEngineRequest.ContextEntry
-	nil,                                              // 91: idm.Policy.ConditionsEntry
-	(*service.Query)(nil),                            // 92: service.Query
-	(*service.ResourcePolicy)(nil),                   // 93: service.ResourcePolicy
-	(*tree.TreeNode)(nil),                            // 94: tree.TreeNode
-	(*tree.Node)(nil),                                // 95: tree.Node
-	(*structpb.Struct)(nil),                          // 96: google.protobuf.Struct
-	(*service.ResourcePolicyQuery)(nil),              // 97: service.ResourcePolicyQuery
+	(*CreateEntityValueRequest)(nil),                 // 50: idm.CreateEntityValueRequest
+	(*CreateEntityValueResponse)(nil),                // 51: idm.CreateEntityValueResponse
+	(*CreateEntityRequest)(nil),                      // 52: idm.CreateEntityRequest
+	(*CreateEntityResponse)(nil),                     // 53: idm.CreateEntityResponse
+	(*DeleteEntityValuesResponse)(nil),               // 54: idm.DeleteEntityValuesResponse
+	(*GetMetaEntityValuesRequest)(nil),               // 55: idm.GetMetaEntityValuesRequest
+	(*MetaEntityValueResponse)(nil),                  // 56: idm.MetaEntityValueResponse
+	(*UserMeta)(nil),                                 // 57: idm.UserMeta
+	(*UserMetaNamespace)(nil),                        // 58: idm.UserMetaNamespace
+	(*MetaEntity)(nil),                               // 59: idm.MetaEntity
+	(*EntityValue)(nil),                              // 60: idm.EntityValue
+	(*UpdateUserMetaRequest)(nil),                    // 61: idm.UpdateUserMetaRequest
+	(*UpdateUserMetaResponse)(nil),                   // 62: idm.UpdateUserMetaResponse
+	(*UpdateUserMetaEvent)(nil),                      // 63: idm.UpdateUserMetaEvent
+	(*SearchUserMetaRequest)(nil),                    // 64: idm.SearchUserMetaRequest
+	(*SearchUserMetaResponse)(nil),                   // 65: idm.SearchUserMetaResponse
+	(*UpdateUserMetaNamespaceRequest)(nil),           // 66: idm.UpdateUserMetaNamespaceRequest
+	(*UpdateUserMetaNamespaceResponse)(nil),          // 67: idm.UpdateUserMetaNamespaceResponse
+	(*ListUserMetaNamespaceRequest)(nil),             // 68: idm.ListUserMetaNamespaceRequest
+	(*ListUserMetaNamespaceResponse)(nil),            // 69: idm.ListUserMetaNamespaceResponse
+	(*GetFieldSchemaRequest)(nil),                    // 70: idm.GetFieldSchemaRequest
+	(*JsonSchemaResponse)(nil),                       // 71: idm.JsonSchemaResponse
+	(*GetNamespaceSchemaRequest)(nil),                // 72: idm.GetNamespaceSchemaRequest
+	(*ChangeEvent)(nil),                              // 73: idm.ChangeEvent
+	(*PolicyEngineRequest)(nil),                      // 74: idm.PolicyEngineRequest
+	(*PolicyEngineResponse)(nil),                     // 75: idm.PolicyEngineResponse
+	(*PolicyCondition)(nil),                          // 76: idm.PolicyCondition
+	(*Policy)(nil),                                   // 77: idm.Policy
+	(*PolicySubject)(nil),                            // 78: idm.PolicySubject
+	(*PolicyResource)(nil),                           // 79: idm.PolicyResource
+	(*PolicyAction)(nil),                             // 80: idm.PolicyAction
+	(*PolicyResourceRel)(nil),                        // 81: idm.PolicyResourceRel
+	(*PolicySubjectRel)(nil),                         // 82: idm.PolicySubjectRel
+	(*PolicyActionRel)(nil),                          // 83: idm.PolicyActionRel
+	(*PolicyRel)(nil),                                // 84: idm.PolicyRel
+	(*PolicyGroup)(nil),                              // 85: idm.PolicyGroup
+	(*StorePolicyGroupRequest)(nil),                  // 86: idm.StorePolicyGroupRequest
+	(*StorePolicyGroupResponse)(nil),                 // 87: idm.StorePolicyGroupResponse
+	(*DeletePolicyGroupRequest)(nil),                 // 88: idm.DeletePolicyGroupRequest
+	(*DeletePolicyGroupResponse)(nil),                // 89: idm.DeletePolicyGroupResponse
+	(*ListPolicyGroupsRequest)(nil),                  // 90: idm.ListPolicyGroupsRequest
+	(*ListPolicyGroupsResponse)(nil),                 // 91: idm.ListPolicyGroupsResponse
+	(*PolicyGroupSingleQuery)(nil),                   // 92: idm.PolicyGroupSingleQuery
+	nil,                                              // 93: idm.User.AttributesEntry
+	nil,                                              // 94: idm.Workspace.RootNodesEntry
+	nil,                                              // 95: idm.UpdateUserMetaEvent.EventMetadataEntry
+	nil,                                              // 96: idm.ChangeEvent.AttributesEntry
+	nil,                                              // 97: idm.PolicyEngineRequest.ContextEntry
+	nil,                                              // 98: idm.Policy.ConditionsEntry
+	(*service.Query)(nil),                            // 99: service.Query
+	(*service.ResourcePolicy)(nil),                   // 100: service.ResourcePolicy
+	(*tree.TreeNode)(nil),                            // 101: tree.TreeNode
+	(*tree.Node)(nil),                                // 102: tree.Node
+	(*structpb.Struct)(nil),                          // 103: google.protobuf.Struct
+	(*service.ResourcePolicyQuery)(nil),              // 104: service.ResourcePolicyQuery
 }
 var file_cells_idm_proto_depIdxs = []int32{
 	15,  // 0: idm.CreateRoleRequest.Role:type_name -> idm.Role
 	15,  // 1: idm.CreateRoleResponse.Role:type_name -> idm.Role
-	92,  // 2: idm.DeleteRoleRequest.Query:type_name -> service.Query
-	92,  // 3: idm.SearchRoleRequest.Query:type_name -> service.Query
+	99,  // 2: idm.DeleteRoleRequest.Query:type_name -> service.Query
+	99,  // 3: idm.SearchRoleRequest.Query:type_name -> service.Query
 	15,  // 4: idm.SearchRoleResponse.Role:type_name -> idm.Role
-	93,  // 5: idm.Role.Policies:type_name -> service.ResourcePolicy
+	100, // 5: idm.Role.Policies:type_name -> service.ResourcePolicy
 	27,  // 6: idm.CreateUserRequest.User:type_name -> idm.User
 	27,  // 7: idm.CreateUserResponse.User:type_name -> idm.User
 	27,  // 8: idm.BindUserResponse.User:type_name -> idm.User
-	92,  // 9: idm.DeleteUserRequest.Query:type_name -> service.Query
-	92,  // 10: idm.SearchUserRequest.Query:type_name -> service.Query
+	99,  // 9: idm.DeleteUserRequest.Query:type_name -> service.Query
+	99,  // 10: idm.SearchUserRequest.Query:type_name -> service.Query
 	27,  // 11: idm.SearchUserResponse.User:type_name -> idm.User
-	94,  // 12: idm.TreeUser.node:type_name -> tree.TreeNode
+	101, // 12: idm.TreeUser.node:type_name -> tree.TreeNode
 	27,  // 13: idm.TreeUser.user:type_name -> idm.User
-	86,  // 14: idm.User.Attributes:type_name -> idm.User.AttributesEntry
+	93,  // 14: idm.User.Attributes:type_name -> idm.User.AttributesEntry
 	15,  // 15: idm.User.Roles:type_name -> idm.Role
-	93,  // 16: idm.User.Policies:type_name -> service.ResourcePolicy
+	100, // 16: idm.User.Policies:type_name -> service.ResourcePolicy
 	0,   // 17: idm.UserSingleQuery.NodeType:type_name -> idm.NodeType
 	35,  // 18: idm.CreateWorkspaceRequest.Workspace:type_name -> idm.Workspace
 	35,  // 19: idm.CreateWorkspaceResponse.Workspace:type_name -> idm.Workspace
-	92,  // 20: idm.DeleteWorkspaceRequest.Query:type_name -> service.Query
-	92,  // 21: idm.SearchWorkspaceRequest.Query:type_name -> service.Query
+	99,  // 20: idm.DeleteWorkspaceRequest.Query:type_name -> service.Query
+	99,  // 21: idm.SearchWorkspaceRequest.Query:type_name -> service.Query
 	35,  // 22: idm.SearchWorkspaceResponse.Workspace:type_name -> idm.Workspace
 	1,   // 23: idm.Workspace.Scope:type_name -> idm.WorkspaceScope
-	93,  // 24: idm.Workspace.Policies:type_name -> service.ResourcePolicy
-	87,  // 25: idm.Workspace.RootNodes:type_name -> idm.Workspace.RootNodesEntry
+	100, // 24: idm.Workspace.Policies:type_name -> service.ResourcePolicy
+	94,  // 25: idm.Workspace.RootNodes:type_name -> idm.Workspace.RootNodesEntry
 	1,   // 26: idm.WorkspaceSingleQuery.scope:type_name -> idm.WorkspaceScope
 	48,  // 27: idm.CreateACLRequest.ACL:type_name -> idm.ACL
 	48,  // 28: idm.CreateACLRequest.Batch:type_name -> idm.ACL
 	48,  // 29: idm.CreateACLResponse.ACL:type_name -> idm.ACL
 	48,  // 30: idm.CreateACLResponse.Batch:type_name -> idm.ACL
-	92,  // 31: idm.ExpireACLRequest.Query:type_name -> service.Query
-	92,  // 32: idm.DeleteACLRequest.Query:type_name -> service.Query
-	92,  // 33: idm.SearchACLRequest.Query:type_name -> service.Query
+	99,  // 31: idm.ExpireACLRequest.Query:type_name -> service.Query
+	99,  // 32: idm.DeleteACLRequest.Query:type_name -> service.Query
+	99,  // 33: idm.SearchACLRequest.Query:type_name -> service.Query
 	48,  // 34: idm.SearchACLResponse.ACL:type_name -> idm.ACL
-	92,  // 35: idm.RestoreACLRequest.Query:type_name -> service.Query
+	99,  // 35: idm.RestoreACLRequest.Query:type_name -> service.Query
 	47,  // 36: idm.ACL.Action:type_name -> idm.ACLAction
 	47,  // 37: idm.ACLSingleQuery.Actions:type_name -> idm.ACLAction
-	93,  // 38: idm.UserMeta.Policies:type_name -> service.ResourcePolicy
-	95,  // 39: idm.UserMeta.ResolvedNode:type_name -> tree.Node
-	93,  // 40: idm.UserMetaNamespace.Policies:type_name -> service.ResourcePolicy
-	96,  // 41: idm.UserMetaNamespace.JsonSchema:type_name -> google.protobuf.Struct
-	5,   // 42: idm.UpdateUserMetaRequest.Operation:type_name -> idm.UpdateUserMetaRequest.UserMetaOp
-	50,  // 43: idm.UpdateUserMetaRequest.MetaDatas:type_name -> idm.UserMeta
-	50,  // 44: idm.UpdateUserMetaResponse.MetaDatas:type_name -> idm.UserMeta
-	88,  // 45: idm.UpdateUserMetaEvent.EventMetadata:type_name -> idm.UpdateUserMetaEvent.EventMetadataEntry
-	6,   // 46: idm.UpdateUserMetaEvent.Operation:type_name -> idm.UpdateUserMetaEvent.UserMetaOp
-	50,  // 47: idm.UpdateUserMetaEvent.UserMeta:type_name -> idm.UserMeta
-	97,  // 48: idm.SearchUserMetaRequest.ResourceQuery:type_name -> service.ResourcePolicyQuery
-	50,  // 49: idm.SearchUserMetaResponse.UserMeta:type_name -> idm.UserMeta
-	7,   // 50: idm.UpdateUserMetaNamespaceRequest.Operation:type_name -> idm.UpdateUserMetaNamespaceRequest.UserMetaNsOp
-	51,  // 51: idm.UpdateUserMetaNamespaceRequest.Namespaces:type_name -> idm.UserMetaNamespace
-	51,  // 52: idm.UpdateUserMetaNamespaceResponse.Namespaces:type_name -> idm.UserMetaNamespace
-	51,  // 53: idm.ListUserMetaNamespaceResponse.UserMetaNamespace:type_name -> idm.UserMetaNamespace
-	96,  // 54: idm.JsonSchemaResponse.JsonSchema:type_name -> google.protobuf.Struct
-	2,   // 55: idm.ChangeEvent.Type:type_name -> idm.ChangeEventType
-	27,  // 56: idm.ChangeEvent.User:type_name -> idm.User
-	15,  // 57: idm.ChangeEvent.Role:type_name -> idm.Role
-	35,  // 58: idm.ChangeEvent.Workspace:type_name -> idm.Workspace
-	48,  // 59: idm.ChangeEvent.Acl:type_name -> idm.ACL
-	51,  // 60: idm.ChangeEvent.MetaNamespace:type_name -> idm.UserMetaNamespace
-	89,  // 61: idm.ChangeEvent.Attributes:type_name -> idm.ChangeEvent.AttributesEntry
-	90,  // 62: idm.PolicyEngineRequest.Context:type_name -> idm.PolicyEngineRequest.ContextEntry
-	71,  // 63: idm.Policy.OrmSubjects:type_name -> idm.PolicySubject
-	72,  // 64: idm.Policy.OrmResources:type_name -> idm.PolicyResource
-	73,  // 65: idm.Policy.OrmActions:type_name -> idm.PolicyAction
-	3,   // 66: idm.Policy.Effect:type_name -> idm.PolicyEffect
-	91,  // 67: idm.Policy.Conditions:type_name -> idm.Policy.ConditionsEntry
-	4,   // 68: idm.PolicyGroup.ResourceGroup:type_name -> idm.PolicyResourceGroup
-	70,  // 69: idm.PolicyGroup.Policies:type_name -> idm.Policy
-	78,  // 70: idm.StorePolicyGroupRequest.PolicyGroup:type_name -> idm.PolicyGroup
-	78,  // 71: idm.StorePolicyGroupResponse.PolicyGroup:type_name -> idm.PolicyGroup
-	78,  // 72: idm.DeletePolicyGroupRequest.PolicyGroup:type_name -> idm.PolicyGroup
-	92,  // 73: idm.ListPolicyGroupsRequest.Query:type_name -> service.Query
-	78,  // 74: idm.ListPolicyGroupsResponse.PolicyGroups:type_name -> idm.PolicyGroup
-	95,  // 75: idm.Workspace.RootNodesEntry.value:type_name -> tree.Node
-	69,  // 76: idm.Policy.ConditionsEntry.value:type_name -> idm.PolicyCondition
-	8,   // 77: idm.RoleService.CreateRole:input_type -> idm.CreateRoleRequest
-	10,  // 78: idm.RoleService.DeleteRole:input_type -> idm.DeleteRoleRequest
-	12,  // 79: idm.RoleService.SearchRole:input_type -> idm.SearchRoleRequest
-	12,  // 80: idm.RoleService.StreamRole:input_type -> idm.SearchRoleRequest
-	12,  // 81: idm.RoleService.CountRole:input_type -> idm.SearchRoleRequest
-	17,  // 82: idm.UserService.CreateUser:input_type -> idm.CreateUserRequest
-	21,  // 83: idm.UserService.DeleteUser:input_type -> idm.DeleteUserRequest
-	19,  // 84: idm.UserService.BindUser:input_type -> idm.BindUserRequest
-	23,  // 85: idm.UserService.CountUser:input_type -> idm.SearchUserRequest
-	23,  // 86: idm.UserService.SearchOne:input_type -> idm.SearchUserRequest
-	23,  // 87: idm.UserService.SearchUser:input_type -> idm.SearchUserRequest
-	23,  // 88: idm.UserService.StreamUser:input_type -> idm.SearchUserRequest
-	29,  // 89: idm.WorkspaceService.CreateWorkspace:input_type -> idm.CreateWorkspaceRequest
-	31,  // 90: idm.WorkspaceService.DeleteWorkspace:input_type -> idm.DeleteWorkspaceRequest
-	33,  // 91: idm.WorkspaceService.SearchWorkspace:input_type -> idm.SearchWorkspaceRequest
-	33,  // 92: idm.WorkspaceService.StreamWorkspace:input_type -> idm.SearchWorkspaceRequest
-	37,  // 93: idm.ACLService.CreateACL:input_type -> idm.CreateACLRequest
-	39,  // 94: idm.ACLService.ExpireACL:input_type -> idm.ExpireACLRequest
-	41,  // 95: idm.ACLService.DeleteACL:input_type -> idm.DeleteACLRequest
-	43,  // 96: idm.ACLService.SearchACL:input_type -> idm.SearchACLRequest
-	43,  // 97: idm.ACLService.StreamACL:input_type -> idm.SearchACLRequest
-	45,  // 98: idm.ACLService.RestoreACL:input_type -> idm.RestoreACLRequest
-	54,  // 99: idm.UserMetaService.UpdateUserMeta:input_type -> idm.UpdateUserMetaRequest
-	57,  // 100: idm.UserMetaService.SearchUserMeta:input_type -> idm.SearchUserMetaRequest
-	59,  // 101: idm.UserMetaService.UpdateUserMetaNamespace:input_type -> idm.UpdateUserMetaNamespaceRequest
-	61,  // 102: idm.UserMetaService.ListUserMetaNamespace:input_type -> idm.ListUserMetaNamespaceRequest
-	63,  // 103: idm.UserMetaService.GetFieldSchema:input_type -> idm.GetFieldSchemaRequest
-	65,  // 104: idm.UserMetaService.GetNamespaceSchema:input_type -> idm.GetNamespaceSchemaRequest
-	67,  // 105: idm.PolicyEngineService.IsAllowed:input_type -> idm.PolicyEngineRequest
-	79,  // 106: idm.PolicyEngineService.StorePolicyGroup:input_type -> idm.StorePolicyGroupRequest
-	83,  // 107: idm.PolicyEngineService.ListPolicyGroups:input_type -> idm.ListPolicyGroupsRequest
-	83,  // 108: idm.PolicyEngineService.StreamPolicyGroups:input_type -> idm.ListPolicyGroupsRequest
-	81,  // 109: idm.PolicyEngineService.DeletePolicyGroup:input_type -> idm.DeletePolicyGroupRequest
-	9,   // 110: idm.RoleService.CreateRole:output_type -> idm.CreateRoleResponse
-	11,  // 111: idm.RoleService.DeleteRole:output_type -> idm.DeleteRoleResponse
-	13,  // 112: idm.RoleService.SearchRole:output_type -> idm.SearchRoleResponse
-	13,  // 113: idm.RoleService.StreamRole:output_type -> idm.SearchRoleResponse
-	14,  // 114: idm.RoleService.CountRole:output_type -> idm.CountRoleResponse
-	18,  // 115: idm.UserService.CreateUser:output_type -> idm.CreateUserResponse
-	22,  // 116: idm.UserService.DeleteUser:output_type -> idm.DeleteUserResponse
-	20,  // 117: idm.UserService.BindUser:output_type -> idm.BindUserResponse
-	25,  // 118: idm.UserService.CountUser:output_type -> idm.CountUserResponse
-	24,  // 119: idm.UserService.SearchOne:output_type -> idm.SearchUserResponse
-	24,  // 120: idm.UserService.SearchUser:output_type -> idm.SearchUserResponse
-	24,  // 121: idm.UserService.StreamUser:output_type -> idm.SearchUserResponse
-	30,  // 122: idm.WorkspaceService.CreateWorkspace:output_type -> idm.CreateWorkspaceResponse
-	32,  // 123: idm.WorkspaceService.DeleteWorkspace:output_type -> idm.DeleteWorkspaceResponse
-	34,  // 124: idm.WorkspaceService.SearchWorkspace:output_type -> idm.SearchWorkspaceResponse
-	34,  // 125: idm.WorkspaceService.StreamWorkspace:output_type -> idm.SearchWorkspaceResponse
-	38,  // 126: idm.ACLService.CreateACL:output_type -> idm.CreateACLResponse
-	40,  // 127: idm.ACLService.ExpireACL:output_type -> idm.ExpireACLResponse
-	42,  // 128: idm.ACLService.DeleteACL:output_type -> idm.DeleteACLResponse
-	44,  // 129: idm.ACLService.SearchACL:output_type -> idm.SearchACLResponse
-	44,  // 130: idm.ACLService.StreamACL:output_type -> idm.SearchACLResponse
-	46,  // 131: idm.ACLService.RestoreACL:output_type -> idm.RestoreACLResponse
-	55,  // 132: idm.UserMetaService.UpdateUserMeta:output_type -> idm.UpdateUserMetaResponse
-	58,  // 133: idm.UserMetaService.SearchUserMeta:output_type -> idm.SearchUserMetaResponse
-	60,  // 134: idm.UserMetaService.UpdateUserMetaNamespace:output_type -> idm.UpdateUserMetaNamespaceResponse
-	62,  // 135: idm.UserMetaService.ListUserMetaNamespace:output_type -> idm.ListUserMetaNamespaceResponse
-	64,  // 136: idm.UserMetaService.GetFieldSchema:output_type -> idm.JsonSchemaResponse
-	64,  // 137: idm.UserMetaService.GetNamespaceSchema:output_type -> idm.JsonSchemaResponse
-	68,  // 138: idm.PolicyEngineService.IsAllowed:output_type -> idm.PolicyEngineResponse
-	80,  // 139: idm.PolicyEngineService.StorePolicyGroup:output_type -> idm.StorePolicyGroupResponse
-	84,  // 140: idm.PolicyEngineService.ListPolicyGroups:output_type -> idm.ListPolicyGroupsResponse
-	78,  // 141: idm.PolicyEngineService.StreamPolicyGroups:output_type -> idm.PolicyGroup
-	82,  // 142: idm.PolicyEngineService.DeletePolicyGroup:output_type -> idm.DeletePolicyGroupResponse
-	110, // [110:143] is the sub-list for method output_type
-	77,  // [77:110] is the sub-list for method input_type
-	77,  // [77:77] is the sub-list for extension type_name
-	77,  // [77:77] is the sub-list for extension extendee
-	0,   // [0:77] is the sub-list for field type_name
+	60,  // 38: idm.CreateEntityValueRequest.EntityValue:type_name -> idm.EntityValue
+	60,  // 39: idm.CreateEntityValueResponse.EntityValue:type_name -> idm.EntityValue
+	59,  // 40: idm.CreateEntityRequest.Entity:type_name -> idm.MetaEntity
+	59,  // 41: idm.CreateEntityResponse.Entity:type_name -> idm.MetaEntity
+	60,  // 42: idm.MetaEntityValueResponse.EntityValue:type_name -> idm.EntityValue
+	100, // 43: idm.UserMeta.Policies:type_name -> service.ResourcePolicy
+	102, // 44: idm.UserMeta.ResolvedNode:type_name -> tree.Node
+	100, // 45: idm.UserMetaNamespace.Policies:type_name -> service.ResourcePolicy
+	103, // 46: idm.UserMetaNamespace.JsonSchema:type_name -> google.protobuf.Struct
+	5,   // 47: idm.UpdateUserMetaRequest.Operation:type_name -> idm.UpdateUserMetaRequest.UserMetaOp
+	57,  // 48: idm.UpdateUserMetaRequest.MetaDatas:type_name -> idm.UserMeta
+	57,  // 49: idm.UpdateUserMetaResponse.MetaDatas:type_name -> idm.UserMeta
+	95,  // 50: idm.UpdateUserMetaEvent.EventMetadata:type_name -> idm.UpdateUserMetaEvent.EventMetadataEntry
+	6,   // 51: idm.UpdateUserMetaEvent.Operation:type_name -> idm.UpdateUserMetaEvent.UserMetaOp
+	57,  // 52: idm.UpdateUserMetaEvent.UserMeta:type_name -> idm.UserMeta
+	104, // 53: idm.SearchUserMetaRequest.ResourceQuery:type_name -> service.ResourcePolicyQuery
+	57,  // 54: idm.SearchUserMetaResponse.UserMeta:type_name -> idm.UserMeta
+	7,   // 55: idm.UpdateUserMetaNamespaceRequest.Operation:type_name -> idm.UpdateUserMetaNamespaceRequest.UserMetaNsOp
+	58,  // 56: idm.UpdateUserMetaNamespaceRequest.Namespaces:type_name -> idm.UserMetaNamespace
+	58,  // 57: idm.UpdateUserMetaNamespaceResponse.Namespaces:type_name -> idm.UserMetaNamespace
+	58,  // 58: idm.ListUserMetaNamespaceResponse.UserMetaNamespace:type_name -> idm.UserMetaNamespace
+	103, // 59: idm.JsonSchemaResponse.JsonSchema:type_name -> google.protobuf.Struct
+	2,   // 60: idm.ChangeEvent.Type:type_name -> idm.ChangeEventType
+	27,  // 61: idm.ChangeEvent.User:type_name -> idm.User
+	15,  // 62: idm.ChangeEvent.Role:type_name -> idm.Role
+	35,  // 63: idm.ChangeEvent.Workspace:type_name -> idm.Workspace
+	48,  // 64: idm.ChangeEvent.Acl:type_name -> idm.ACL
+	58,  // 65: idm.ChangeEvent.MetaNamespace:type_name -> idm.UserMetaNamespace
+	96,  // 66: idm.ChangeEvent.Attributes:type_name -> idm.ChangeEvent.AttributesEntry
+	97,  // 67: idm.PolicyEngineRequest.Context:type_name -> idm.PolicyEngineRequest.ContextEntry
+	78,  // 68: idm.Policy.OrmSubjects:type_name -> idm.PolicySubject
+	79,  // 69: idm.Policy.OrmResources:type_name -> idm.PolicyResource
+	80,  // 70: idm.Policy.OrmActions:type_name -> idm.PolicyAction
+	3,   // 71: idm.Policy.Effect:type_name -> idm.PolicyEffect
+	98,  // 72: idm.Policy.Conditions:type_name -> idm.Policy.ConditionsEntry
+	4,   // 73: idm.PolicyGroup.ResourceGroup:type_name -> idm.PolicyResourceGroup
+	77,  // 74: idm.PolicyGroup.Policies:type_name -> idm.Policy
+	85,  // 75: idm.StorePolicyGroupRequest.PolicyGroup:type_name -> idm.PolicyGroup
+	85,  // 76: idm.StorePolicyGroupResponse.PolicyGroup:type_name -> idm.PolicyGroup
+	85,  // 77: idm.DeletePolicyGroupRequest.PolicyGroup:type_name -> idm.PolicyGroup
+	99,  // 78: idm.ListPolicyGroupsRequest.Query:type_name -> service.Query
+	85,  // 79: idm.ListPolicyGroupsResponse.PolicyGroups:type_name -> idm.PolicyGroup
+	102, // 80: idm.Workspace.RootNodesEntry.value:type_name -> tree.Node
+	76,  // 81: idm.Policy.ConditionsEntry.value:type_name -> idm.PolicyCondition
+	8,   // 82: idm.RoleService.CreateRole:input_type -> idm.CreateRoleRequest
+	10,  // 83: idm.RoleService.DeleteRole:input_type -> idm.DeleteRoleRequest
+	12,  // 84: idm.RoleService.SearchRole:input_type -> idm.SearchRoleRequest
+	12,  // 85: idm.RoleService.StreamRole:input_type -> idm.SearchRoleRequest
+	12,  // 86: idm.RoleService.CountRole:input_type -> idm.SearchRoleRequest
+	17,  // 87: idm.UserService.CreateUser:input_type -> idm.CreateUserRequest
+	21,  // 88: idm.UserService.DeleteUser:input_type -> idm.DeleteUserRequest
+	19,  // 89: idm.UserService.BindUser:input_type -> idm.BindUserRequest
+	23,  // 90: idm.UserService.CountUser:input_type -> idm.SearchUserRequest
+	23,  // 91: idm.UserService.SearchOne:input_type -> idm.SearchUserRequest
+	23,  // 92: idm.UserService.SearchUser:input_type -> idm.SearchUserRequest
+	23,  // 93: idm.UserService.StreamUser:input_type -> idm.SearchUserRequest
+	29,  // 94: idm.WorkspaceService.CreateWorkspace:input_type -> idm.CreateWorkspaceRequest
+	31,  // 95: idm.WorkspaceService.DeleteWorkspace:input_type -> idm.DeleteWorkspaceRequest
+	33,  // 96: idm.WorkspaceService.SearchWorkspace:input_type -> idm.SearchWorkspaceRequest
+	33,  // 97: idm.WorkspaceService.StreamWorkspace:input_type -> idm.SearchWorkspaceRequest
+	37,  // 98: idm.ACLService.CreateACL:input_type -> idm.CreateACLRequest
+	39,  // 99: idm.ACLService.ExpireACL:input_type -> idm.ExpireACLRequest
+	41,  // 100: idm.ACLService.DeleteACL:input_type -> idm.DeleteACLRequest
+	43,  // 101: idm.ACLService.SearchACL:input_type -> idm.SearchACLRequest
+	43,  // 102: idm.ACLService.StreamACL:input_type -> idm.SearchACLRequest
+	45,  // 103: idm.ACLService.RestoreACL:input_type -> idm.RestoreACLRequest
+	61,  // 104: idm.UserMetaService.UpdateUserMeta:input_type -> idm.UpdateUserMetaRequest
+	64,  // 105: idm.UserMetaService.SearchUserMeta:input_type -> idm.SearchUserMetaRequest
+	66,  // 106: idm.UserMetaService.UpdateUserMetaNamespace:input_type -> idm.UpdateUserMetaNamespaceRequest
+	68,  // 107: idm.UserMetaService.ListUserMetaNamespace:input_type -> idm.ListUserMetaNamespaceRequest
+	70,  // 108: idm.UserMetaService.GetFieldSchema:input_type -> idm.GetFieldSchemaRequest
+	72,  // 109: idm.UserMetaService.GetNamespaceSchema:input_type -> idm.GetNamespaceSchemaRequest
+	55,  // 110: idm.UserMetaService.GetEntityValues:input_type -> idm.GetMetaEntityValuesRequest
+	55,  // 111: idm.UserMetaService.DeleteEntityValues:input_type -> idm.GetMetaEntityValuesRequest
+	52,  // 112: idm.UserMetaService.CreateEntity:input_type -> idm.CreateEntityRequest
+	50,  // 113: idm.UserMetaService.CreateEntityValues:input_type -> idm.CreateEntityValueRequest
+	74,  // 114: idm.PolicyEngineService.IsAllowed:input_type -> idm.PolicyEngineRequest
+	86,  // 115: idm.PolicyEngineService.StorePolicyGroup:input_type -> idm.StorePolicyGroupRequest
+	90,  // 116: idm.PolicyEngineService.ListPolicyGroups:input_type -> idm.ListPolicyGroupsRequest
+	90,  // 117: idm.PolicyEngineService.StreamPolicyGroups:input_type -> idm.ListPolicyGroupsRequest
+	88,  // 118: idm.PolicyEngineService.DeletePolicyGroup:input_type -> idm.DeletePolicyGroupRequest
+	9,   // 119: idm.RoleService.CreateRole:output_type -> idm.CreateRoleResponse
+	11,  // 120: idm.RoleService.DeleteRole:output_type -> idm.DeleteRoleResponse
+	13,  // 121: idm.RoleService.SearchRole:output_type -> idm.SearchRoleResponse
+	13,  // 122: idm.RoleService.StreamRole:output_type -> idm.SearchRoleResponse
+	14,  // 123: idm.RoleService.CountRole:output_type -> idm.CountRoleResponse
+	18,  // 124: idm.UserService.CreateUser:output_type -> idm.CreateUserResponse
+	22,  // 125: idm.UserService.DeleteUser:output_type -> idm.DeleteUserResponse
+	20,  // 126: idm.UserService.BindUser:output_type -> idm.BindUserResponse
+	25,  // 127: idm.UserService.CountUser:output_type -> idm.CountUserResponse
+	24,  // 128: idm.UserService.SearchOne:output_type -> idm.SearchUserResponse
+	24,  // 129: idm.UserService.SearchUser:output_type -> idm.SearchUserResponse
+	24,  // 130: idm.UserService.StreamUser:output_type -> idm.SearchUserResponse
+	30,  // 131: idm.WorkspaceService.CreateWorkspace:output_type -> idm.CreateWorkspaceResponse
+	32,  // 132: idm.WorkspaceService.DeleteWorkspace:output_type -> idm.DeleteWorkspaceResponse
+	34,  // 133: idm.WorkspaceService.SearchWorkspace:output_type -> idm.SearchWorkspaceResponse
+	34,  // 134: idm.WorkspaceService.StreamWorkspace:output_type -> idm.SearchWorkspaceResponse
+	38,  // 135: idm.ACLService.CreateACL:output_type -> idm.CreateACLResponse
+	40,  // 136: idm.ACLService.ExpireACL:output_type -> idm.ExpireACLResponse
+	42,  // 137: idm.ACLService.DeleteACL:output_type -> idm.DeleteACLResponse
+	44,  // 138: idm.ACLService.SearchACL:output_type -> idm.SearchACLResponse
+	44,  // 139: idm.ACLService.StreamACL:output_type -> idm.SearchACLResponse
+	46,  // 140: idm.ACLService.RestoreACL:output_type -> idm.RestoreACLResponse
+	62,  // 141: idm.UserMetaService.UpdateUserMeta:output_type -> idm.UpdateUserMetaResponse
+	65,  // 142: idm.UserMetaService.SearchUserMeta:output_type -> idm.SearchUserMetaResponse
+	67,  // 143: idm.UserMetaService.UpdateUserMetaNamespace:output_type -> idm.UpdateUserMetaNamespaceResponse
+	69,  // 144: idm.UserMetaService.ListUserMetaNamespace:output_type -> idm.ListUserMetaNamespaceResponse
+	71,  // 145: idm.UserMetaService.GetFieldSchema:output_type -> idm.JsonSchemaResponse
+	71,  // 146: idm.UserMetaService.GetNamespaceSchema:output_type -> idm.JsonSchemaResponse
+	56,  // 147: idm.UserMetaService.GetEntityValues:output_type -> idm.MetaEntityValueResponse
+	54,  // 148: idm.UserMetaService.DeleteEntityValues:output_type -> idm.DeleteEntityValuesResponse
+	53,  // 149: idm.UserMetaService.CreateEntity:output_type -> idm.CreateEntityResponse
+	51,  // 150: idm.UserMetaService.CreateEntityValues:output_type -> idm.CreateEntityValueResponse
+	75,  // 151: idm.PolicyEngineService.IsAllowed:output_type -> idm.PolicyEngineResponse
+	87,  // 152: idm.PolicyEngineService.StorePolicyGroup:output_type -> idm.StorePolicyGroupResponse
+	91,  // 153: idm.PolicyEngineService.ListPolicyGroups:output_type -> idm.ListPolicyGroupsResponse
+	85,  // 154: idm.PolicyEngineService.StreamPolicyGroups:output_type -> idm.PolicyGroup
+	89,  // 155: idm.PolicyEngineService.DeletePolicyGroup:output_type -> idm.DeletePolicyGroupResponse
+	119, // [119:156] is the sub-list for method output_type
+	82,  // [82:119] is the sub-list for method input_type
+	82,  // [82:82] is the sub-list for extension type_name
+	82,  // [82:82] is the sub-list for extension extendee
+	0,   // [0:82] is the sub-list for field type_name
 }
 
 func init() { file_cells_idm_proto_init() }
@@ -6160,7 +6508,7 @@ func file_cells_idm_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cells_idm_proto_rawDesc), len(file_cells_idm_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   84,
+			NumMessages:   91,
 			NumExtensions: 0,
 			NumServices:   6,
 		},

--- a/common/proto/idm/cells-idm.pb.go
+++ b/common/proto/idm/cells-idm.pb.go
@@ -6193,7 +6193,7 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\tSearchACL\x12\x15.idm.SearchACLRequest\x1a\x16.idm.SearchACLResponse\"\x000\x01\x12@\n" +
 	"\tStreamACL\x12\x15.idm.SearchACLRequest\x1a\x16.idm.SearchACLResponse\"\x00(\x010\x01\x12?\n" +
 	"\n" +
-	"RestoreACL\x12\x16.idm.RestoreACLRequest\x1a\x17.idm.RestoreACLResponse\"\x002\xe3\x06\n" +
+	"RestoreACL\x12\x16.idm.RestoreACLRequest\x1a\x17.idm.RestoreACLResponse\"\x002\xd9\x06\n" +
 	"\x0fUserMetaService\x12K\n" +
 	"\x0eUpdateUserMeta\x12\x1a.idm.UpdateUserMetaRequest\x1a\x1b.idm.UpdateUserMetaResponse\"\x00\x12M\n" +
 	"\x0eSearchUserMeta\x12\x1a.idm.SearchUserMetaRequest\x1a\x1b.idm.SearchUserMetaResponse\"\x000\x01\x12f\n" +
@@ -6201,8 +6201,8 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\x15ListUserMetaNamespace\x12!.idm.ListUserMetaNamespaceRequest\x1a\".idm.ListUserMetaNamespaceResponse\"\x000\x01\x12G\n" +
 	"\x0eGetFieldSchema\x12\x1a.idm.GetFieldSchemaRequest\x1a\x17.idm.JsonSchemaResponse\"\x00\x12O\n" +
 	"\x12GetNamespaceSchema\x12\x1e.idm.GetNamespaceSchemaRequest\x1a\x17.idm.JsonSchemaResponse\"\x00\x12R\n" +
-	"\x0fGetEntityValues\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1c.idm.MetaEntityValueResponse\"\x00\x12\\\n" +
-	"\x16DeleteEntityValuesData\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1f.idm.DeleteEntityValuesResponse\"\x00\x12E\n" +
+	"\x0fGetEntityValues\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1c.idm.MetaEntityValueResponse\"\x00\x12R\n" +
+	"\fDeleteEntity\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1f.idm.DeleteEntityValuesResponse\"\x00\x12E\n" +
 	"\fCreateEntity\x12\x18.idm.CreateEntityRequest\x1a\x19.idm.CreateEntityResponse\"\x00\x12U\n" +
 	"\x12CreateEntityValues\x12\x1d.idm.CreateEntityValueRequest\x1a\x1e.idm.CreateEntityValueResponse\"\x002\x9f\x03\n" +
 	"\x13PolicyEngineService\x12B\n" +
@@ -6445,7 +6445,7 @@ var file_cells_idm_proto_depIdxs = []int32{
 	70,  // 108: idm.UserMetaService.GetFieldSchema:input_type -> idm.GetFieldSchemaRequest
 	72,  // 109: idm.UserMetaService.GetNamespaceSchema:input_type -> idm.GetNamespaceSchemaRequest
 	55,  // 110: idm.UserMetaService.GetEntityValues:input_type -> idm.GetMetaEntityValuesRequest
-	55,  // 111: idm.UserMetaService.DeleteEntityValuesData:input_type -> idm.GetMetaEntityValuesRequest
+	55,  // 111: idm.UserMetaService.DeleteEntity:input_type -> idm.GetMetaEntityValuesRequest
 	52,  // 112: idm.UserMetaService.CreateEntity:input_type -> idm.CreateEntityRequest
 	50,  // 113: idm.UserMetaService.CreateEntityValues:input_type -> idm.CreateEntityValueRequest
 	74,  // 114: idm.PolicyEngineService.IsAllowed:input_type -> idm.PolicyEngineRequest
@@ -6482,7 +6482,7 @@ var file_cells_idm_proto_depIdxs = []int32{
 	71,  // 145: idm.UserMetaService.GetFieldSchema:output_type -> idm.JsonSchemaResponse
 	71,  // 146: idm.UserMetaService.GetNamespaceSchema:output_type -> idm.JsonSchemaResponse
 	56,  // 147: idm.UserMetaService.GetEntityValues:output_type -> idm.MetaEntityValueResponse
-	54,  // 148: idm.UserMetaService.DeleteEntityValuesData:output_type -> idm.DeleteEntityValuesResponse
+	54,  // 148: idm.UserMetaService.DeleteEntity:output_type -> idm.DeleteEntityValuesResponse
 	53,  // 149: idm.UserMetaService.CreateEntity:output_type -> idm.CreateEntityResponse
 	51,  // 150: idm.UserMetaService.CreateEntityValues:output_type -> idm.CreateEntityValueResponse
 	75,  // 151: idm.PolicyEngineService.IsAllowed:output_type -> idm.PolicyEngineResponse

--- a/common/proto/idm/cells-idm.pb.go
+++ b/common/proto/idm/cells-idm.pb.go
@@ -6193,7 +6193,7 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\tSearchACL\x12\x15.idm.SearchACLRequest\x1a\x16.idm.SearchACLResponse\"\x000\x01\x12@\n" +
 	"\tStreamACL\x12\x15.idm.SearchACLRequest\x1a\x16.idm.SearchACLResponse\"\x00(\x010\x01\x12?\n" +
 	"\n" +
-	"RestoreACL\x12\x16.idm.RestoreACLRequest\x1a\x17.idm.RestoreACLResponse\"\x002\xdf\x06\n" +
+	"RestoreACL\x12\x16.idm.RestoreACLRequest\x1a\x17.idm.RestoreACLResponse\"\x002\xe3\x06\n" +
 	"\x0fUserMetaService\x12K\n" +
 	"\x0eUpdateUserMeta\x12\x1a.idm.UpdateUserMetaRequest\x1a\x1b.idm.UpdateUserMetaResponse\"\x00\x12M\n" +
 	"\x0eSearchUserMeta\x12\x1a.idm.SearchUserMetaRequest\x1a\x1b.idm.SearchUserMetaResponse\"\x000\x01\x12f\n" +
@@ -6201,8 +6201,8 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\x15ListUserMetaNamespace\x12!.idm.ListUserMetaNamespaceRequest\x1a\".idm.ListUserMetaNamespaceResponse\"\x000\x01\x12G\n" +
 	"\x0eGetFieldSchema\x12\x1a.idm.GetFieldSchemaRequest\x1a\x17.idm.JsonSchemaResponse\"\x00\x12O\n" +
 	"\x12GetNamespaceSchema\x12\x1e.idm.GetNamespaceSchemaRequest\x1a\x17.idm.JsonSchemaResponse\"\x00\x12R\n" +
-	"\x0fGetEntityValues\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1c.idm.MetaEntityValueResponse\"\x00\x12X\n" +
-	"\x12DeleteEntityValues\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1f.idm.DeleteEntityValuesResponse\"\x00\x12E\n" +
+	"\x0fGetEntityValues\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1c.idm.MetaEntityValueResponse\"\x00\x12\\\n" +
+	"\x16DeleteEntityValuesData\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1f.idm.DeleteEntityValuesResponse\"\x00\x12E\n" +
 	"\fCreateEntity\x12\x18.idm.CreateEntityRequest\x1a\x19.idm.CreateEntityResponse\"\x00\x12U\n" +
 	"\x12CreateEntityValues\x12\x1d.idm.CreateEntityValueRequest\x1a\x1e.idm.CreateEntityValueResponse\"\x002\x9f\x03\n" +
 	"\x13PolicyEngineService\x12B\n" +
@@ -6445,7 +6445,7 @@ var file_cells_idm_proto_depIdxs = []int32{
 	70,  // 108: idm.UserMetaService.GetFieldSchema:input_type -> idm.GetFieldSchemaRequest
 	72,  // 109: idm.UserMetaService.GetNamespaceSchema:input_type -> idm.GetNamespaceSchemaRequest
 	55,  // 110: idm.UserMetaService.GetEntityValues:input_type -> idm.GetMetaEntityValuesRequest
-	55,  // 111: idm.UserMetaService.DeleteEntityValues:input_type -> idm.GetMetaEntityValuesRequest
+	55,  // 111: idm.UserMetaService.DeleteEntityValuesData:input_type -> idm.GetMetaEntityValuesRequest
 	52,  // 112: idm.UserMetaService.CreateEntity:input_type -> idm.CreateEntityRequest
 	50,  // 113: idm.UserMetaService.CreateEntityValues:input_type -> idm.CreateEntityValueRequest
 	74,  // 114: idm.PolicyEngineService.IsAllowed:input_type -> idm.PolicyEngineRequest
@@ -6482,7 +6482,7 @@ var file_cells_idm_proto_depIdxs = []int32{
 	71,  // 145: idm.UserMetaService.GetFieldSchema:output_type -> idm.JsonSchemaResponse
 	71,  // 146: idm.UserMetaService.GetNamespaceSchema:output_type -> idm.JsonSchemaResponse
 	56,  // 147: idm.UserMetaService.GetEntityValues:output_type -> idm.MetaEntityValueResponse
-	54,  // 148: idm.UserMetaService.DeleteEntityValues:output_type -> idm.DeleteEntityValuesResponse
+	54,  // 148: idm.UserMetaService.DeleteEntityValuesData:output_type -> idm.DeleteEntityValuesResponse
 	53,  // 149: idm.UserMetaService.CreateEntity:output_type -> idm.CreateEntityResponse
 	51,  // 150: idm.UserMetaService.CreateEntityValues:output_type -> idm.CreateEntityValueResponse
 	75,  // 151: idm.PolicyEngineService.IsAllowed:output_type -> idm.PolicyEngineResponse

--- a/common/proto/idm/cells-idm.proto
+++ b/common/proto/idm/cells-idm.proto
@@ -448,7 +448,7 @@ service UserMetaService {
     rpc GetFieldSchema(GetFieldSchemaRequest) returns (JsonSchemaResponse) {}
     rpc GetNamespaceSchema(GetNamespaceSchemaRequest) returns (JsonSchemaResponse) {}
     rpc GetEntityValues(GetMetaEntityValuesRequest) returns (MetaEntityValueResponse) {}
-    rpc DeleteEntityValuesData(GetMetaEntityValuesRequest) returns (DeleteEntityValuesResponse) {}
+    rpc DeleteEntity(GetMetaEntityValuesRequest) returns (DeleteEntityValuesResponse) {}
     rpc CreateEntity(CreateEntityRequest) returns (CreateEntityResponse) {}
     rpc CreateEntityValues(CreateEntityValueRequest) returns (CreateEntityValueResponse) {}
 }

--- a/common/proto/idm/cells-idm.proto
+++ b/common/proto/idm/cells-idm.proto
@@ -447,6 +447,38 @@ service UserMetaService {
     rpc ListUserMetaNamespace(ListUserMetaNamespaceRequest) returns (stream ListUserMetaNamespaceResponse){}
     rpc GetFieldSchema(GetFieldSchemaRequest) returns (JsonSchemaResponse) {}
     rpc GetNamespaceSchema(GetNamespaceSchemaRequest) returns (JsonSchemaResponse) {}
+    rpc GetEntityValues(GetMetaEntityValuesRequest) returns (MetaEntityValueResponse) {}
+    rpc DeleteEntityValues(GetMetaEntityValuesRequest) returns (DeleteEntityValuesResponse) {}
+    rpc CreateEntity(CreateEntityRequest) returns (CreateEntityResponse) {}
+    rpc CreateEntityValues(CreateEntityValueRequest) returns (CreateEntityValueResponse) {}
+}
+
+message CreateEntityValueRequest{
+    repeated EntityValue EntityValue = 1;
+}
+
+message CreateEntityValueResponse{
+    repeated EntityValue EntityValue = 1;
+}
+
+message CreateEntityRequest{
+    MetaEntity Entity = 1;
+}
+
+message CreateEntityResponse{
+    MetaEntity Entity = 1;
+}
+
+message DeleteEntityValuesResponse{
+    int64 RowsDeleted = 1;
+}
+
+message GetMetaEntityValuesRequest{
+    string EntityUuid = 1;
+}
+
+message MetaEntityValueResponse{
+    repeated EntityValue EntityValue = 1;
 }
 
 // Piece of metadata attached to a node

--- a/common/proto/idm/cells-idm.proto
+++ b/common/proto/idm/cells-idm.proto
@@ -448,7 +448,7 @@ service UserMetaService {
     rpc GetFieldSchema(GetFieldSchemaRequest) returns (JsonSchemaResponse) {}
     rpc GetNamespaceSchema(GetNamespaceSchemaRequest) returns (JsonSchemaResponse) {}
     rpc GetEntityValues(GetMetaEntityValuesRequest) returns (MetaEntityValueResponse) {}
-    rpc DeleteEntityValues(GetMetaEntityValuesRequest) returns (DeleteEntityValuesResponse) {}
+    rpc DeleteEntityValuesData(GetMetaEntityValuesRequest) returns (DeleteEntityValuesResponse) {}
     rpc CreateEntity(CreateEntityRequest) returns (CreateEntityResponse) {}
     rpc CreateEntityValues(CreateEntityValueRequest) returns (CreateEntityValueResponse) {}
 }

--- a/common/proto/idm/cells-idm_grpc.pb.go
+++ b/common/proto/idm/cells-idm_grpc.pb.go
@@ -1170,7 +1170,7 @@ const (
 	UserMetaService_GetFieldSchema_FullMethodName          = "/idm.UserMetaService/GetFieldSchema"
 	UserMetaService_GetNamespaceSchema_FullMethodName      = "/idm.UserMetaService/GetNamespaceSchema"
 	UserMetaService_GetEntityValues_FullMethodName         = "/idm.UserMetaService/GetEntityValues"
-	UserMetaService_DeleteEntityValuesData_FullMethodName  = "/idm.UserMetaService/DeleteEntityValuesData"
+	UserMetaService_DeleteEntity_FullMethodName            = "/idm.UserMetaService/DeleteEntity"
 	UserMetaService_CreateEntity_FullMethodName            = "/idm.UserMetaService/CreateEntity"
 	UserMetaService_CreateEntityValues_FullMethodName      = "/idm.UserMetaService/CreateEntityValues"
 )
@@ -1189,7 +1189,7 @@ type UserMetaServiceClient interface {
 	GetFieldSchema(ctx context.Context, in *GetFieldSchemaRequest, opts ...grpc.CallOption) (*JsonSchemaResponse, error)
 	GetNamespaceSchema(ctx context.Context, in *GetNamespaceSchemaRequest, opts ...grpc.CallOption) (*JsonSchemaResponse, error)
 	GetEntityValues(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*MetaEntityValueResponse, error)
-	DeleteEntityValuesData(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*DeleteEntityValuesResponse, error)
+	DeleteEntity(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*DeleteEntityValuesResponse, error)
 	CreateEntity(ctx context.Context, in *CreateEntityRequest, opts ...grpc.CallOption) (*CreateEntityResponse, error)
 	CreateEntityValues(ctx context.Context, in *CreateEntityValueRequest, opts ...grpc.CallOption) (*CreateEntityValueResponse, error)
 }
@@ -1290,10 +1290,10 @@ func (c *userMetaServiceClient) GetEntityValues(ctx context.Context, in *GetMeta
 	return out, nil
 }
 
-func (c *userMetaServiceClient) DeleteEntityValuesData(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*DeleteEntityValuesResponse, error) {
+func (c *userMetaServiceClient) DeleteEntity(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*DeleteEntityValuesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(DeleteEntityValuesResponse)
-	err := c.cc.Invoke(ctx, UserMetaService_DeleteEntityValuesData_FullMethodName, in, out, cOpts...)
+	err := c.cc.Invoke(ctx, UserMetaService_DeleteEntity_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1334,7 +1334,7 @@ type UserMetaServiceServer interface {
 	GetFieldSchema(context.Context, *GetFieldSchemaRequest) (*JsonSchemaResponse, error)
 	GetNamespaceSchema(context.Context, *GetNamespaceSchemaRequest) (*JsonSchemaResponse, error)
 	GetEntityValues(context.Context, *GetMetaEntityValuesRequest) (*MetaEntityValueResponse, error)
-	DeleteEntityValuesData(context.Context, *GetMetaEntityValuesRequest) (*DeleteEntityValuesResponse, error)
+	DeleteEntity(context.Context, *GetMetaEntityValuesRequest) (*DeleteEntityValuesResponse, error)
 	CreateEntity(context.Context, *CreateEntityRequest) (*CreateEntityResponse, error)
 	CreateEntityValues(context.Context, *CreateEntityValueRequest) (*CreateEntityValueResponse, error)
 	mustEmbedUnimplementedUserMetaServiceServer()
@@ -1368,8 +1368,8 @@ func (UnimplementedUserMetaServiceServer) GetNamespaceSchema(context.Context, *G
 func (UnimplementedUserMetaServiceServer) GetEntityValues(context.Context, *GetMetaEntityValuesRequest) (*MetaEntityValueResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetEntityValues not implemented")
 }
-func (UnimplementedUserMetaServiceServer) DeleteEntityValuesData(context.Context, *GetMetaEntityValuesRequest) (*DeleteEntityValuesResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method DeleteEntityValuesData not implemented")
+func (UnimplementedUserMetaServiceServer) DeleteEntity(context.Context, *GetMetaEntityValuesRequest) (*DeleteEntityValuesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteEntity not implemented")
 }
 func (UnimplementedUserMetaServiceServer) CreateEntity(context.Context, *CreateEntityRequest) (*CreateEntityResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateEntity not implemented")
@@ -1510,20 +1510,20 @@ func _UserMetaService_GetEntityValues_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
-func _UserMetaService_DeleteEntityValuesData_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _UserMetaService_DeleteEntity_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetMetaEntityValuesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(UserMetaServiceServer).DeleteEntityValuesData(ctx, in)
+		return srv.(UserMetaServiceServer).DeleteEntity(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: UserMetaService_DeleteEntityValuesData_FullMethodName,
+		FullMethod: UserMetaService_DeleteEntity_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(UserMetaServiceServer).DeleteEntityValuesData(ctx, req.(*GetMetaEntityValuesRequest))
+		return srv.(UserMetaServiceServer).DeleteEntity(ctx, req.(*GetMetaEntityValuesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1592,8 +1592,8 @@ var UserMetaService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _UserMetaService_GetEntityValues_Handler,
 		},
 		{
-			MethodName: "DeleteEntityValuesData",
-			Handler:    _UserMetaService_DeleteEntityValuesData_Handler,
+			MethodName: "DeleteEntity",
+			Handler:    _UserMetaService_DeleteEntity_Handler,
 		},
 		{
 			MethodName: "CreateEntity",

--- a/common/proto/idm/cells-idm_grpc.pb.go
+++ b/common/proto/idm/cells-idm_grpc.pb.go
@@ -1169,6 +1169,10 @@ const (
 	UserMetaService_ListUserMetaNamespace_FullMethodName   = "/idm.UserMetaService/ListUserMetaNamespace"
 	UserMetaService_GetFieldSchema_FullMethodName          = "/idm.UserMetaService/GetFieldSchema"
 	UserMetaService_GetNamespaceSchema_FullMethodName      = "/idm.UserMetaService/GetNamespaceSchema"
+	UserMetaService_GetEntityValues_FullMethodName         = "/idm.UserMetaService/GetEntityValues"
+	UserMetaService_DeleteEntityValues_FullMethodName      = "/idm.UserMetaService/DeleteEntityValues"
+	UserMetaService_CreateEntity_FullMethodName            = "/idm.UserMetaService/CreateEntity"
+	UserMetaService_CreateEntityValues_FullMethodName      = "/idm.UserMetaService/CreateEntityValues"
 )
 
 // UserMetaServiceClient is the client API for UserMetaService service.
@@ -1184,6 +1188,10 @@ type UserMetaServiceClient interface {
 	ListUserMetaNamespace(ctx context.Context, in *ListUserMetaNamespaceRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListUserMetaNamespaceResponse], error)
 	GetFieldSchema(ctx context.Context, in *GetFieldSchemaRequest, opts ...grpc.CallOption) (*JsonSchemaResponse, error)
 	GetNamespaceSchema(ctx context.Context, in *GetNamespaceSchemaRequest, opts ...grpc.CallOption) (*JsonSchemaResponse, error)
+	GetEntityValues(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*MetaEntityValueResponse, error)
+	DeleteEntityValues(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*DeleteEntityValuesResponse, error)
+	CreateEntity(ctx context.Context, in *CreateEntityRequest, opts ...grpc.CallOption) (*CreateEntityResponse, error)
+	CreateEntityValues(ctx context.Context, in *CreateEntityValueRequest, opts ...grpc.CallOption) (*CreateEntityValueResponse, error)
 }
 
 type userMetaServiceClient struct {
@@ -1272,6 +1280,46 @@ func (c *userMetaServiceClient) GetNamespaceSchema(ctx context.Context, in *GetN
 	return out, nil
 }
 
+func (c *userMetaServiceClient) GetEntityValues(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*MetaEntityValueResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(MetaEntityValueResponse)
+	err := c.cc.Invoke(ctx, UserMetaService_GetEntityValues_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *userMetaServiceClient) DeleteEntityValues(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*DeleteEntityValuesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteEntityValuesResponse)
+	err := c.cc.Invoke(ctx, UserMetaService_DeleteEntityValues_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *userMetaServiceClient) CreateEntity(ctx context.Context, in *CreateEntityRequest, opts ...grpc.CallOption) (*CreateEntityResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateEntityResponse)
+	err := c.cc.Invoke(ctx, UserMetaService_CreateEntity_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *userMetaServiceClient) CreateEntityValues(ctx context.Context, in *CreateEntityValueRequest, opts ...grpc.CallOption) (*CreateEntityValueResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateEntityValueResponse)
+	err := c.cc.Invoke(ctx, UserMetaService_CreateEntityValues_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // UserMetaServiceServer is the server API for UserMetaService service.
 // All implementations must embed UnimplementedUserMetaServiceServer
 // for forward compatibility.
@@ -1285,6 +1333,10 @@ type UserMetaServiceServer interface {
 	ListUserMetaNamespace(*ListUserMetaNamespaceRequest, grpc.ServerStreamingServer[ListUserMetaNamespaceResponse]) error
 	GetFieldSchema(context.Context, *GetFieldSchemaRequest) (*JsonSchemaResponse, error)
 	GetNamespaceSchema(context.Context, *GetNamespaceSchemaRequest) (*JsonSchemaResponse, error)
+	GetEntityValues(context.Context, *GetMetaEntityValuesRequest) (*MetaEntityValueResponse, error)
+	DeleteEntityValues(context.Context, *GetMetaEntityValuesRequest) (*DeleteEntityValuesResponse, error)
+	CreateEntity(context.Context, *CreateEntityRequest) (*CreateEntityResponse, error)
+	CreateEntityValues(context.Context, *CreateEntityValueRequest) (*CreateEntityValueResponse, error)
 	mustEmbedUnimplementedUserMetaServiceServer()
 }
 
@@ -1312,6 +1364,18 @@ func (UnimplementedUserMetaServiceServer) GetFieldSchema(context.Context, *GetFi
 }
 func (UnimplementedUserMetaServiceServer) GetNamespaceSchema(context.Context, *GetNamespaceSchemaRequest) (*JsonSchemaResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetNamespaceSchema not implemented")
+}
+func (UnimplementedUserMetaServiceServer) GetEntityValues(context.Context, *GetMetaEntityValuesRequest) (*MetaEntityValueResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetEntityValues not implemented")
+}
+func (UnimplementedUserMetaServiceServer) DeleteEntityValues(context.Context, *GetMetaEntityValuesRequest) (*DeleteEntityValuesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteEntityValues not implemented")
+}
+func (UnimplementedUserMetaServiceServer) CreateEntity(context.Context, *CreateEntityRequest) (*CreateEntityResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateEntity not implemented")
+}
+func (UnimplementedUserMetaServiceServer) CreateEntityValues(context.Context, *CreateEntityValueRequest) (*CreateEntityValueResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateEntityValues not implemented")
 }
 func (UnimplementedUserMetaServiceServer) mustEmbedUnimplementedUserMetaServiceServer() {}
 func (UnimplementedUserMetaServiceServer) testEmbeddedByValue()                         {}
@@ -1428,6 +1492,78 @@ func _UserMetaService_GetNamespaceSchema_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _UserMetaService_GetEntityValues_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetMetaEntityValuesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UserMetaServiceServer).GetEntityValues(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UserMetaService_GetEntityValues_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UserMetaServiceServer).GetEntityValues(ctx, req.(*GetMetaEntityValuesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _UserMetaService_DeleteEntityValues_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetMetaEntityValuesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UserMetaServiceServer).DeleteEntityValues(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UserMetaService_DeleteEntityValues_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UserMetaServiceServer).DeleteEntityValues(ctx, req.(*GetMetaEntityValuesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _UserMetaService_CreateEntity_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateEntityRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UserMetaServiceServer).CreateEntity(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UserMetaService_CreateEntity_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UserMetaServiceServer).CreateEntity(ctx, req.(*CreateEntityRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _UserMetaService_CreateEntityValues_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateEntityValueRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UserMetaServiceServer).CreateEntityValues(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UserMetaService_CreateEntityValues_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UserMetaServiceServer).CreateEntityValues(ctx, req.(*CreateEntityValueRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // UserMetaService_ServiceDesc is the grpc.ServiceDesc for UserMetaService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -1450,6 +1586,22 @@ var UserMetaService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetNamespaceSchema",
 			Handler:    _UserMetaService_GetNamespaceSchema_Handler,
+		},
+		{
+			MethodName: "GetEntityValues",
+			Handler:    _UserMetaService_GetEntityValues_Handler,
+		},
+		{
+			MethodName: "DeleteEntityValues",
+			Handler:    _UserMetaService_DeleteEntityValues_Handler,
+		},
+		{
+			MethodName: "CreateEntity",
+			Handler:    _UserMetaService_CreateEntity_Handler,
+		},
+		{
+			MethodName: "CreateEntityValues",
+			Handler:    _UserMetaService_CreateEntityValues_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/common/proto/idm/cells-idm_grpc.pb.go
+++ b/common/proto/idm/cells-idm_grpc.pb.go
@@ -1170,7 +1170,7 @@ const (
 	UserMetaService_GetFieldSchema_FullMethodName          = "/idm.UserMetaService/GetFieldSchema"
 	UserMetaService_GetNamespaceSchema_FullMethodName      = "/idm.UserMetaService/GetNamespaceSchema"
 	UserMetaService_GetEntityValues_FullMethodName         = "/idm.UserMetaService/GetEntityValues"
-	UserMetaService_DeleteEntityValues_FullMethodName      = "/idm.UserMetaService/DeleteEntityValues"
+	UserMetaService_DeleteEntityValuesData_FullMethodName  = "/idm.UserMetaService/DeleteEntityValuesData"
 	UserMetaService_CreateEntity_FullMethodName            = "/idm.UserMetaService/CreateEntity"
 	UserMetaService_CreateEntityValues_FullMethodName      = "/idm.UserMetaService/CreateEntityValues"
 )
@@ -1189,7 +1189,7 @@ type UserMetaServiceClient interface {
 	GetFieldSchema(ctx context.Context, in *GetFieldSchemaRequest, opts ...grpc.CallOption) (*JsonSchemaResponse, error)
 	GetNamespaceSchema(ctx context.Context, in *GetNamespaceSchemaRequest, opts ...grpc.CallOption) (*JsonSchemaResponse, error)
 	GetEntityValues(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*MetaEntityValueResponse, error)
-	DeleteEntityValues(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*DeleteEntityValuesResponse, error)
+	DeleteEntityValuesData(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*DeleteEntityValuesResponse, error)
 	CreateEntity(ctx context.Context, in *CreateEntityRequest, opts ...grpc.CallOption) (*CreateEntityResponse, error)
 	CreateEntityValues(ctx context.Context, in *CreateEntityValueRequest, opts ...grpc.CallOption) (*CreateEntityValueResponse, error)
 }
@@ -1290,10 +1290,10 @@ func (c *userMetaServiceClient) GetEntityValues(ctx context.Context, in *GetMeta
 	return out, nil
 }
 
-func (c *userMetaServiceClient) DeleteEntityValues(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*DeleteEntityValuesResponse, error) {
+func (c *userMetaServiceClient) DeleteEntityValuesData(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*DeleteEntityValuesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(DeleteEntityValuesResponse)
-	err := c.cc.Invoke(ctx, UserMetaService_DeleteEntityValues_FullMethodName, in, out, cOpts...)
+	err := c.cc.Invoke(ctx, UserMetaService_DeleteEntityValuesData_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1334,7 +1334,7 @@ type UserMetaServiceServer interface {
 	GetFieldSchema(context.Context, *GetFieldSchemaRequest) (*JsonSchemaResponse, error)
 	GetNamespaceSchema(context.Context, *GetNamespaceSchemaRequest) (*JsonSchemaResponse, error)
 	GetEntityValues(context.Context, *GetMetaEntityValuesRequest) (*MetaEntityValueResponse, error)
-	DeleteEntityValues(context.Context, *GetMetaEntityValuesRequest) (*DeleteEntityValuesResponse, error)
+	DeleteEntityValuesData(context.Context, *GetMetaEntityValuesRequest) (*DeleteEntityValuesResponse, error)
 	CreateEntity(context.Context, *CreateEntityRequest) (*CreateEntityResponse, error)
 	CreateEntityValues(context.Context, *CreateEntityValueRequest) (*CreateEntityValueResponse, error)
 	mustEmbedUnimplementedUserMetaServiceServer()
@@ -1368,8 +1368,8 @@ func (UnimplementedUserMetaServiceServer) GetNamespaceSchema(context.Context, *G
 func (UnimplementedUserMetaServiceServer) GetEntityValues(context.Context, *GetMetaEntityValuesRequest) (*MetaEntityValueResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetEntityValues not implemented")
 }
-func (UnimplementedUserMetaServiceServer) DeleteEntityValues(context.Context, *GetMetaEntityValuesRequest) (*DeleteEntityValuesResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method DeleteEntityValues not implemented")
+func (UnimplementedUserMetaServiceServer) DeleteEntityValuesData(context.Context, *GetMetaEntityValuesRequest) (*DeleteEntityValuesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteEntityValuesData not implemented")
 }
 func (UnimplementedUserMetaServiceServer) CreateEntity(context.Context, *CreateEntityRequest) (*CreateEntityResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateEntity not implemented")
@@ -1510,20 +1510,20 @@ func _UserMetaService_GetEntityValues_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
-func _UserMetaService_DeleteEntityValues_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _UserMetaService_DeleteEntityValuesData_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetMetaEntityValuesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(UserMetaServiceServer).DeleteEntityValues(ctx, in)
+		return srv.(UserMetaServiceServer).DeleteEntityValuesData(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: UserMetaService_DeleteEntityValues_FullMethodName,
+		FullMethod: UserMetaService_DeleteEntityValuesData_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(UserMetaServiceServer).DeleteEntityValues(ctx, req.(*GetMetaEntityValuesRequest))
+		return srv.(UserMetaServiceServer).DeleteEntityValuesData(ctx, req.(*GetMetaEntityValuesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1592,8 +1592,8 @@ var UserMetaService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _UserMetaService_GetEntityValues_Handler,
 		},
 		{
-			MethodName: "DeleteEntityValues",
-			Handler:    _UserMetaService_DeleteEntityValues_Handler,
+			MethodName: "DeleteEntityValuesData",
+			Handler:    _UserMetaService_DeleteEntityValuesData_Handler,
 		},
 		{
 			MethodName: "CreateEntity",

--- a/common/proto/idm/cells-idm_grpc.stub.pb.go
+++ b/common/proto/idm/cells-idm_grpc.stub.pb.go
@@ -418,8 +418,8 @@ func (s *UserMetaServiceStub) Invoke(ctx context.Context, method string, args in
 		} else {
 			e = er
 		}
-	case "/idm.UserMetaService/DeleteEntityValues":
-		resp, er := s.UserMetaServiceServer.DeleteEntityValues(ctx, args.(*GetMetaEntityValuesRequest))
+	case "/idm.UserMetaService/DeleteEntityValuesData":
+		resp, er := s.UserMetaServiceServer.DeleteEntityValuesData(ctx, args.(*GetMetaEntityValuesRequest))
 		if er == nil {
 			e = stubs.AssignToInterface(resp, reply)
 		} else {

--- a/common/proto/idm/cells-idm_grpc.stub.pb.go
+++ b/common/proto/idm/cells-idm_grpc.stub.pb.go
@@ -411,6 +411,34 @@ func (s *UserMetaServiceStub) Invoke(ctx context.Context, method string, args in
 		} else {
 			e = er
 		}
+	case "/idm.UserMetaService/GetEntityValues":
+		resp, er := s.UserMetaServiceServer.GetEntityValues(ctx, args.(*GetMetaEntityValuesRequest))
+		if er == nil {
+			e = stubs.AssignToInterface(resp, reply)
+		} else {
+			e = er
+		}
+	case "/idm.UserMetaService/DeleteEntityValues":
+		resp, er := s.UserMetaServiceServer.DeleteEntityValues(ctx, args.(*GetMetaEntityValuesRequest))
+		if er == nil {
+			e = stubs.AssignToInterface(resp, reply)
+		} else {
+			e = er
+		}
+	case "/idm.UserMetaService/CreateEntity":
+		resp, er := s.UserMetaServiceServer.CreateEntity(ctx, args.(*CreateEntityRequest))
+		if er == nil {
+			e = stubs.AssignToInterface(resp, reply)
+		} else {
+			e = er
+		}
+	case "/idm.UserMetaService/CreateEntityValues":
+		resp, er := s.UserMetaServiceServer.CreateEntityValues(ctx, args.(*CreateEntityValueRequest))
+		if er == nil {
+			e = stubs.AssignToInterface(resp, reply)
+		} else {
+			e = er
+		}
 	default:
 		e = errors.New(method + " not implemented")
 	}

--- a/common/proto/idm/cells-idm_grpc.stub.pb.go
+++ b/common/proto/idm/cells-idm_grpc.stub.pb.go
@@ -418,8 +418,8 @@ func (s *UserMetaServiceStub) Invoke(ctx context.Context, method string, args in
 		} else {
 			e = er
 		}
-	case "/idm.UserMetaService/DeleteEntityValuesData":
-		resp, er := s.UserMetaServiceServer.DeleteEntityValuesData(ctx, args.(*GetMetaEntityValuesRequest))
+	case "/idm.UserMetaService/DeleteEntity":
+		resp, er := s.UserMetaServiceServer.DeleteEntity(ctx, args.(*GetMetaEntityValuesRequest))
 		if er == nil {
 			e = stubs.AssignToInterface(resp, reply)
 		} else {

--- a/common/proto/idm/meta-ns.go
+++ b/common/proto/idm/meta-ns.go
@@ -85,6 +85,7 @@ func (d *metaNsDef) DefaultHide() bool {
 	return d.Hide
 }
 
+// legacy to be removed
 func (d *metaNsDef) GetEntityId() string {
 	return ""
 }

--- a/common/proto/idm/meta-ns.go
+++ b/common/proto/idm/meta-ns.go
@@ -52,7 +52,6 @@ type MetaNsDef struct {
 	Type   string `json:"type,omitempty"`
 	Entity struct {
 		EntityID string `json:"entity_id,omitempty"`
-		Entity   string `json:"entity,omitempty"`
 	} `json:"entity,omitempty"`
 	Data struct {
 		Items []struct {
@@ -60,8 +59,8 @@ type MetaNsDef struct {
 			Value string `json:"value"`
 			Color string `json:"color,omitempty"`
 		} `json:"items,omitempty"`
-		Steps  bool     `json:"steps,omitempty"`
-		Entity []string `json:"entity,omitempty"`
+		Steps       bool     `json:"steps,omitempty"`
+		EntityItems []string `json:"entityItems,omitempty"`
 	} `json:"data,omitempty"`
 	GroupName string `json:"groupName,omitempty"`
 	Steps     bool   `json:"steps,omitempty"`
@@ -124,7 +123,7 @@ func (d *MetaNsDef) GetItems() []string {
 }
 
 func (d *MetaNsDef) GetEntities() []string {
-	return d.Data.Entity
+	return d.Data.EntityItems
 }
 
 func (d *MetaNsDef) GetEntityId() string {
@@ -138,7 +137,7 @@ func (d *MetaNsDef) SetEntityId(entityID string) {
 func (m *UserMetaNamespace) UnmarshallDefinition() (MetaNamespaceDefinition, error) {
 	var fullDef MetaNsDef
 	if e := json.Unmarshal([]byte(m.JsonDefinition), &fullDef); e == nil {
-		if fullDef.Entity.EntityID != "" || len(fullDef.Data.Items) > 0 || len(fullDef.Data.Entity) > 0 {
+		if fullDef.Entity.EntityID != "" || len(fullDef.Data.Items) > 0 || len(fullDef.Data.EntityItems) > 0 {
 			return &fullDef, nil
 		}
 	}

--- a/common/proto/idm/meta-ns.go
+++ b/common/proto/idm/meta-ns.go
@@ -29,6 +29,9 @@ type MetaNamespaceDefinition interface {
 	GetData() interface{}
 	GetSteps() bool
 	DefaultHide() bool
+	GetEntityId() string
+	GetItems() []string
+	GetEntities() []string
 }
 
 type TypedUserMetaNamespace struct {
@@ -36,13 +39,36 @@ type TypedUserMetaNamespace struct {
 	*UserMetaNamespace
 }
 
+// metaNsDef is the legacy internal type for backward compatibility
 type metaNsDef struct {
-	Type  string
+	Type  string      `json:"type,omitempty"`
 	Data  interface{} `json:"data,omitempty"`
 	Steps bool        `json:"steps,omitempty"`
 	Hide  bool        `json:"hide,omitempty"`
 }
 
+// MetaNsDef is the full structured type with entity support
+type MetaNsDef struct {
+	Type   string `json:"type,omitempty"`
+	Entity struct {
+		EntityID string `json:"entity_id,omitempty"`
+		Entity   string `json:"entity,omitempty"`
+	} `json:"entity,omitempty"`
+	Data struct {
+		Items []struct {
+			Key   string `json:"key"`
+			Value string `json:"value"`
+			Color string `json:"color,omitempty"`
+		} `json:"items,omitempty"`
+		Steps  bool     `json:"steps,omitempty"`
+		Entity []string `json:"entity,omitempty"`
+	} `json:"data,omitempty"`
+	GroupName string `json:"groupName,omitempty"`
+	Steps     bool   `json:"steps,omitempty"`
+	Hide      bool   `json:"hide,omitempty"`
+}
+
+// Implement MetaNamespaceDefinition interface for legacy metaNsDef
 func (d *metaNsDef) GetType() string {
 	return d.Type
 }
@@ -59,11 +85,67 @@ func (d *metaNsDef) DefaultHide() bool {
 	return d.Hide
 }
 
-func (m *UserMetaNamespace) UnmarshallDefinition() (MetaNamespaceDefinition, error) {
-	var def metaNsDef
-	if e := json.Unmarshal([]byte(m.JsonDefinition), &def); e != nil {
-		return nil, e
-	} else {
-		return &def, nil
+func (d *metaNsDef) GetEntityId() string {
+	return ""
+}
+
+func (d *metaNsDef) GetItems() []string {
+	return nil
+}
+
+func (d *metaNsDef) GetEntities() []string {
+	return nil
+}
+
+// Implement MetaNamespaceDefinition interface for MetaNsDef
+func (d *MetaNsDef) GetType() string {
+	return d.Type
+}
+
+func (d *MetaNsDef) GetData() interface{} {
+	return d.Data
+}
+
+func (d *MetaNsDef) GetSteps() bool {
+	return d.Steps
+}
+
+func (d *MetaNsDef) DefaultHide() bool {
+	return d.Hide
+}
+
+func (d *MetaNsDef) GetItems() []string {
+	var items []string
+	for _, item := range d.Data.Items {
+		items = append(items, item.Value)
 	}
+	return items
+}
+
+func (d *MetaNsDef) GetEntities() []string {
+	return d.Data.Entity
+}
+
+func (d *MetaNsDef) GetEntityId() string {
+	return d.Entity.EntityID
+}
+
+func (d *MetaNsDef) SetEntityId(entityID string) {
+	d.Entity.EntityID = entityID
+}
+
+func (m *UserMetaNamespace) UnmarshallDefinition() (MetaNamespaceDefinition, error) {
+	var fullDef MetaNsDef
+	if e := json.Unmarshal([]byte(m.JsonDefinition), &fullDef); e == nil {
+		if fullDef.Entity.EntityID != "" || len(fullDef.Data.Items) > 0 || len(fullDef.Data.Entity) > 0 {
+			return &fullDef, nil
+		}
+	}
+
+	// Default to legacy metaNsDef for backward compatibility
+	var legacyDef metaNsDef
+	if e := json.Unmarshal([]byte(m.JsonDefinition), &legacyDef); e != nil {
+		return nil, e
+	}
+	return &legacyDef, nil
 }

--- a/frontend/assets/access.settings/res/i18n/admin/en-us.all.json
+++ b/frontend/assets/access.settings/res/i18n/admin/en-us.all.json
@@ -863,6 +863,9 @@
   "metadata.type.css_label": {
     "other": "Color Labels"
   },
+  "metadata.type.auto_complete" :{
+    "other": "Auto Complete"
+  },
   "metadata.type.tags": {
     "other": "Extensible Tags"
   },

--- a/frontend/assets/access.settings/res/js/AdminWorkspaces/editor/MetaNamespace.js
+++ b/frontend/assets/access.settings/res/js/AdminWorkspaces/editor/MetaNamespace.js
@@ -25,6 +25,7 @@ import PropTypes from 'prop-types';
 import Pydio from 'pydio'
 import { Dialog, FlatButton, Toggle } from 'material-ui'
 import { muiThemeable } from 'material-ui/styles'
+import { MantineProvider } from '@mantine/core';
 import { IdmUserMetaNamespace, ServiceResourcePolicy, UserMetaServiceApi } from 'cells-sdk'
 import Metadata from '../model/Metadata'
 import PydioApi from 'pydio/http/api'
@@ -256,6 +257,15 @@ class MetaNamespace extends React.Component {
         return defaultValue;
     }
 
+    setEntityValues(valueStr) {
+        const { namespace } = this.state;
+        const def = JSON.parse(namespace.JsonDefinition);
+        const entityValues = valueStr.split(',').map(s => s.trim()).filter(Boolean);
+        const data = { ...def.data, entity: entityValues };
+        namespace.JsonDefinition = JSON.stringify({ ...def, data })
+        this.setState({ namespace });    
+    }
+
     getCommaSeparatedEntities () {
         const { namespace } = this.state;
         try {
@@ -314,7 +324,7 @@ class MetaNamespace extends React.Component {
         if (!metaModule) {
             return null;
         }
-        const { TypeEditor } = metaModule;
+        const { TypeEditor, TagsCloudInput } = metaModule;
         let title;
         if (namespace.Label) {
             title = namespace.Label;
@@ -419,16 +429,16 @@ class MetaNamespace extends React.Component {
                     readOnly={readonly}
                     variant={"v2"}
                 />
-                {type === 'tag_cloud' && (
-                    <ModernTextField
-                        floatingLabelText={m('tag_cloud.entity')}
-                        value={this.getAdditionalData({ entity: '' }).entity || ''}
-                        onChange={(e, v) => { this.setAdditionalDataKey('entity', v) }}
-                        fullWidth={true}
-                        readOnly={readonly}
-                        variant={"v2"}
-                        hintText={m('tag_cloud.entity.hint')}
-                    />
+                {(type === 'tag_cloud' || type === 'auto_complete') && (
+                    <MantineProvider>
+                        <TagsCloudInput
+                            label={m('tag_cloud.entity')}
+                            disabled={false}
+                            value={this.getCommaSeparatedEntities()}
+                            onCommitChange={(v) => this.setEntityValues(v)} 
+                            hintText={m('tag_cloud.entity.hint')}
+                        />
+                    </MantineProvider>
                 )}
                 {USERMETA_PROMPT_FF && (
                     namespace?.Namespace?.toString().length > 0 &&
@@ -512,7 +522,6 @@ class MetaNamespace extends React.Component {
                     menuProps={{ maxHeight: 300, overflowY: 'auto' }}
                 />
             </Dialog>
-
         );
     }
 

--- a/frontend/assets/access.settings/res/js/AdminWorkspaces/editor/MetaNamespace.js
+++ b/frontend/assets/access.settings/res/js/AdminWorkspaces/editor/MetaNamespace.js
@@ -261,7 +261,7 @@ class MetaNamespace extends React.Component {
         const { namespace } = this.state;
         const def = JSON.parse(namespace.JsonDefinition);
         const entityValues = valueStr.split(',').map(s => s.trim()).filter(Boolean);
-        const data = { ...def.data, entity: entityValues };
+        const data = { ...def.data, entityItems: entityValues };
         namespace.JsonDefinition = JSON.stringify({ ...def, data })
         this.setState({ namespace });    
     }

--- a/frontend/assets/access.settings/res/js/AdminWorkspaces/editor/MetaNamespace.js
+++ b/frontend/assets/access.settings/res/js/AdminWorkspaces/editor/MetaNamespace.js
@@ -271,10 +271,10 @@ class MetaNamespace extends React.Component {
         try {
             const parsed = JSON.parse(namespace.JsonDefinition || '{}');
             const entityStr = parsed && parsed.data && parsed.data.entity;
-            if (!entityStr || typeof entityStr !== 'string') return [];
-            return entityStr.split(',').map(s => s.trim()).filter(Boolean);
+            if (!entityStr || typeof entityStr !== 'string') return '';
+            return entityStr;
         } catch (e) {
-            return [];
+            return '';
         }
     }
 

--- a/frontend/assets/meta.user/res/js/TypeEditor.js
+++ b/frontend/assets/meta.user/res/js/TypeEditor.js
@@ -27,17 +27,20 @@ import {muiThemeable} from 'material-ui/styles'
 const {ModernSelectField, ModernTextField, ThemedModernStyles} = Pydio.requireLib('hoc');
 
 const MetaTypes = {
-    "string":       "Text",
-    "textarea":     "Long Text",
-    "integer":      "Number",
-    "boolean":      "Boolean",
-    "date":         "Date",
-    "choice":       "Selection",
-    "tags":         "Extensible Tags",
-    "stars_rate":   "Stars Rating",
-    "css_label":    "Color Labels",
-    "json":         "JSON",
-    "url":          "External URL"
+    "boolean": "Boolean",
+    "choice": "Selection",
+    "css_label": "Color Labels",
+    "date": "Date",
+    "integer": "Number",
+    "json": "JSON",
+    "multi_value": "Multi Value Selection",
+    "stars_rate": "Stars Rating",
+    "string": "Text",
+    "tag_cloud": "Tag Cloud",
+    "tags": "Extensible Tags",
+    "textarea": "Long Text",
+    "url": "External URL",
+    "auto_complete": "Auto complete"
 }
 
 class TypeEditor extends React.Component {

--- a/frontend/assets/meta.user/res/js/fieldsv2/TagsCloudInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/TagsCloudInput.tsx
@@ -21,7 +21,7 @@
 import React, { useEffect, useState } from 'react'
 import { TagsInput } from '@mantine/core'
 import { StringItemsInputProps } from "./CommonInputProps";
-import PropTypes from 'prop-types';
+
 /**
  * @typedef {Object} TagsCloudInputProps
  * @property {string} name
@@ -78,8 +78,12 @@ export const TagsCloudInput: React.FC<StringItemsInputProps> = ({
     }, [name])
 
     const onChangeJoin = (values: string[]) => {
-        const joined = values.join(',')
-        setLocalValue(joined.split(',').filter(v => v))
+        if(values.length > 0 ) {
+            const joined = values.join(',')
+            setLocalValue(joined.split(',').filter(v => v))
+        } else {
+            setLocalValue([])
+        }
     }
 
     return <TagsInput
@@ -94,17 +98,4 @@ export const TagsCloudInput: React.FC<StringItemsInputProps> = ({
             onCommitChange(formatValueArrayToString([...localValue, value]));
         }}
     />
-}
-
-TagsCloudInput.propTypes = {
-    name: PropTypes.string,
-    label: PropTypes.string,
-    description: PropTypes.string,
-    placeholder: PropTypes.string,
-    disabled: PropTypes.bool,
-    dataLoader: PropTypes.func,
-    requestToggleClose: PropTypes.bool,
-    errorText: PropTypes.string,
-    value: PropTypes.string,
-    onCommitChange: PropTypes.func,
 }

--- a/frontend/assets/meta.user/res/js/fieldsv2/TagsCloudInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/TagsCloudInput.tsx
@@ -21,6 +21,20 @@
 import React, { useEffect, useState } from 'react'
 import { TagsInput } from '@mantine/core'
 import { StringItemsInputProps } from "./CommonInputProps";
+import PropTypes from 'prop-types';
+/**
+ * @typedef {Object} TagsCloudInputProps
+ * @property {string} name
+ * @property {string} label
+ * @property {string} description
+ * @property {string} placeholder
+ * @property {boolean} disabled
+ * @property {function} dataLoader
+ * @property {boolean} requestToggleClose
+ * @property {string} errorText
+ * @property {string} value
+ * @property {function} onCommitChange
+ */
 
 const formatValueStringToArray = (value: string) => {
     return (value || '').split(',').filter((tag) => tag.trim());
@@ -30,6 +44,9 @@ const formatValueArrayToString = (value: string[]) => {
     return value.filter(v => v).join(',')
 }
 
+/**
+ * @param {TagsCloudInputProps} props
+ */
 export const TagsCloudInput: React.FC<StringItemsInputProps> = ({
     name,
     label,
@@ -77,4 +94,17 @@ export const TagsCloudInput: React.FC<StringItemsInputProps> = ({
             onCommitChange(formatValueArrayToString([...localValue, value]));
         }}
     />
+}
+
+TagsCloudInput.propTypes = {
+    name: PropTypes.string,
+    label: PropTypes.string,
+    description: PropTypes.string,
+    placeholder: PropTypes.string,
+    disabled: PropTypes.bool,
+    dataLoader: PropTypes.func,
+    requestToggleClose: PropTypes.bool,
+    errorText: PropTypes.string,
+    value: PropTypes.string,
+    onCommitChange: PropTypes.func,
 }

--- a/frontend/assets/meta.user/res/js/index.js
+++ b/frontend/assets/meta.user/res/js/index.js
@@ -30,7 +30,6 @@ import {
     useMetadataContext
 }  from "./context/metadata";
 import { TagsCloudInput } from './fieldsv2/TagsCloudInput'
-import { MetadataContextProvider }  from "./context/metadata";
 
 export {
     Renderer,

--- a/frontend/assets/meta.user/res/js/index.js
+++ b/frontend/assets/meta.user/res/js/index.js
@@ -29,6 +29,8 @@ import {
     MetadataContextProvider,
     useMetadataContext
 }  from "./context/metadata";
+import { TagsCloudInput } from './fieldsv2/TagsCloudInput'
+import { MetadataContextProvider }  from "./context/metadata";
 
 export {
     Renderer,
@@ -39,6 +41,7 @@ export {
     UserMetaPanelV2,
     MetaClient,
     TypeEditor,
+    TagsCloudInput,
     MetadataContextProvider,
     useMetadataContext,
 }

--- a/idm/meta/client.go
+++ b/idm/meta/client.go
@@ -88,7 +88,7 @@ type UserMetaClient interface {
 	GetEntityValues(ctx context.Context, entityID string) ([]*idm.EntityValue, error)
 	IsContextEditable(ctx context.Context, resourceId string, policies []*serviceproto.ResourcePolicy) bool
 	MatchPolicies(ctx context.Context, resourceId string, policies []*serviceproto.ResourcePolicy, action serviceproto.ResourcePolicyAction, subjects ...string) bool
-	DeleteEntityValuesData(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error)
+	DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error)
 	CreateEntity(ctx context.Context, input *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error)
 	CreateEntityValues(ctx context.Context, input *idm.CreateEntityValueRequest) (*idm.CreateEntityValueResponse, error)
 }
@@ -368,11 +368,11 @@ func (u *umClient) GetEntityValues(ctx context.Context, entityID string) ([]*idm
 	return resp.EntityValue, nil
 }
 
-func (u *umClient) DeleteEntityValuesData(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
+func (u *umClient) DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
 	req := &idm.GetMetaEntityValuesRequest{
 		EntityUuid: entityID,
 	}
-	resp, err := u.ServiceClient(ctx).DeleteEntityValuesData(ctx, req)
+	resp, err := u.ServiceClient(ctx).DeleteEntity(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/idm/meta/client.go
+++ b/idm/meta/client.go
@@ -85,9 +85,12 @@ type UserMetaClient interface {
 	ServiceClient(ctx context.Context) idm.UserMetaServiceClient
 	DraftMetaNamespace(ctx context.Context, ctxWorkspace *idm.Workspace) (string, bool)
 	TagValuesHandler() TagsValuesClient
-
+	GetEntityValues(ctx context.Context, entityID string) ([]*idm.EntityValue, error)
 	IsContextEditable(ctx context.Context, resourceId string, policies []*serviceproto.ResourcePolicy) bool
 	MatchPolicies(ctx context.Context, resourceId string, policies []*serviceproto.ResourcePolicy, action serviceproto.ResourcePolicyAction, subjects ...string) bool
+	DeleteEntityValues(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error)
+	CreateEntity(ctx context.Context, input *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error)
+	CreateEntityValues(ctx context.Context, input *idm.CreateEntityValueRequest) (*idm.CreateEntityValueResponse, error)
 }
 
 type umClient struct {
@@ -352,6 +355,47 @@ func (u *umClient) TagValuesHandler() TagsValuesClient {
 // PoliciesForMeta is an empty handler for PolicyChecker
 func (u *umClient) PoliciesForMeta(_ context.Context, _ string, _ interface{}) (policies []*serviceproto.ResourcePolicy, e error) {
 	return
+}
+
+func (u *umClient) GetEntityValues(ctx context.Context, entityID string) ([]*idm.EntityValue, error) {
+	req := &idm.GetMetaEntityValuesRequest{
+		EntityUuid: entityID,
+	}
+	resp, err := u.ServiceClient(ctx).GetEntityValues(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.EntityValue, nil
+}
+
+func (u *umClient) DeleteEntityValues(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
+	req := &idm.GetMetaEntityValuesRequest{
+		EntityUuid: entityID,
+	}
+	resp, err := u.ServiceClient(ctx).DeleteEntityValues(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (u *umClient) CreateEntity(ctx context.Context, input *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error) {
+	req := input
+	resp, err := u.ServiceClient(ctx).CreateEntity(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+
+}
+
+func (u *umClient) CreateEntityValues(ctx context.Context, input *idm.CreateEntityValueRequest) (*idm.CreateEntityValueResponse, error) {
+	req := input
+	resp, err := u.ServiceClient(ctx).CreateEntityValues(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 // fromNodeMeta matches allowed namespaces from incoming node Metadata

--- a/idm/meta/client.go
+++ b/idm/meta/client.go
@@ -88,7 +88,7 @@ type UserMetaClient interface {
 	GetEntityValues(ctx context.Context, entityID string) ([]*idm.EntityValue, error)
 	IsContextEditable(ctx context.Context, resourceId string, policies []*serviceproto.ResourcePolicy) bool
 	MatchPolicies(ctx context.Context, resourceId string, policies []*serviceproto.ResourcePolicy, action serviceproto.ResourcePolicyAction, subjects ...string) bool
-	DeleteEntityValues(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error)
+	DeleteEntityValuesData(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error)
 	CreateEntity(ctx context.Context, input *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error)
 	CreateEntityValues(ctx context.Context, input *idm.CreateEntityValueRequest) (*idm.CreateEntityValueResponse, error)
 }
@@ -368,11 +368,11 @@ func (u *umClient) GetEntityValues(ctx context.Context, entityID string) ([]*idm
 	return resp.EntityValue, nil
 }
 
-func (u *umClient) DeleteEntityValues(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
+func (u *umClient) DeleteEntityValuesData(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
 	req := &idm.GetMetaEntityValuesRequest{
 		EntityUuid: entityID,
 	}
-	resp, err := u.ServiceClient(ctx).DeleteEntityValues(ctx, req)
+	resp, err := u.ServiceClient(ctx).DeleteEntityValuesData(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/idm/meta/dao.go
+++ b/idm/meta/dao.go
@@ -78,7 +78,7 @@ type EntityValueDAO interface {
 	CreateEntityValues(ctx context.Context, values []*idm.EntityValue) ([]*idm.EntityValue, error)
 	CreateEntityValue(ctx context.Context, value *idm.EntityValue) (*idm.EntityValue, error)
 	GetEntityValues(ctx context.Context, entityUuid string) ([]*idm.EntityValue, error)
-	DeleteEntityValuesData(ctx context.Context, entityUuid string) (*idm.DeleteEntityValuesResponse, error)
+	DeleteEntity(ctx context.Context, entityUuid string) (*idm.DeleteEntityValuesResponse, error)
 
 	// Link operations
 	LinkMetaValue(ctx context.Context, metaUuid string, valueUuid string) error

--- a/idm/meta/dao.go
+++ b/idm/meta/dao.go
@@ -75,8 +75,10 @@ type EntityValueDAO interface {
 	GetEntity(ctx context.Context, entityUuid string) (*idm.MetaEntity, error)
 
 	// Entity Value operations
+	CreateEntityValues(ctx context.Context, values []*idm.EntityValue) ([]*idm.EntityValue, error)
 	CreateEntityValue(ctx context.Context, value *idm.EntityValue) (*idm.EntityValue, error)
 	GetEntityValues(ctx context.Context, entityUuid string) ([]*idm.EntityValue, error)
+	DeleteEntityValues(ctx context.Context, entityUuid string) (*idm.DeleteEntityValuesResponse, error)
 
 	// Link operations
 	LinkMetaValue(ctx context.Context, metaUuid string, valueUuid string) error

--- a/idm/meta/dao.go
+++ b/idm/meta/dao.go
@@ -78,7 +78,7 @@ type EntityValueDAO interface {
 	CreateEntityValues(ctx context.Context, values []*idm.EntityValue) ([]*idm.EntityValue, error)
 	CreateEntityValue(ctx context.Context, value *idm.EntityValue) (*idm.EntityValue, error)
 	GetEntityValues(ctx context.Context, entityUuid string) ([]*idm.EntityValue, error)
-	DeleteEntityValues(ctx context.Context, entityUuid string) (*idm.DeleteEntityValuesResponse, error)
+	DeleteEntityValuesData(ctx context.Context, entityUuid string) (*idm.DeleteEntityValuesResponse, error)
 
 	// Link operations
 	LinkMetaValue(ctx context.Context, metaUuid string, valueUuid string) error

--- a/idm/meta/dao/sql/ev-sql.go
+++ b/idm/meta/dao/sql/ev-sql.go
@@ -267,7 +267,7 @@ func (s *evSqlImpl) GetMetaEntityValues(ctx context.Context, metaUuid string) ([
 	return values, nil
 }
 
-func (s *evSqlImpl) DeleteEntityValuesData(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
+func (s *evSqlImpl) DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
 	if err := s.validateUUIDs(entityID); err != nil {
 		return nil, err
 	}

--- a/idm/meta/dao/sql/ev-sql.go
+++ b/idm/meta/dao/sql/ev-sql.go
@@ -103,7 +103,6 @@ func (u *Entities) AsEntity(res *idm.MetaEntity) *idm.MetaEntity {
 }
 
 func (u *Entities) FromEntity(res *idm.MetaEntity) *Entities {
-	u.UUID = res.Uuid
 	if u.UUID == "" {
 		u.UUID = uuid.New().String()
 	}
@@ -115,6 +114,14 @@ func (u *Entities) FromEntity(res *idm.MetaEntity) *Entities {
 
 func (s *evSqlImpl) CreateEntity(ctx context.Context, entity *idm.MetaEntity) (*idm.MetaEntity, error) {
 	res := (&Entities{}).FromEntity(entity)
+	// //check if entity with the same label exists
+	// var existing Entities
+	// tx := s.Session(ctx).Where("label = ?", res.Label).First(&existing)
+	// if tx.Error == nil {
+	// 	// if a row exists with the same label
+	// 	return nil, evTagError(errors.New("entity with the same label already exists"))
+	// }
+
 	tx := s.Session(ctx).Create(res)
 	if tx.Error != nil {
 		return nil, evTagError(tx.Error)
@@ -177,6 +184,24 @@ func (s *evSqlImpl) CreateEntityValue(ctx context.Context, value *idm.EntityValu
 	return model.AsEntityValue(&idm.EntityValue{}), nil
 }
 
+func (s *evSqlImpl) CreateEntityValues(ctx context.Context, values []*idm.EntityValue) ([]*idm.EntityValue, error) {
+	if len(values) == 0 {
+		return []*idm.EntityValue{}, nil
+	}
+
+	createdValues := make([]*idm.EntityValue, 0, len(values))
+
+	for _, value := range values {
+		created, err := s.CreateEntityValue(ctx, value)
+		if err != nil {
+			return nil, err
+		}
+		createdValues = append(createdValues, created)
+	}
+
+	return createdValues, nil
+}
+
 func (s *evSqlImpl) GetEntityValues(ctx context.Context, entityUuid string) ([]*idm.EntityValue, error) {
 	var models []*EntityValues
 	tx := s.Session(ctx).Where(&EntityValues{EntityUUID: entityUuid}).Find(&models)
@@ -194,6 +219,9 @@ func (s *evSqlImpl) GetEntityValues(ctx context.Context, entityUuid string) ([]*
 
 func (s *evSqlImpl) validateUUIDs(uuids ...string) error {
 	for _, u := range uuids {
+		if u == "" {
+			return evTagError(errors.New("uuid cannot be empty"))
+		}
 		if _, err := uuid.Parse(u); err != nil {
 			return evTagError(errors.New("invalid uuid: " + u))
 		}
@@ -237,4 +265,32 @@ func (s *evSqlImpl) GetMetaEntityValues(ctx context.Context, metaUuid string) ([
 	}
 
 	return values, nil
+}
+
+func (s *evSqlImpl) DeleteEntityValues(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
+	if err := s.validateUUIDs(entityID); err != nil {
+		return nil, err
+	}
+	MetaValuesRelsModel := &MetaValuesRel{}
+
+	tx := s.Session(ctx).Where("e_value_uuid IN (SELECT uuid FROM idm_usr_meta_entity_values WHERE entity_uuid = ?)", entityID).Delete(MetaValuesRelsModel)
+	if tx.Error != nil {
+		return nil, evTagError(tx.Error)
+	}
+
+	EntityValuesModel := &EntityValues{}
+	tx = s.Session(ctx).Where(&EntityValues{EntityUUID: entityID}).Delete(EntityValuesModel)
+	if tx.Error != nil {
+		return nil, evTagError(tx.Error)
+	}
+
+	EntitiesModel := &Entities{}
+	tx = s.Session(ctx).Where(&Entities{UUID: entityID}).Delete(EntitiesModel)
+	if tx.Error != nil {
+		return nil, evTagError(tx.Error)
+	}
+
+	return &idm.DeleteEntityValuesResponse{
+		RowsDeleted: tx.RowsAffected,
+	}, nil
 }

--- a/idm/meta/dao/sql/ev-sql.go
+++ b/idm/meta/dao/sql/ev-sql.go
@@ -267,13 +267,14 @@ func (s *evSqlImpl) GetMetaEntityValues(ctx context.Context, metaUuid string) ([
 	return values, nil
 }
 
-func (s *evSqlImpl) DeleteEntityValues(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
+func (s *evSqlImpl) DeleteEntityValuesData(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
 	if err := s.validateUUIDs(entityID); err != nil {
 		return nil, err
 	}
-	MetaValuesRelsModel := &MetaValuesRel{}
 
-	tx := s.Session(ctx).Where("e_value_uuid IN (SELECT uuid FROM idm_usr_meta_entity_values WHERE entity_uuid = ?)", entityID).Delete(MetaValuesRelsModel)
+	subQuery := s.Session(ctx).Model(&EntityValues{}).Select("uuid").Where("entity_uuid = ?", entityID)
+
+	tx := s.Session(ctx).Where("e_value_uuid IN (?)", subQuery).Delete(&MetaValuesRel{})
 	if tx.Error != nil {
 		return nil, evTagError(tx.Error)
 	}

--- a/idm/meta/dao/sql/ev-sql_test.go
+++ b/idm/meta/dao/sql/ev-sql_test.go
@@ -178,7 +178,7 @@ func TestEntityValueCrud(t *testing.T) {
 
 			//delete all the entitites, values
 
-			deletedRows, err := mockDAO.DeleteEntityValuesData(ctx, createdEntity.Uuid)
+			deletedRows, err := mockDAO.DeleteEntity(ctx, createdEntity.Uuid)
 
 			So(err, ShouldBeNil)
 			So(deletedRows, ShouldNotBeEmpty)

--- a/idm/meta/dao/sql/ev-sql_test.go
+++ b/idm/meta/dao/sql/ev-sql_test.go
@@ -156,6 +156,34 @@ func TestEntityValueCrud(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(values, ShouldHaveLength, 2)
 		})
+
+		Convey("Delete Entity values and meta relations", func() {
+			createdEntity, err := createTestEntity(ctx, mockDAO, "Link Entity")
+			So(err, ShouldBeNil)
+
+			value1, err := createTestEntityValue(ctx, mockDAO, "Value 1", createdEntity.Uuid)
+			So(err, ShouldBeNil)
+
+			value2, err := createTestEntityValue(ctx, mockDAO, "Value 2", createdEntity.Uuid)
+			So(err, ShouldBeNil)
+
+			metaWithId, err := createTestMeta(ctx, "test-node", "test-namespace")
+			So(err, ShouldBeNil)
+
+			err = mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value1.Uuid)
+			So(err, ShouldBeNil)
+
+			err = mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value2.Uuid)
+			So(err, ShouldBeNil)
+
+			//delete all the entitites, values
+
+			deletedRows, err := mockDAO.DeleteEntityValuesData(ctx, createdEntity.Uuid)
+
+			So(err, ShouldBeNil)
+			So(deletedRows, ShouldNotBeEmpty)
+
+		})
 	})
 }
 

--- a/idm/meta/dao/sql/ns-sql_test.go
+++ b/idm/meta/dao/sql/ns-sql_test.go
@@ -151,7 +151,7 @@ func TestNSNewFields(t *testing.T) {
 			mockDAO, err0 := manager.Resolve[meta.NamespaceDAO](ctx)
 			So(err0, ShouldBeNil)
 			tv := json_schema.LegacyTypeToLabel([]byte("{\"type\":\"string\"}"))
-			jsb, err1 := json_schema.GetJsonSchema(tv)
+			jsb, err1 := json_schema.GetJsonSchema(tv, "")
 			So(err1, ShouldBeNil)
 			schemaAsJson := datatypes.JSON(jsb)
 			jsStruct, err := json_schema.JsonToProtoStruct(&schemaAsJson)
@@ -202,7 +202,7 @@ func TestNSDeleteWithJsonSchema(t *testing.T) {
 			nsKey := "namespace-delete-jsonschema"
 			nsLabel := "label-delete-jsonschema"
 
-			jsBytes, err := json_schema.GetJsonSchema(json_schema.LegacyTypeToLabel([]byte("{\"type\":\"string\"}")))
+			jsBytes, err := json_schema.GetJsonSchema(json_schema.LegacyTypeToLabel([]byte("{\"type\":\"string\"}")), "")
 			So(err, ShouldBeNil)
 			jsAsJSON := datatypes.JSON(jsBytes)
 			jsStruct, err := json_schema.JsonToProtoStruct(&jsAsJSON)

--- a/idm/meta/grpc/handler.go
+++ b/idm/meta/grpc/handler.go
@@ -445,14 +445,14 @@ func (h *Handler) GetEntityValues(ctx context.Context, req *idm.GetMetaEntityVal
 	}, nil
 }
 
-func (h *Handler) DeleteEntityValuesData(ctx context.Context, req *idm.GetMetaEntityValuesRequest) (*idm.DeleteEntityValuesResponse, error) {
+func (h *Handler) DeleteEntity(ctx context.Context, req *idm.GetMetaEntityValuesRequest) (*idm.DeleteEntityValuesResponse, error) {
 	dao, err := manager.Resolve[meta.DAO](ctx)
 	if err != nil {
 		return nil, err
 	}
 	evDAO := dao.GetEntityValueDao()
 
-	resp, err := evDAO.DeleteEntityValuesData(ctx, req.EntityUuid)
+	resp, err := evDAO.DeleteEntity(ctx, req.EntityUuid)
 	if err != nil {
 		return nil, err
 	}

--- a/idm/meta/grpc/handler.go
+++ b/idm/meta/grpc/handler.go
@@ -445,14 +445,14 @@ func (h *Handler) GetEntityValues(ctx context.Context, req *idm.GetMetaEntityVal
 	}, nil
 }
 
-func (h *Handler) DeleteEntityValues(ctx context.Context, req *idm.GetMetaEntityValuesRequest) (*idm.DeleteEntityValuesResponse, error) {
+func (h *Handler) DeleteEntityValuesData(ctx context.Context, req *idm.GetMetaEntityValuesRequest) (*idm.DeleteEntityValuesResponse, error) {
 	dao, err := manager.Resolve[meta.DAO](ctx)
 	if err != nil {
 		return nil, err
 	}
 	evDAO := dao.GetEntityValueDao()
 
-	resp, err := evDAO.DeleteEntityValues(ctx, req.EntityUuid)
+	resp, err := evDAO.DeleteEntityValuesData(ctx, req.EntityUuid)
 	if err != nil {
 		return nil, err
 	}

--- a/idm/meta/grpc/handler.go
+++ b/idm/meta/grpc/handler.go
@@ -408,7 +408,7 @@ func (h *Handler) GetNamespaceSchema(ctx context.Context, req *idm.GetNamespaceS
 	}
 	namespaceDAO := dao.GetNamespaceDao()
 
-	if req.FieldType != "" && req.Namespace != "" && req.Format != "" {
+	if req.FieldType != "" && req.Namespace != "" {
 		schema, err := namespaceDAO.GetNamespaceSchemaSample(ctx, req.FieldType, req.Namespace, req.Format)
 		if err != nil {
 			return nil, err
@@ -426,6 +426,72 @@ func (h *Handler) GetNamespaceSchema(ctx context.Context, req *idm.GetNamespaceS
 	} else {
 		return nil, err
 	}
+}
+
+func (h *Handler) GetEntityValues(ctx context.Context, req *idm.GetMetaEntityValuesRequest) (*idm.MetaEntityValueResponse, error) {
+	dao, err := manager.Resolve[meta.DAO](ctx)
+	if err != nil {
+		return nil, err
+	}
+	entityDAO := dao.GetEntityValueDao()
+
+	values, err := entityDAO.GetEntityValues(ctx, req.EntityUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	return &idm.MetaEntityValueResponse{
+		EntityValue: values,
+	}, nil
+}
+
+func (h *Handler) DeleteEntityValues(ctx context.Context, req *idm.GetMetaEntityValuesRequest) (*idm.DeleteEntityValuesResponse, error) {
+	dao, err := manager.Resolve[meta.DAO](ctx)
+	if err != nil {
+		return nil, err
+	}
+	evDAO := dao.GetEntityValueDao()
+
+	resp, err := evDAO.DeleteEntityValues(ctx, req.EntityUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (h *Handler) CreateEntity(ctx context.Context, req *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error) {
+	dao, err := manager.Resolve[meta.DAO](ctx)
+	if err != nil {
+		return nil, err
+	}
+	evDAO := dao.GetEntityValueDao()
+
+	entity, err := evDAO.CreateEntity(ctx, req.Entity)
+	if err != nil {
+		return nil, err
+	}
+
+	return &idm.CreateEntityResponse{
+		Entity: entity,
+	}, nil
+}
+
+func (h *Handler) CreateEntityValues(ctx context.Context, req *idm.CreateEntityValueRequest) (*idm.CreateEntityValueResponse, error) {
+	dao, err := manager.Resolve[meta.DAO](ctx)
+	if err != nil {
+		return nil, err
+	}
+	evDAO := dao.GetEntityValueDao()
+
+	values, err := evDAO.CreateEntityValues(ctx, req.EntityValue)
+	if err != nil {
+		return nil, err
+	}
+
+	return &idm.CreateEntityValueResponse{
+		EntityValue: values,
+	}, nil
 }
 
 func (h *Handler) resultsToCache(ctx context.Context, nodeId string, searchSubjects []string, results []*idm.UserMeta) {

--- a/idm/meta/json_schema/json_schema.go
+++ b/idm/meta/json_schema/json_schema.go
@@ -122,19 +122,20 @@ func (f *MetaSchemaFactory) BuildMetaSchema(label string) *structpb.Struct {
 
 	case "types":
 		return toProtoStruct(map[string]interface{}{
-			"string":      "Text",
-			"textarea":    "Long Text",
-			"integer":     "Number",
-			"boolean":     "Boolean",
-			"date":        "Date",
-			"choice":      "Selection",
-			"tags":        "Extensible Tags",
-			"tag_cloud":   "Tag Cloud",
-			"multi_value": "Multi Value Selection",
-			"stars_rate":  "Stars Rating",
-			"css_label":   "Color Labels",
-			"json":        "JSON",
-			"url":         "External URL",
+			"string":        "Text",
+			"textarea":      "Long Text",
+			"integer":       "Number",
+			"boolean":       "Boolean",
+			"date":          "Date",
+			"choice":        "Selection",
+			"tags":          "Extensible Tags",
+			"tag_cloud":     "Tag Cloud",
+			"multi_value":   "Multi Value Selection",
+			"stars_rate":    "Stars Rating",
+			"css_label":     "Color Labels",
+			"json":          "JSON",
+			"url":           "External URL",
+			"auto_complete": "Auto Complete",
 		})
 
 	default:
@@ -290,7 +291,7 @@ func (f *JSONSchemaFactory) BuildJsonSchema(label string, name string, format st
 	case "choice":
 		var t = fmt.Sprintf("%s-tags", usermeta)
 		if name != "" {
-			t = fmt.Sprintf("usermeta-%s", name)
+			t = fmt.Sprintf(name)
 		}
 		f.root["title"] = t
 		props[t] = withArraySchema()

--- a/idm/meta/rest/handler.go
+++ b/idm/meta/rest/handler.go
@@ -45,23 +45,6 @@ import (
 
 var ns_with_ev = []string{"tag_cloud", "choice", "auto_complete"}
 
-type jsonDefinition struct {
-	Entity struct {
-		EntityID string `json:"entity_id"`
-		Entity   string `json:"entity"`
-	} `json:"entity"`
-	Data struct {
-		Items []struct {
-			Key   string `json:"key"`
-			Value string `json:"value"`
-			Color string `json:"color,omitempty"`
-		} `json:"items"`
-		Steps bool `json:"steps"`
-	} `json:"data"`
-	GroupName string `json:"groupName"`
-	Type      string `json:"type"`
-}
-
 func NewUserMetaHandler() *UserMetaHandler {
 	return &UserMetaHandler{
 		UserMetaClient: meta.NewUserMetaClient(),
@@ -179,22 +162,22 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 		if !strings.HasPrefix(ns.Namespace, common.MetaNamespaceUserspacePrefix) {
 			return errors.WithMessage(errors.InvalidParameters, "user defined meta must start with "+common.MetaNamespaceUserspacePrefix+" prefix")
 		}
-		if _, e := ns.UnmarshallDefinition(); e != nil {
+		// Use the helper to validate and get definition
+		definition, e := ns.UnmarshallDefinition()
+		if e != nil {
 			return errors.WithMessagef(errors.UnmarshalError, "invalid json definition for namespace: %s, %v", ns.Namespace, e)
 		}
 		if input.Operation == idm.UpdateUserMetaNamespaceRequest_PUT {
-			if ns.FieldType != "" {
-				var def jsonDefinition
-				if err := json.Unmarshal([]byte(ns.JsonDefinition), &def); err != nil {
-					return errors.WithMessagef(errors.UnmarshalError, "unable to parse json definition to check existing entity_id for namespace %s: %v", ns.Namespace, err)
-				}
-				if def.Entity.EntityID == "" {
+			fieldType := definition.GetType()
+			if fieldType != "" { //
+				// Check if entity_id is already set
+				if definition.GetEntityId() == "" { // TODO handle if entityId is already set (update scenario)
 					// Set description
 					var desc = ""
 					if ns.Description != "" {
 						desc = ns.Description
 					} else {
-						desc = "Entity for " + ns.FieldType + " namespace"
+						desc = "Entity for " + fieldType + " namespace"
 					}
 					// Its somewhat dangerous to create before namespace has been created but its more efficient than doing it after
 					entity, err := s.ServiceClient(ctx).CreateEntity(ctx, &idm.CreateEntityRequest{
@@ -207,29 +190,25 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 						return err
 					}
 
-					if slices.Contains(ns_with_ev, ns.FieldType) {
+					if slices.Contains(ns_with_ev, fieldType) {
 						// Create empty entity values
 						var evs []*idm.EntityValue
-						items, ei := parseItems(ns.JsonDefinition)
-						if ei == nil {
-							if len(items) > 0 {
-								for _, item := range items {
-									evs = append(evs, &idm.EntityValue{
-										EntityUuid: entity.Entity.Uuid,
-										Label:      item,
-									})
-								}
+						items := definition.GetItems()
+						if len(items) > 0 {
+							for _, item := range items {
+								evs = append(evs, &idm.EntityValue{
+									EntityUuid: entity.Entity.Uuid,
+									Label:      item,
+								})
 							}
 						}
-						entities, et := parseEntities(ns.JsonDefinition)
-						if et == nil {
-							if len(entities) > 0 {
-								for _, ent := range entities {
-									evs = append(evs, &idm.EntityValue{
-										EntityUuid: entity.Entity.Uuid,
-										Label:      ent,
-									})
-								}
+						entities := definition.GetEntities()
+						if len(entities) > 0 {
+							for _, ent := range entities {
+								evs = append(evs, &idm.EntityValue{
+									EntityUuid: entity.Entity.Uuid,
+									Label:      ent,
+								})
 							}
 						}
 
@@ -240,13 +219,16 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 							return err
 						}
 					}
-					def.Entity.EntityID = entity.Entity.Uuid
 
-					updatedJsDef, err := json.Marshal(def)
-					if err != nil {
-						return errors.WithMessagef(errors.UnmarshalError, "unable to marshal updated json definition to add entity_id for namespace %s: %v", ns.Namespace, err)
+					// Cast to concrete type for modification
+					if def, ok := definition.(*idm.MetaNsDef); ok {
+						def.SetEntityId(entity.Entity.Uuid)
+						updatedJsDef, err := json.Marshal(def)
+						if err != nil {
+							return err
+						}
+						ns.JsonDefinition = string(updatedJsDef)
 					}
-					ns.JsonDefinition = string(updatedJsDef)
 				}
 			}
 		}
@@ -255,10 +237,12 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 	response, err := s.ServiceClient(ctx).UpdateUserMetaNamespace(ctx, &input)
 	if err != nil {
 		for _, ns := range input.Namespaces {
-			if ns.FieldType != "" {
-				entityID, err := parseEntityId(ns.JsonDefinition)
-				if err != nil {
-					return err
+			// Use helper to check if we need to cleanup
+			definition, _ := ns.UnmarshallDefinition()
+			if definition != nil && definition.GetType() != "" {
+				entityID := definition.GetEntityId()
+				if entityID == "" {
+					continue
 				}
 				if _, err := s.DeleteEntityValues(ctx, entityID); err != nil {
 					return err
@@ -268,10 +252,12 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 		return err
 	} else if input.Operation == idm.UpdateUserMetaNamespaceRequest_DELETE {
 		for _, ns := range input.Namespaces {
-			if ns.FieldType != "" {
-				entityID, err := parseEntityId(ns.JsonDefinition)
-				if err != nil {
-					return err
+			// Use helper to check if we need to cleanup
+			definition, _ := ns.UnmarshallDefinition()
+			if definition != nil && definition.GetType() != "" {
+				entityID := definition.GetEntityId()
+				if entityID == "" {
+					continue
 				}
 				if _, err := s.DeleteEntityValues(ctx, entityID); err != nil {
 					return err
@@ -333,27 +319,36 @@ func (s *UserMetaHandler) ListUserMetaTags(req *restful.Request, rsp *restful.Re
 	if er != nil {
 		return er
 	}
-	if _, ok := nss[ns]; !ok { // ns not found or filtered by policies
+	nsObject, ok := nss[ns]
+	if !ok { // ns not found or filtered by policies
 		return errors.WithMessagef(errors.StatusNotFound, "namespace %s does not exist", ns)
 	}
-	if slices.Contains(ns_with_ev, nss[ns].FieldType) {
-		jsDef := nss[ns].JsonDefinition
 
-		entityID, err := parseEntityId(jsDef)
+	// Use the helper to get definition
+	if nss[ns].FieldType != "" && slices.Contains(ns_with_ev, nss[ns].FieldType) {
+		definition, err := nsObject.UnmarshallDefinition()
 		if err != nil {
 			return err
 		}
-		entityValues, err := s.GetEntityValues(ctx, entityID)
-		if err != nil {
-			return err
+
+		// Check type through interface
+		if slices.Contains(ns_with_ev, definition.GetType()) {
+			entityID := definition.GetEntityId()
+			if entityID == "" {
+				return err
+			}
+			entityValues, err := s.GetEntityValues(ctx, entityID)
+			if err != nil {
+				return err
+			}
+			tags := []string{}
+			for _, ev := range entityValues {
+				tags = append(tags, ev.Label)
+			}
+			return rsp.WriteEntity(&rest.ListUserMetaTagsResponse{
+				Tags: tags,
+			})
 		}
-		tags := []string{}
-		for _, ev := range entityValues {
-			tags = append(tags, ev.Label)
-		}
-		return rsp.WriteEntity(&rest.ListUserMetaTagsResponse{
-			Tags: tags,
-		})
 	}
 
 	tags, _ := s.TagValuesHandler().ListTags(ctx, ns)
@@ -435,48 +430,4 @@ func (s *UserMetaHandler) ListAllNamespaces(ctx context.Context, client idm.User
 func (s *UserMetaHandler) PoliciesForMeta(ctx context.Context, resourceId string, resourceClient interface{}) (policies []*serviceproto.ResourcePolicy, e error) {
 
 	return
-}
-
-func parseItems(jsonDef string) ([]string, error) {
-	var def struct {
-		Data struct {
-			Items []struct {
-				Key   string `json:"key"`
-				Value string `json:"value"`
-				Color string `json:"color,omitempty"`
-			} `json:"items"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal([]byte(jsonDef), &def); err != nil {
-		return nil, err
-	}
-	var items []string
-	for _, item := range def.Data.Items {
-		items = append(items, item.Value)
-	}
-	return items, nil
-}
-
-func parseEntities(jsonDef string) ([]string, error) {
-	var def struct {
-		Data struct {
-			Entity []string `json:"entity"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal([]byte(jsonDef), &def); err != nil {
-		return nil, err
-	}
-	return def.Data.Entity, nil
-}
-
-func parseEntityId(jsonDef string) (string, error) {
-	var def struct {
-		Entity struct {
-			EntityID string `json:"entity_id"`
-		} `json:"entity"`
-	}
-	if err := json.Unmarshal([]byte(jsonDef), &def); err != nil {
-		return "", err
-	}
-	return def.Entity.EntityID, nil
 }

--- a/idm/meta/rest/handler.go
+++ b/idm/meta/rest/handler.go
@@ -244,7 +244,7 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 				if entityID == "" {
 					continue
 				}
-				if _, err := s.DeleteEntityValuesData(ctx, entityID); err != nil {
+				if _, err := s.DeleteEntity(ctx, entityID); err != nil {
 					return err
 				}
 			}
@@ -259,7 +259,7 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 				if entityID == "" {
 					continue
 				}
-				if _, err := s.DeleteEntityValuesData(ctx, entityID); err != nil {
+				if _, err := s.DeleteEntity(ctx, entityID); err != nil {
 					return err
 				}
 			}

--- a/idm/meta/rest/handler.go
+++ b/idm/meta/rest/handler.go
@@ -244,7 +244,7 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 				if entityID == "" {
 					continue
 				}
-				if _, err := s.DeleteEntityValues(ctx, entityID); err != nil {
+				if _, err := s.DeleteEntityValuesData(ctx, entityID); err != nil {
 					return err
 				}
 			}
@@ -259,7 +259,7 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 				if entityID == "" {
 					continue
 				}
-				if _, err := s.DeleteEntityValues(ctx, entityID); err != nil {
+				if _, err := s.DeleteEntityValuesData(ctx, entityID); err != nil {
 					return err
 				}
 			}

--- a/idm/meta/rest/handler.go
+++ b/idm/meta/rest/handler.go
@@ -22,7 +22,9 @@ package rest
 
 import (
 	"context"
+	"encoding/json"
 	"path"
+	"slices"
 	"strings"
 
 	restful "github.com/emicklei/go-restful/v3"
@@ -40,6 +42,25 @@ import (
 	"github.com/pydio/cells/v5/common/telemetry/log"
 	"github.com/pydio/cells/v5/idm/meta"
 )
+
+var ns_with_ev = []string{"tag_cloud", "choice", "auto_complete"}
+
+type jsonDefinition struct {
+	Entity struct {
+		EntityID string `json:"entity_id"`
+		Entity   string `json:"entity"`
+	} `json:"entity"`
+	Data struct {
+		Items []struct {
+			Key   string `json:"key"`
+			Value string `json:"value"`
+			Color string `json:"color,omitempty"`
+		} `json:"items"`
+		Steps bool `json:"steps"`
+	} `json:"data"`
+	GroupName string `json:"groupName"`
+	Type      string `json:"type"`
+}
 
 func NewUserMetaHandler() *UserMetaHandler {
 	return &UserMetaHandler{
@@ -161,15 +182,104 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 		if _, e := ns.UnmarshallDefinition(); e != nil {
 			return errors.WithMessagef(errors.UnmarshalError, "invalid json definition for namespace: %s, %v", ns.Namespace, e)
 		}
+		if input.Operation == idm.UpdateUserMetaNamespaceRequest_PUT {
+			if ns.FieldType != "" {
+				var def jsonDefinition
+				if err := json.Unmarshal([]byte(ns.JsonDefinition), &def); err != nil {
+					return errors.WithMessagef(errors.UnmarshalError, "unable to parse json definition to check existing entity_id for namespace %s: %v", ns.Namespace, err)
+				}
+				if def.Entity.EntityID == "" {
+					// Set description
+					var desc = ""
+					if ns.Description != "" {
+						desc = ns.Description
+					} else {
+						desc = "Entity for " + ns.FieldType + " namespace"
+					}
+					// Its somewhat dangerous to create before namespace has been created but its more efficient than doing it after
+					entity, err := s.ServiceClient(ctx).CreateEntity(ctx, &idm.CreateEntityRequest{
+						Entity: &idm.MetaEntity{
+							Label:       "ns-entity-" + ns.Namespace,
+							Description: desc,
+						},
+					})
+					if err != nil {
+						return err
+					}
+
+					if slices.Contains(ns_with_ev, ns.FieldType) {
+						// Create empty entity values
+						var evs []*idm.EntityValue
+						items, ei := parseItems(ns.JsonDefinition)
+						if ei == nil {
+							if len(items) > 0 {
+								for _, item := range items {
+									evs = append(evs, &idm.EntityValue{
+										EntityUuid: entity.Entity.Uuid,
+										Label:      item,
+									})
+								}
+							}
+						}
+						entities, et := parseEntities(ns.JsonDefinition)
+						if et == nil {
+							if len(entities) > 0 {
+								for _, ent := range entities {
+									evs = append(evs, &idm.EntityValue{
+										EntityUuid: entity.Entity.Uuid,
+										Label:      ent,
+									})
+								}
+							}
+						}
+
+						_, err := s.ServiceClient(ctx).CreateEntityValues(ctx, &idm.CreateEntityValueRequest{
+							EntityValue: evs,
+						})
+						if err != nil {
+							return err
+						}
+					}
+					def.Entity.EntityID = entity.Entity.Uuid
+
+					updatedJsDef, err := json.Marshal(def)
+					if err != nil {
+						return errors.WithMessagef(errors.UnmarshalError, "unable to marshal updated json definition to add entity_id for namespace %s: %v", ns.Namespace, err)
+					}
+					ns.JsonDefinition = string(updatedJsDef)
+				}
+			}
+		}
 	}
 
 	response, err := s.ServiceClient(ctx).UpdateUserMetaNamespace(ctx, &input)
 	if err != nil {
+		for _, ns := range input.Namespaces {
+			if ns.FieldType != "" {
+				entityID, err := parseEntityId(ns.JsonDefinition)
+				if err != nil {
+					return err
+				}
+				if _, err := s.DeleteEntityValues(ctx, entityID); err != nil {
+					return err
+				}
+			}
+		}
 		return err
-	} else {
-		return rsp.WriteEntity(response)
+	} else if input.Operation == idm.UpdateUserMetaNamespaceRequest_DELETE {
+		for _, ns := range input.Namespaces {
+			if ns.FieldType != "" {
+				entityID, err := parseEntityId(ns.JsonDefinition)
+				if err != nil {
+					return err
+				}
+				if _, err := s.DeleteEntityValues(ctx, entityID); err != nil {
+					return err
+				}
+			}
+		}
 	}
-
+	return rsp.WriteEntity(response)
 }
 
 func (s *UserMetaHandler) ListUserMetaNamespace(req *restful.Request, rsp *restful.Response) error {
@@ -226,6 +336,26 @@ func (s *UserMetaHandler) ListUserMetaTags(req *restful.Request, rsp *restful.Re
 	if _, ok := nss[ns]; !ok { // ns not found or filtered by policies
 		return errors.WithMessagef(errors.StatusNotFound, "namespace %s does not exist", ns)
 	}
+	if slices.Contains(ns_with_ev, nss[ns].FieldType) {
+		jsDef := nss[ns].JsonDefinition
+
+		entityID, err := parseEntityId(jsDef)
+		if err != nil {
+			return err
+		}
+		entityValues, err := s.GetEntityValues(ctx, entityID)
+		if err != nil {
+			return err
+		}
+		tags := []string{}
+		for _, ev := range entityValues {
+			tags = append(tags, ev.Label)
+		}
+		return rsp.WriteEntity(&rest.ListUserMetaTagsResponse{
+			Tags: tags,
+		})
+	}
+
 	tags, _ := s.TagValuesHandler().ListTags(ctx, ns)
 	return rsp.WriteEntity(&rest.ListUserMetaTagsResponse{
 		Tags: tags,
@@ -305,4 +435,48 @@ func (s *UserMetaHandler) ListAllNamespaces(ctx context.Context, client idm.User
 func (s *UserMetaHandler) PoliciesForMeta(ctx context.Context, resourceId string, resourceClient interface{}) (policies []*serviceproto.ResourcePolicy, e error) {
 
 	return
+}
+
+func parseItems(jsonDef string) ([]string, error) {
+	var def struct {
+		Data struct {
+			Items []struct {
+				Key   string `json:"key"`
+				Value string `json:"value"`
+				Color string `json:"color,omitempty"`
+			} `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(jsonDef), &def); err != nil {
+		return nil, err
+	}
+	var items []string
+	for _, item := range def.Data.Items {
+		items = append(items, item.Value)
+	}
+	return items, nil
+}
+
+func parseEntities(jsonDef string) ([]string, error) {
+	var def struct {
+		Data struct {
+			Entity []string `json:"entity"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(jsonDef), &def); err != nil {
+		return nil, err
+	}
+	return def.Data.Entity, nil
+}
+
+func parseEntityId(jsonDef string) (string, error) {
+	var def struct {
+		Entity struct {
+			EntityID string `json:"entity_id"`
+		} `json:"entity"`
+	}
+	if err := json.Unmarshal([]byte(jsonDef), &def); err != nil {
+		return "", err
+	}
+	return def.Entity.EntityID, nil
 }


### PR DESCRIPTION
## General note:
The rest handler logic is done as a work around for entity & values creation using json defintion to maintain backward compatiability and meet the initial goal of this concept, as the logic gets more complicated to handle json parsing and entity & value creation the surface area of errors is increased in this layer for these new namespace types wrapped in If statements. The plan is to add new endpoints to manage these resources.

- add new proto defintions for the new services
- generate gRPC bufs
- Add dao handlers
- expose grpc methods via meta client
- extend rest handler methods update and list namespaces
- add json parsing helpers
- move constants
- extend  json_schema types handler
- update test
- use new mantine Tag cloud input component on admin meta create wizard
- add i18n keys