### PR TITLE
fix: add required mark to input components and fix FieldEdit layout

### DIFF
--- a/frontend/assets/meta.user/res/js/components/FieldEdit.tsx
+++ b/frontend/assets/meta.user/res/js/components/FieldEdit.tsx
@@ -50,7 +50,7 @@ export interface FieldEditProps {
 /**
  * Renders a single metadata field in edit mode
  */
-export const FieldEdit: React.FC<FieldEditProps> = ({
+const FieldEditInternal: React.FC<FieldEditProps> = ({
     context,
     name,
     meta,
@@ -167,4 +167,16 @@ export const FieldEdit: React.FC<FieldEditProps> = ({
             return <TextInput {...baseProps} subType={type} />;
     }
 };
+
+export const FieldEdit = (props) => {
+    // NOTE: fixes the issue with Field label/input split in
+    // the Prompt To Upload dialog
+    return (<div style={{
+        width: '100%',
+        overflowY: 'scroll',
+        overflowX: 'hidden',
+    }}>
+        <FieldEditInternal {...props} />
+    </div>)
+}
 

--- a/frontend/assets/meta.user/res/js/context/metadata.test.tsx
+++ b/frontend/assets/meta.user/res/js/context/metadata.test.tsx
@@ -1,0 +1,400 @@
+import * as React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Mock } from 'vitest'
+import { renderHook, act, waitFor, render, screen } from '@testing-library/react'
+
+// Suppress console.log from reducer
+vi.spyOn(console, 'log').mockImplementation(() => {})
+
+import testSchema from '../__fixtures__/test-schema.json'
+
+// Mock MetaClient before importing the module
+vi.mock('../MetaClient', () => ({
+    default: {
+        getInstance: vi.fn()
+    }
+}))
+
+// Mock ajv and ajv-formats
+const { mockCompile, mockAjv, mockAddFormats } = vi.hoisted(() => {
+    const mockCompile = vi.fn()
+    const mockAjv = vi.fn(function() {
+        return {
+            compile: mockCompile
+        }
+    })
+    const mockAddFormats = vi.fn()
+    return { mockCompile, mockAjv, mockAddFormats }
+})
+vi.mock('ajv', () => ({
+    default: mockAjv,
+    JSONSchemaType: {},
+    ValidateFunction: {},
+    __esModule: true
+}))
+vi.mock('ajv-formats', () => ({
+    default: mockAddFormats
+}))
+
+import MetaClient from '../MetaClient'
+import { MetadataContextProvider, useMetadataContext, MetadataContext } from './metadata'
+
+interface MockNode {
+  getMetadata: Mock<any>;
+  getPath: Mock<any>;
+  replaceMetadata: Mock<any>;
+  [key: string]: any;
+}
+
+// Helper to create a mock node
+const createMockNode = (overrides: Partial<MockNode> = {}): MockNode => ({
+    getMetadata: vi.fn(() => new Map()),
+    getPath: vi.fn(() => '/test/path'),
+    replaceMetadata: vi.fn(),
+    ...overrides
+})
+
+describe('MetadataContext', () => {
+    let mockNode: MockNode
+    let mockSaveMeta: Mock<any>
+    let mockOnDataChanged: Mock<any>
+    let mockValidator: Mock<any> & { errors: any }
+
+    beforeEach(() => {
+        mockNode = createMockNode()
+        mockSaveMeta = vi.fn(() => Promise.resolve())
+        mockOnDataChanged = vi.fn()
+        mockValidator = vi.fn() as Mock<any> & { errors: any }
+        mockCompile.mockReturnValue(mockValidator)
+        // Setup default MetaClient mock
+        MetaClient.getInstance.mockReturnValue({
+            getNamespaceSchema: vi.fn(() => Promise.resolve({ JsonSchema: null }))
+        })
+        vi.clearAllMocks()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+
+
+    describe('MetadataContextProvider', () => {
+        it('renders children and provides context', () => {
+            const TestChild = () => {
+                const context = useMetadataContext()
+                return <div data-testid="child">{context.state.node ? 'has node' : 'no node'}</div>
+            }
+
+            render(
+                <MetadataContextProvider
+                    node={mockNode}
+                    saveMeta={mockSaveMeta}
+                    value={{}}
+                    onDataChanged={mockOnDataChanged}
+                >
+                    <TestChild />
+                </MetadataContextProvider>
+            )
+
+            expect(screen.getByTestId('child')).toHaveTextContent('has node')
+        })
+
+        it('initializes state with node and value props', () => {
+            const { result } = renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{ fields: { test: 'value' } }}
+                        onDataChanged={mockOnDataChanged}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            expect(result.current.state.node).toBe(mockNode)
+            expect(result.current.state.fields).toEqual({ test: 'value' })
+        })
+
+        it('calls getNamespaceSchema on node change', async () => {
+            const mockGetNamespaceSchema = vi.fn(() => Promise.resolve({ JsonSchema: testSchema }))
+            MetaClient.getInstance.mockReturnValue({
+                getNamespaceSchema: mockGetNamespaceSchema
+            })
+
+            renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{}}
+                        onDataChanged={mockOnDataChanged}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            await waitFor(() => {
+                expect(mockGetNamespaceSchema).toHaveBeenCalled()
+            })
+            // Should set jsonSchema in state
+            // We can't directly access state, but we can check that compile was called
+            await waitFor(() => {
+                expect(mockCompile).toHaveBeenCalledWith(testSchema)
+            })
+        })
+
+        it('updates formState when node path changes', async () => {
+            const metadata = new Map([['key', 'value']])
+            mockNode.getMetadata.mockReturnValue(metadata)
+
+            const { result } = renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{}}
+                        onDataChanged={mockOnDataChanged}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            // Wait for initial effects
+            await waitFor(() => {
+                expect(result.current.state.formState.get('key')).toBe('value')
+            })
+        })
+
+        it('calls onDataChanged when formState changes', async () => {
+            const { result } = renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{}}
+                        onDataChanged={mockOnDataChanged}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            const newFormState = new Map([['newKey', 'newValue']])
+            act(() => {
+                result.current.actions.setFormState(newFormState)
+            })
+
+            expect(mockOnDataChanged).toHaveBeenCalledWith(newFormState, expect.any(Boolean))
+        })
+
+        it('validates and saves when shouldSave becomes true', async () => {
+            // Setup validator to pass
+            mockValidator.mockReturnValue(true)
+            mockValidator.errors = null
+
+            const { result } = renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{}}
+                        onDataChanged={mockOnDataChanged}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            // Set jsonSchema to trigger validator creation
+            act(() => {
+                result.current.actions.setJsonSchema(testSchema)
+            })
+
+            // Set formState
+            act(() => {
+                result.current.actions.setFormState(new Map([['usermeta-text', 'valid']]))
+            })
+
+            // After validation passes, errors should be empty object
+            await waitFor(() => {
+                expect(result.current.state.errors).toEqual({})
+            })
+
+            // Trigger save
+            act(() => {
+                result.current.actions.setShouldSave(true)
+            })
+
+            await waitFor(() => {
+                expect(mockSaveMeta).toHaveBeenCalled()
+                expect(result.current.state.saving).toBe(false)
+                expect(result.current.state.shouldSave).toBe(false)
+            })
+        })
+
+        it('does not save when validation fails and savePartially is false', async () => {
+            // Setup validator to fail
+            mockValidator.mockReturnValue(false)
+            mockValidator.errors = [
+                { instancePath: '/usermeta-text', schemaPath: '#/properties/usermeta-text/minLength', message: 'must be at least 3 characters', params: {} }
+            ]
+
+            const { result } = renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{}}
+                        onDataChanged={mockOnDataChanged}
+                        savePartially={false}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            act(() => {
+                result.current.actions.setJsonSchema(testSchema)
+            })
+
+            act(() => {
+                result.current.actions.setFormState(new Map([['usermeta-text', 'ab']]))
+            })
+
+            act(() => {
+                result.current.actions.setShouldSave(true)
+            })
+
+            await waitFor(() => {
+                expect(mockSaveMeta).not.toHaveBeenCalled()
+                const errors = result.current.state.errors
+                // errors could be Map or plain object
+                const error = errors.get ? errors.get('usermeta-text') : errors['usermeta-text']
+                expect(error).toEqual(expect.any(String))
+            })
+        })
+
+        it('saves even when validation fails if savePartially is true', async () => {
+            mockValidator.mockReturnValue(false)
+            mockValidator.errors = []
+
+            const { result } = renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{}}
+                        onDataChanged={mockOnDataChanged}
+                        savePartially={true}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            act(() => {
+                result.current.actions.setJsonSchema(testSchema)
+            })
+
+            act(() => {
+                result.current.actions.setFormState(new Map([['usermeta-text', 'ab']]))
+            })
+
+            act(() => {
+                result.current.actions.setShouldSave(true)
+            })
+
+            await waitFor(() => {
+                expect(mockSaveMeta).toHaveBeenCalled()
+            })
+        })
+    })
+
+    describe('useMetadataContext', () => {
+        it('returns default context when used outside provider', () => {
+            const { result } = renderHook(() => useMetadataContext())
+            expect(result.current.state.node).toBeNull()
+            expect(result.current.state.saving).toBe(false)
+            expect(result.current.state.formState).toBeInstanceOf(Map)
+            expect(result.current.state.fields).toEqual({})
+            expect(result.current.state.namespaceJsonSchema).toBeNull()
+            expect(result.current.state.jsonSchema).toBeNull()
+            expect(result.current.state.shouldSave).toBe(false)
+            expect(result.current.state.editingTag).toBe('none')
+            expect(result.current.state.errors).toEqual({})
+            // dispatch and actions should be noop functions
+            expect(typeof result.current.dispatch).toBe('function')
+            expect(typeof result.current.actions.setSaving).toBe('function')
+        })
+
+        it('returns provider context when inside provider', () => {
+            const { result } = renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{}}
+                        onDataChanged={mockOnDataChanged}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            expect(result.current.state.node).toBe(mockNode)
+            expect(typeof result.current.dispatch).toBe('function')
+            expect(typeof result.current.actions.setSaving).toBe('function')
+        })
+
+        it('actions update state via dispatch', () => {
+            const { result } = renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{}}
+                        onDataChanged={mockOnDataChanged}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            act(() => {
+                result.current.actions.setSaving(true)
+            })
+            expect(result.current.state.saving).toBe(true)
+
+            act(() => {
+                result.current.actions.setFields({ foo: 'bar' })
+            })
+            expect(result.current.state.fields).toEqual({ foo: 'bar' })
+
+            const newFormState = new Map([['key', 'val']])
+            act(() => {
+                result.current.actions.setFormState(newFormState)
+            })
+            expect(result.current.state.formState).toBe(newFormState)
+
+            act(() => {
+                result.current.actions.setNamespaceJsonSchema(testSchema)
+            })
+            expect(result.current.state.namespaceJsonSchema).toBe(testSchema)
+
+            act(() => {
+                result.current.actions.setShouldSave(true)
+            })
+            expect(result.current.state.shouldSave).toBe(true)
+
+            act(() => {
+                result.current.actions.setJsonSchema(testSchema)
+            })
+            expect(result.current.state.jsonSchema).toBe(testSchema)
+        })
+    })
+})

--- a/frontend/assets/meta.user/res/js/fieldsv2/DateTimeInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/DateTimeInput.tsx
@@ -38,7 +38,7 @@ export const DateTimeInput: React.FC<InputProps> = ({
         label,
         disabled,
         error: errorText,
-        required: required,
+        required,
     }
 
     const popoverProps : PopoverProps = {withinPortal: false}

--- a/frontend/assets/meta.user/res/js/fieldsv2/NumbersInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/NumbersInput.tsx
@@ -27,6 +27,7 @@ export const NumbersInput: React.FC<InputProps> = ({
     description,
     placeholder,
     disabled,
+    required,
     value,
     requestToggleClose,
     onChange,
@@ -39,6 +40,7 @@ export const NumbersInput: React.FC<InputProps> = ({
         label,
         value: value || '',
         disabled,
+        required,
         error: errorText,
     }
 

--- a/frontend/assets/meta.user/res/js/fieldsv2/RatingInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/RatingInput.tsx
@@ -19,12 +19,19 @@
  */
 
 import React from 'react'
-import {Input, Rating} from '@mantine/core'
-import {InputProps} from "./CommonInputProps";
+import { Input, Rating } from '@mantine/core'
+import { InputProps } from "./CommonInputProps";
 
-export const RatingInput:React.FC<InputProps> = (props: InputProps) => {
-
-    const {label, description, value, errorText, disabled, onChange, requestToggleClose} = props;
+export const RatingInput: React.FC<InputProps> = ({
+    label,
+    description,
+    value,
+    errorText,
+    disabled,
+    required,
+    onChange,
+    requestToggleClose
+}: InputProps) => {
 
     return (
         <Input.Wrapper
@@ -33,20 +40,21 @@ export const RatingInput:React.FC<InputProps> = (props: InputProps) => {
             label={label}
             error={errorText}
             description={description}
+            required={required}
         >
             <Input
                 component={"div"}
                 disabled={disabled}
             >
-                <div style={{display: 'flex', alignItems: 'center'}} onBlur={requestToggleClose}>
+                <div style={{ display: 'flex', alignItems: 'center' }} onBlur={requestToggleClose}>
                     <span
                         className={'mdi mdi-star-off-outline'}
-                        style={{fontSize: 19, marginRight: 5, cursor: 'pointer'}}
-                        onClick={() => {!disabled? onChange( '', true):null}}
+                        style={{ fontSize: 19, marginRight: 5, cursor: 'pointer' }}
+                        onClick={() => { !disabled ? onChange('', true) : null }}
                     />
                     <Rating
                         className={""}
-                        value={parseInt(value)||0}
+                        value={parseInt(value) || 0}
                         onChange={(n) => onChange(n, true)}
                         readOnly={false}
                     />

--- a/frontend/assets/meta.user/res/js/fieldsv2/SearchModifierInput.test.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/SearchModifierInput.test.tsx
@@ -1,15 +1,19 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 
 import { TextSearchModifierInput, RangeSearchModifierInput } from './SearchModifierInput'
 import { TextSearchModifiers, NumberRangeModifiers } from './SearchModifiers'
 
-vi.mock('./SearchModifiers', () => ({
-    LeftSectionMenu: ({ items, onChange }) => (
-        <button onClick={() => onChange(items[0]?.value || '')}>menu</button>
-    )
-}))
+vi.mock('./SearchModifiers', async (importOriginal) => {
+    const actual = await importOriginal()
+    return {
+        ...actual,
+        LeftSectionMenu: ({ items, onChange }) => (
+            <button onClick={() => onChange(items[0]?.value || '')}>menu</button>
+        )
+    }
+})
 
 const renderProbe = ({ text, leftSection, onTextChange, onSubmit, onBlur, autoFocus }) => (
     <div>
@@ -24,6 +28,7 @@ const renderProbe = ({ text, leftSection, onTextChange, onSubmit, onBlur, autoFo
 
 describe('SearchModifierInput', () => {
     beforeEach(() => {
+        cleanup()
         vi.clearAllMocks()
     })
 

--- a/frontend/assets/meta.user/res/js/fieldsv2/SwitchInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/SwitchInput.tsx
@@ -19,28 +19,36 @@
  */
 
 import React from 'react'
-import {Input, Switch} from '@mantine/core'
-import {InputProps} from "./CommonInputProps";
+import { Input, Switch } from '@mantine/core'
+import { InputProps } from "./CommonInputProps";
 
-export const SwitchInput:React.FC<InputProps> = (props: InputProps) => {
-
-    const {label, description, value, errorText, disabled, onChange, requestToggleClose} = props;
+export const SwitchInput: React.FC<InputProps> = ({
+    label,
+    description,
+    value,
+    errorText,
+    disabled,
+    required,
+    onChange,
+    requestToggleClose
+}: InputProps) => {
 
     return (
         <Input.Wrapper
             label={label}
             description={description}
+            required={required}
             error={errorText}
         >
             <Input component={"div"} onBlur={requestToggleClose}>
-            <div style={{display: 'flex', alignItems: 'center', height:'100%'}} onBlur={requestToggleClose}>
-                <Switch
-                    label={label}
-                    checked={value}
-                    onChange={(e) => onChange(e.currentTarget.checked, true)}
-                    disabled={disabled}
-                />
-            </div>
+                <div style={{ display: 'flex', alignItems: 'center', height: '100%' }} onBlur={requestToggleClose}>
+                    <Switch
+                        label={label}
+                        checked={value}
+                        onChange={(e) => onChange(e.currentTarget.checked, true)}
+                        disabled={disabled}
+                    />
+                </div>
             </Input>
         </Input.Wrapper>
     )

--- a/frontend/assets/meta.user/res/js/fieldsv2/TagsCloudInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/TagsCloudInput.tsx
@@ -50,6 +50,7 @@ const formatValueArrayToString = (value: string[]) => {
 export const TagsCloudInput: React.FC<StringItemsInputProps> = ({
     name,
     label,
+    required,
     description,
     placeholder,
     dataLoader,
@@ -69,6 +70,7 @@ export const TagsCloudInput: React.FC<StringItemsInputProps> = ({
         description,
         placeholder,
         error: errorText,
+        required,
     }
 
     useEffect(() => {

--- a/frontend/assets/meta.user/res/js/fieldsv2/TextInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/TextInput.tsx
@@ -22,17 +22,30 @@ import React from 'react'
 import {TextInput as MTextInput, Textarea, JsonInput} from '@mantine/core'
 import {InputProps} from "./CommonInputProps";
 
-export const TextInput: React.FC<InputProps> = ({label, description, placeholder, subType, disabled, value, onChange, errorText, requestToggleClose}) => {
+export const TextInput: React.FC<InputProps> = ({
+    label,
+    description,
+    placeholder,
+    subType,
+    disabled,
+    required,
+    value,
+    onChange,
+    errorText,
+    requestToggleClose
+}) => {
     const props = {
         label,
         description,
         placeholder,
         value:value||'',
         disabled,
+        required,
         error: errorText,
         autoFocus:!!requestToggleClose,
-        onBlur:requestToggleClose
-}
+        onBlur: requestToggleClose
+    }
+
     const onChangeEvent = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => onChange(e.target.value)
     const onChangeString = (value: string) => onChange(value)
     const simpleEnter = (event: React.KeyboardEvent) => {

--- a/frontend/assets/meta.user/res/js/fieldsv2/URLInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/URLInput.tsx
@@ -22,15 +22,27 @@ import React from 'react'
 import {TextInput} from '@mantine/core'
 import {InputProps} from "./CommonInputProps";
 
-export const URLInput: React.FC<InputProps> = ({label, description, placeholder, disabled, value, onChange, requestToggleClose, errorText}) => {
+export const URLInput: React.FC<InputProps> = ({
+    label,
+    description,
+    placeholder,
+    disabled,
+    required,
+    value,
+    onChange,
+    requestToggleClose,
+    errorText
+}) => {
     const props = {
         label,
         description,
+        required,
         placeholder,
         value,
         disabled,
         error: errorText,
     }
+
     const onChangeEvent = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => onChange(e.target.value)
     const simpleEnter = (event: React.KeyboardEvent) => {
         if(event.key === 'Enter'){

--- a/frontend/assets/vitest.config.js
+++ b/frontend/assets/vitest.config.js
@@ -30,7 +30,7 @@ export default defineConfig({
 		// Provide a browser-like DOM for React component testing.
 		environment: 'jsdom',
 		// Discover both .js and .jsx test files under the repo.
-		include: ['**/*.{test,spec}.{js,jsx}'],
+		include: ['**/*.{test,spec}.{js,jsx,ts,tsx}'],
 		deps: {
 			inline: ['pydio/http/api', 'cells-sdk'],
 		},


### PR DESCRIPTION
This commit adds the missing required prop to several metadata input components and fixes a layout issue in the FieldEdit component.

Detailed Changes:
 - Implementation:
   - Added required prop to NumbersInput, RatingInput, SwitchInput, TagsCloudInput, TextInput, and URLInput components.
   - Fixed a prop name in DateTimeInput from required: required to required.
   - Changed FieldEdit export to wrap component in a scrollable div to fix layout in the Prompt To Upload dialog.
 - Documentation:
   - Updated component prop destructuring for better readability in RatingInput and SwitchInput.