### PR TITLE
fix(metadata): fix metadata saving and validation logic

### DIFF
--- a/frontend/assets/meta.user/res/js/InfoPanel.js
+++ b/frontend/assets/meta.user/res/js/InfoPanel.js
@@ -49,6 +49,12 @@ const InfoPanel = ({ pydio, node, popoverPanel, style, ...infoProps }) => {
             });
     }, [node, setSaving, setUpdateData])
 
+    const submitMetadata = useCallback(() => {
+        saveMeta(updateData)
+        setUpdateData(null)
+    }, [saveMeta, updateData])
+
+
     let actions = [];
     const { MessageHash } = pydio;
 
@@ -60,7 +66,7 @@ const InfoPanel = ({ pydio, node, popoverPanel, style, ...infoProps }) => {
             <FlatButton
                 key="edit"
                 label={MessageHash['meta.user.15']}
-                onClick={saveMeta}
+                onClick={submitMetadata}
                 disabled={!valid}
             />
         );
@@ -82,7 +88,10 @@ const InfoPanel = ({ pydio, node, popoverPanel, style, ...infoProps }) => {
             node={node}
             saveMeta={saveMeta}
             saving={saving}
-            savePartialy={true}
+            onDataChanged={(data, isValid) => {
+                setUpdateData(data)
+                setValid(isValid)
+            }}
         >
             <InfoPanelCard
                 {...infoProps}
@@ -102,7 +111,6 @@ const InfoPanel = ({ pydio, node, popoverPanel, style, ...infoProps }) => {
                     onChangeUpdateData={setUpdateData}
                     onValidStatusChanged={(v) => { setValid(v) }}
                     saving={saving}
-                    autoSave={saveMeta}
                     style={panelStyle}
                     useTogglableFields={true}
                 />

--- a/frontend/assets/meta.user/res/js/UserMetaDialog.js
+++ b/frontend/assets/meta.user/res/js/UserMetaDialog.js
@@ -44,19 +44,23 @@ export default createReactClass({
         SubmitButtonProviderMixin
     ],
 
-    saveMeta(){
-        let values = this.refs.panel.getUpdateData();
-        let params = {};
-        values.forEach(function(v, k){
-            params[k] = v;
-        });
-        return MetaClient.getInstance().saveMeta(this.props.selection.getSelectedNodes(), values);
+    saveMeta(metadata){
+        return MetaClient
+            .getInstance()
+            .saveMeta(this.props.selection.getSelectedNodes(), metadata);
     },
 
     submit(){
-        this.saveMeta().then(() => {
+        this.saveMeta(this.formMetadata).then(() => {
             this.dismiss();
         });
+    },
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.selection !== this.props.selection) {
+            // FIXME: Store the form state without re-rendering.
+            this.formMetadata = new Map();
+        }
     },
 
     render(){
@@ -64,8 +68,10 @@ export default createReactClass({
             <PydioMantineProvider>
                 <MetadataContextProvider
                     node={this.props.selection.isUnique() ? this.props.selection.getUniqueNode() : new Node()}
-                    saveMeta={this.submit}
+                    saveMeta={(metadata) => this.saveMeta(metadata)}
                     saving={false}
+                    savePartialy={!this.props.selection.isUnique()}
+                    onDataChanged={(metadata) => this.formMetadata = metadata}
                 >
                     <UserMetaPanelV2
                         pydio={this.props.pydio}

--- a/frontend/assets/meta.user/res/js/components/FieldEdit.tsx
+++ b/frontend/assets/meta.user/res/js/components/FieldEdit.tsx
@@ -54,6 +54,9 @@ export const FieldEdit: React.FC<FieldEditProps> = ({
     name,
     meta,
     saving,
+    // FIXME: Toggleable fields are disabled
+    // updateValue,
+    // requestToggleClose,
 }) => {
     const { state, actions } = context;
     const { type, readonly, required, label, data } = meta;
@@ -79,18 +82,19 @@ export const FieldEdit: React.FC<FieldEditProps> = ({
             actions.setFormState(state.formState.set(name, v))
         },
         errorText,
-        requestToggleClose: () => {
-            actions.setShouldSave(true)
-            actions.setEditingTag('none')
-        },
+        requestToggleClose: () => {} // FIXME: Toggleable fields are disabled
+        // requestToggleClose: () => {
+        //     // NOTE: means this isnot a toggleable field
+        //     if (!requestToggleClose) return
+        //
+        //     requestToggleClose()
+        // },
     };
 
     const onCommitChange = (v) => {
         if (state.errors[name]) return
 
         actions.setFormState(state.formState.set(name, v))
-        actions.setShouldSave(true)
-        actions.setEditingTag('none')
     }
 
     switch (type) {
@@ -106,7 +110,7 @@ export const FieldEdit: React.FC<FieldEditProps> = ({
         case 'tags':
             return <TagsCloudInput
                 {...baseProps}
-                value={state.formState.get(name)}
+                value={state.formState.get(name) || ""}
                 disabled={state.saving || state.shouldSave}
                 onCommitChange={onCommitChange}
                 data={[]}

--- a/frontend/assets/meta.user/res/js/components/MetadataGroup.js
+++ b/frontend/assets/meta.user/res/js/components/MetadataGroup.js
@@ -55,12 +55,12 @@ export const MetadataGroup = ({
     pydio,
     onRequestEditMode,
     useTogglableFields,
-    autoSave,
     saving,
     metadataContext,
 }) => {
     const context = metadataContext || useMetadataContext();
     const metadata = node.getMetadata();
+    const [fieldBeingEditted, setFieldBeingEditted] = React.useState('none');
     const elements = [];
     let nonEmptyDataCount = 0;
 
@@ -83,31 +83,43 @@ export const MetadataGroup = ({
         if (!editMode && value) {
             nonEmptyDataCount++;
         }
-        let Component = MetadataField
-        if(useTogglableFields) {
-            Component = TogglableField
-        }
 
-        elements.push(
-            <Component
-                context={context}
-                key={key}
-                fieldKey={key}
-                meta={meta}
-                node={node}
-                editMode={editMode}
-                multiple={multiple}
-                value={value}
-                checked={fields[key] || false}
-                updateValue={updateValue}
-                onCheck={onCheck}
-                configsForGroup={configsForGroup}
-                supportTemplates={supportTemplates}
-                additionalProps={additionalProps}
-                autoSave={autoSave}
-                saving={saving}
-            />
-        );
+        if(useTogglableFields) {
+            elements.push(
+                <TogglableField
+                    key={key}
+                    fieldKey={key}
+                    context={context}
+                    meta={meta}
+                    node={node}
+                    updateValue={updateValue}
+                    configsForGroup={configsForGroup}
+                    supportTemplates={supportTemplates}
+                    additionalProps={additionalProps}
+                    isEditing={fieldBeingEditted === key}
+                    setFieldBeingEditted={setFieldBeingEditted}
+                />
+            );
+        } else {
+            elements.push(
+                <MetadataField
+                    key={key}
+                    context={context}
+                    fieldKey={key}
+                    meta={meta}
+                    node={node}
+                    editMode={editMode}
+                    multiple={multiple}
+                    value={value}
+                    checked={fields[key] || false}
+                    updateValue={updateValue}
+                    onCheck={onCheck}
+                    configsForGroup={configsForGroup}
+                    supportTemplates={supportTemplates}
+                    additionalProps={additionalProps}
+                />
+            );
+        }
     });
 
     // Styles for headers and fields
@@ -185,7 +197,6 @@ export const MetadataGroup = ({
                         onToggleGroup={onToggleGroup}
                         pydio={pydio}
                         onRequestEditMode={onRequestEditMode}
-                        autoSave={autoSave}
                         saving={saving}
                         useTogglableFields={useTogglableFields}
                     />

--- a/frontend/assets/meta.user/res/js/components/TogglableField.css
+++ b/frontend/assets/meta.user/res/js/components/TogglableField.css
@@ -4,10 +4,6 @@
 
 .panelCard .panelContent .infoPanelRow.togglable.no-value .infoPanelValue {}
 
-.panelCard .panelContent .infoPanelRow.togglable{
-    padding-bottom: 10px;
-}
-
 .infoPanelRow.togglable .infoPanelValue {
     background: var(--md-sys-color-surface-3);
     min-height: 35px;
@@ -30,7 +26,7 @@
     .panelCard .panelContent .infoPanelFlexRow .infoPanelRow,
     .panelCard .panelContent .infoPanelFlexRow .infoPanelRow.togglable.no-value,
     .panelCard .panelContent .infoPanelFlexRow .mantine-InputWrapper-root {
-        display: flex;
+        display: block;
         align-items: start;
     }
 
@@ -43,8 +39,8 @@
     .panelCard .panelContent .infoPanelFlexRow .mantine-InputWrapper-label {
         min-width: 100px;
         width: 30%;
-        padding: 10px 4px 10px 0;
-        margin-bottom: inherit;
+        padding: 2px 2px 2px 0;
+        margin-bottom: 2px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/frontend/assets/meta.user/res/js/components/TogglableField.js
+++ b/frontend/assets/meta.user/res/js/components/TogglableField.js
@@ -26,6 +26,7 @@ import {FieldDisplay} from './FieldDisplay';
  * Main component that handles a metadata field in edit or display mode
  */
 export const TogglableField = ({
+      context,
       fieldKey,
       meta,
       node,
@@ -33,48 +34,50 @@ export const TogglableField = ({
       configsForGroup,
       supportTemplates,
       additionalProps,
-      context,
+      isEditing,
+      setFieldBeingEditted,
   }) => {
 
     const { state, actions } = context;
     const value = state.formState.get(fieldKey)
 
-    const shouldStayInEditMode = state.errors[fieldKey]
-    if (state.editingTag === fieldKey || shouldStayInEditMode) {
-        return <FieldEdit
-            context={context}
-            name={fieldKey}
-            meta={meta}
-            value={value}
-            updateValue={(key, value, submit) => {
-                updateValue(key, value, submit);
-                if(submit) {
-                    actions.setShouldSave(true)
-                    actions.setEditingTag('none')
-                }
+    // FIXME: Let's enable the togglable forms in a second step
+    // if (isEditing || state.errors[fieldKey]) {
+    return <FieldEdit
+        context={context}
+        name={fieldKey}
+        meta={meta}
+        value={value}
+        updateValue={(key, value, submit) => {
+            updateValue(key, value, submit);
+            actions.setFormState(state.formState.set(key, value))
+            setFieldBeingEditted('none')
 
-                actions.setFormState(state.formState.set(key, value))
-            }}
-            requestToggleClose={()=> {
+            if(submit) {
                 actions.setShouldSave(true)
-                actions.setEditingTag('none')
-            }}
-            configsForGroup={configsForGroup}
-            supportTemplates={supportTemplates}
-            additionalProps={additionalProps}
-        />;
-    }
+                setFieldBeingEditted('none')
+            }
+        }}
+        requestToggleClose={()=> {
+            actions.setShouldSave(true)
+            setFieldBeingEditted('none')
+        }}
+        configsForGroup={configsForGroup}
+        supportTemplates={supportTemplates}
+        additionalProps={additionalProps}
+    />;
 
-    return (
-        <FieldDisplay
-            className={"togglable"}
-            fieldKey={fieldKey}
-            meta={meta}
-            value={value}
-            node={node}
-            onValueClick={() => {
-                actions.setEditingTag(fieldKey)
-            }}
-        />
-    );
+    // return (
+    //     <FieldDisplay
+    //         className={"togglable"}
+    //         fieldKey={fieldKey}
+    //         meta={meta}
+    //         value={value}
+    //         node={node}
+    //         onValueClick={() => {
+    //             console.log('(TogglableField:78) - @@@@@@ fieldKey: ', fieldKey);
+    //             setFieldBeingEditted(fieldKey)
+    //         }}
+    //     />
+    // );
 };

--- a/frontend/assets/meta.user/res/js/context/metadata.tsx
+++ b/frontend/assets/meta.user/res/js/context/metadata.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
-import MetaClient, { PydioNode } from "../MetaClient";
+import MetaClient from "../MetaClient";
+
+// FIXME: Properly type this
+type PydioNode = unknown;
 
 import Ajv, { JSONSchemaType, ValidateFunction } from "ajv";
 import addFormats from 'ajv-formats'
@@ -23,7 +26,6 @@ type MetadataAction =
     | { type: 'set_fields'; fields: {[key: string]: any} }
     | { type: 'set_namespace_schema'; namespaceJsonSchema: JSONSchemaType<any> | null }
     | { type: 'set_should_save'; shouldSave: boolean }
-    | { type: 'set_editing_tag'; editingTag: string }
     | { type: 'set_json_schema'; jsonSchema: JSONSchemaType<any> | null }
     | { type: 'set_errors'; errors: {[key: string]: string} };
 
@@ -33,7 +35,6 @@ interface MetadataActions {
     setFormState: (formState: Map<string, any>) => void;
     setShouldSave: (shouldSave: boolean) => void;
     setFields: (fields: {[key: string]: any}) => void;
-    setEditingTag: (editingTag: string) => void;
     setJsonSchema: (jsonSchema: JSONSchemaType<any> | null) => void;
 }
 
@@ -72,8 +73,6 @@ const reducer = (state: MetadataState, action: MetadataAction): MetadataState =>
             return { ...state, namespaceJsonSchema: action.namespaceJsonSchema }
         case 'set_should_save':
             return { ...state, shouldSave: action.shouldSave }
-        case 'set_editing_tag':
-            return { ...state, editingTag: action.editingTag }
         case 'set_json_schema':
             return { ...state, jsonSchema: action.jsonSchema }
         case 'set_errors':
@@ -94,7 +93,6 @@ const defaultContext: MetadataContextType = {
         setFields: noop,
         setNamespaceJsonSchema: noop,
         setShouldSave: noop,
-        setEditingTag: noop,
         setJsonSchema: noop
     }
 }
@@ -123,8 +121,6 @@ const formatSpecialCasesForValidation = (formState: Map<string, any>, jsonSchema
         if (properties[k]?.format === 'time') {
             const date = new Date(parseFloat(v) * 1000).toISOString();
             const [hours, minutes, seconds] = date.split('T')[1].split(':');
-            console.log('(metadata:127) - @@@@@@ hours: ', hours);
-            console.log('(metadata:127) - @@@@@@ minutes: ', minutes);
             entries[k] = `${hours}:${minutes}:${seconds}`;
             return
         }
@@ -140,21 +136,23 @@ const formatSpecialCasesForValidation = (formState: Map<string, any>, jsonSchema
     return entries
 }
 
+type MetadataContextProviderProps = {
+    node: PydioNode;
+    saveMeta: (formData: Map<string, any>) => Promise<any>;
+    value: any;
+    onDataChanged: (formData: Map<string, any>, isValid: boolean) => void;
+    savePartially: boolean;
+    children: React.ReactNode;
+}
+
 export const MetadataContextProvider = ({
     node,
     saveMeta,
     value,
     onDataChanged,
-    savePartialy,
+    savePartially = false,
     children,
-}: {
-    node: PydioNode;
-    saveMeta: (formData: Map<string, any>) => Promise<any>;
-    value: any;
-    onDataChanged: (formData: Map<string, any>, isValid: boolean) => void;
-    savePartialy: boolean;
-    children: React.ReactNode;
-}) => {
+}: MetadataContextProviderProps) => {
     const validatorRef = React.useRef<ValidateFunction<any> | null>(null);
     const [state, dispatch] = React.useReducer(reducer, {
         ...initialState,
@@ -169,9 +167,8 @@ export const MetadataContextProvider = ({
         setSaving: (saving) => dispatch({ type: 'set_saving', saving }),
 
         setFormState: (formState) => {
-            let isValid = true;
+            let isValid = false;
             if (validatorRef.current) {
-                console.log('(metadata:165) - @@@@@@ setFormState');
                 isValid = validatorRef.current(
                     formatSpecialCasesForValidation(
                         formState,
@@ -184,19 +181,16 @@ export const MetadataContextProvider = ({
 
             dispatch({ type: 'set_form_state', formState })
 
+            // NOTE: For parents that require holding state because we can't
+            // wrap them with a provider.
+            // eg. frontend/assets/meta.user/res/js/InfoPanel.js#92-95
             if (onDataChanged) onDataChanged(formState, isValid)
         },
 
-        setShouldSave: (shouldSave) => {
-            if (!savePartialy) return
-
-            dispatch({ type: 'set_should_save', shouldSave })
-        },
-
+        setShouldSave: (shouldSave) => dispatch({ type: 'set_should_save', shouldSave }),
         setFields: (fields) => dispatch({ type: 'set_fields', fields }),
-        setEditingTag: (editingTag) => dispatch({ type: 'set_editing_tag', editingTag }),
         setJsonSchema: (jsonSchema) => dispatch({ type: 'set_json_schema', jsonSchema })
-    }), [])
+    }), []);
 
     React.useEffect(() => {
         if (!state.jsonSchema) return
@@ -216,7 +210,7 @@ export const MetadataContextProvider = ({
                 actions.setJsonSchema(ns.JsonSchema)
             })
 
-        actions.setFormState(new Map())
+        actions.setFormState(new Map(node.getMetadata()))
     }, [node]);
 
 
@@ -228,12 +222,12 @@ export const MetadataContextProvider = ({
     }, [node.getPath(), state.saving]);
 
 
+    // NOTE: here is the final validation and save of the metadata
     React.useEffect(() => {
-        if (Object.keys(state.errors).length > 0) return;
+        if (!state.shouldSave) return;
 
         if (validatorRef.current) {
-            console.log('(metadata:226) - @@@@@@  validatorRef.current: ',  validatorRef.current);
-            validatorRef.current(
+            let isValid = validatorRef.current(
                 formatSpecialCasesForValidation(
                     state.formState,
                     validatorRef.current.schema
@@ -241,6 +235,10 @@ export const MetadataContextProvider = ({
             )
             const errors = mapErrors(validatorRef.current.errors)
             dispatch({ type: 'set_errors', errors })
+
+            // NOTE: savePartialy is only for the mutiple node selection for now
+            // see: frontend/assets/meta.user/res/js/UserMetaDialog.js
+            if (!savePartially && !isValid) return;
         }
 
         if (state.shouldSave && saveMeta) {

--- a/frontend/assets/meta.user/res/js/fieldsv2/TagsCloudInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/TagsCloudInput.tsx
@@ -35,20 +35,20 @@ export const TagsCloudInput: React.FC<StringItemsInputProps> = ({
     label,
     description,
     placeholder,
-    disabled,
     dataLoader,
-    requestToggleClose,
     errorText,
     value,
     onCommitChange,
 }) => {
-
-    const [localValue, setLocalValue] = useState(formatValueStringToArray(value));
+    const [localValue, setLocalValue] = useState([]);
     const [items, setItems] = useState<string[]>([]);
+
+    React.useEffect(() => {
+        setLocalValue(formatValueStringToArray(value));
+    }, [value]);
 
     const props = {
         label,
-        disabled: disabled,
         description,
         placeholder,
         error: errorText,
@@ -61,8 +61,8 @@ export const TagsCloudInput: React.FC<StringItemsInputProps> = ({
     }, [name])
 
     const onChangeJoin = (values: string[]) => {
-        const joined = values.join(',')
-        setLocalValue(joined.split(',').filter(v => v))
+        setLocalValue(values.filter(v => v))
+        onCommitChange(formatValueArrayToString(values));
     }
 
     return <TagsInput
@@ -71,9 +71,19 @@ export const TagsCloudInput: React.FC<StringItemsInputProps> = ({
         data={items}
         onChange={onChangeJoin}
         comboboxProps={{ withinPortal: false }}
-        autoFocus={!!requestToggleClose}
+        onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
+            const { key, target } = e;
+            const { value } = target;
+            if(key === 'Enter'){
+                onCommitChange(formatValueArrayToString([...localValue, value]));
+            }
+            if (key === ',') {
+                onCommitChange(formatValueArrayToString([...localValue, value]));
+            }
+        }}
         onBlur={(e) => {
             const { value } = e.target;
+            console.log('(TagsCloudInput:76) - @@@@@@ localValue: ', localValue);
             onCommitChange(formatValueArrayToString([...localValue, value]));
         }}
     />

--- a/frontend/assets/meta.user/res/js/fieldsv2/TimeInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/TimeInput.tsx
@@ -30,8 +30,6 @@ const timestampToDate = (timestamp: number) => {
     const hours = date.getHours();
     const minutes = date.getMinutes();
 
-    console.log('(TimeInput:34) - @@@@@@ hours: ', hours);
-    console.log('(TimeInput:34) - @@@@@@ minutes: ', minutes);
     return `${hours}:${minutes}`;
 }
 
@@ -39,8 +37,6 @@ const dateToTimestamp = (time: string) => {
     if (!time) return '';
 
     const [hours, minutes] = time.split(':');
-    console.log('(TimeInput:41) - @@@@@@ hours: ', hours);
-    console.log('(TimeInput:41) - @@@@@@ minutes: ', minutes);
     const timestamp = new Date();
     timestamp.setHours(parseInt(hours));
     timestamp.setMinutes(parseInt(minutes));


### PR DESCRIPTION
This commit fixes issues with metadata saving, validation, and form state management across multiple components.

Detailed Changes:
 - Implementation:
   - Changed InfoPanel to use submitMetadata callback instead of direct saveMeta call
   - Changed UserMetaDialog to store form metadata in component state and pass it to saveMeta
   - Changed FieldEdit to remove auto-saving logic and fix tags input value handling
   - Changed MetadataGroup to conditionally render TogglableField or MetadataField based on useTogglableFields prop
   - Changed TogglableField to always render FieldEdit and remove display mode (temporarily disabled toggle functionality)
   - Changed metadata context to remove editingTag state, fix validation timing, and improve form state initialization
   - Changed TagsCloudInput to fix value synchronization and keyboard handling
   - Changed TimeInput to remove debug console logs
 - Documentation:
   - Added proper TypeScript types for MetadataContextProvider props
   - Added comments explaining form state handling for parent components