### PR TITLE
feat(ui): fix Select component dropdown auto-open behavior

### DIFF
--- a/frontend/assets/meta.user/res/js/fieldsv2/Select.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/Select.tsx
@@ -95,7 +95,6 @@ export const Selector: React.FC<SelectInputProps> = ({value, label, description,
             comboboxProps={{ withinPortal: false }}
             styles={leftSection?{input:{paddingLeft: 30}}:undefined}
             renderOption={handleColors?renderOptions:undefined}
-            defaultDropdownOpened={!!requestToggleClose}
             onDropdownClose={requestToggleClose}
             onBlur={requestToggleClose}
         />


### PR DESCRIPTION
Changed the Select component to remove the defaultDropdownOpened prop and rely on onDropdownClose and onBlur handlers for closing.

Detailed Changes:
 - Implementation:
   - Changed Select.tsx to remove the defaultDropdownOpened prop which was forcing the dropdown open. The dropdown now closes using the onDropdownClose and onBlur handlers as intended.