### PR TITLE
feat(meta): add URL functionality to URLInput component

### DIFF
--- a/frontend/assets/meta.user/res/js/fieldsv2/URLInput.test.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/URLInput.test.tsx
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2026 Abstrium SAS <team (at) pyd.io>
+ * This file is part of Pydio.
+ *
+ * Pydio is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { ensureHttpScheme, formatURL } from './URLInput'
+
+describe('URL Utility Functions', () => {
+    describe('ensureHttpScheme', () => {
+        it('adds https:// to URLs without a scheme', () => {
+            expect(ensureHttpScheme('example.com')).toBe('https://example.com')
+        })
+
+        it('preserves existing http:// scheme', () => {
+            expect(ensureHttpScheme('http://example.com')).toBe('http://example.com')
+        })
+
+        it('preserves existing https:// scheme', () => {
+            expect(ensureHttpScheme('https://example.com')).toBe('https://example.com')
+        })
+
+        it('preserves mailto: scheme', () => {
+            expect(ensureHttpScheme('mailto:test@example.com')).toBe('mailto:test@example.com')
+        })
+
+        it('preserves ftp: scheme', () => {
+            expect(ensureHttpScheme('ftp://example.com')).toBe('ftp://example.com')
+        })
+
+        it('preserves other schemes like tel:', () => {
+            expect(ensureHttpScheme('tel:+1234567890')).toBe('tel:+1234567890')
+        })
+
+        it('preserves custom schemes with multiple characters', () => {
+            expect(ensureHttpScheme('git+https://github.com/repo.git')).toBe(
+                'git+https://github.com/repo.git'
+            )
+        })
+
+        it('handles empty string', () => {
+            expect(ensureHttpScheme('')).toBe('')
+        })
+
+        it('handles null/undefined by treating as empty string', () => {
+            expect(ensureHttpScheme(null as any)).toBe('')
+            expect(ensureHttpScheme(undefined as any)).toBe('')
+        })
+
+        it('trims whitespace before checking scheme', () => {
+            expect(ensureHttpScheme('  example.com  ')).toBe('https://example.com')
+            expect(ensureHttpScheme('  http://example.com  ')).toBe('http://example.com')
+        })
+
+        it('does not add scheme to whitespace-only strings', () => {
+            expect(ensureHttpScheme('   ')).toBe('')
+        })
+
+        it('handles URLs with multiple dots correctly', () => {
+            expect(ensureHttpScheme('example.co.uk')).toBe('https://example.co.uk')
+        })
+
+        it('handles URLs with hyphens in domain', () => {
+            expect(ensureHttpScheme('my-example.com')).toBe('https://my-example.com')
+        })
+
+        it('handles URLs with subdomains', () => {
+            expect(ensureHttpScheme('sub.domain.example.com')).toBe('https://sub.domain.example.com')
+        })
+
+        it('handles URLs with ports', () => {
+            expect(ensureHttpScheme('example.com:8080')).toBe('https://example.com:8080')
+        })
+
+        it('handles URLs with paths', () => {
+            expect(ensureHttpScheme('example.com/path/to/page')).toBe('https://example.com/path/to/page')
+        })
+
+        it('handles URLs with query strings', () => {
+            expect(ensureHttpScheme('example.com?param=value')).toBe('https://example.com?param=value')
+        })
+
+        it('handles URLs with fragments', () => {
+            expect(ensureHttpScheme('example.com#section')).toBe('https://example.com#section')
+        })
+    })
+
+    describe('formatURL', () => {
+        it('returns empty strings for empty input', () => {
+            const result = formatURL('')
+            expect(result).toEqual({ normalizedURL: '', displayURL: '' })
+        })
+
+        it('returns empty strings for whitespace-only input', () => {
+            const result = formatURL('   ')
+            expect(result).toEqual({ normalizedURL: '', displayURL: '' })
+        })
+
+        it('normalizes URL and extracts hostname for display', () => {
+            const result = formatURL('example.com')
+            expect(result.normalizedURL).toBe('https://example.com')
+            expect(result.displayURL).toBe('example.com')
+        })
+
+        it('extracts hostname from full URL with path', () => {
+            const result = formatURL('example.com/path/to/page')
+            expect(result.displayURL).toBe('example.com')
+        })
+
+        it('extracts hostname from URL with subdomain', () => {
+            const result = formatURL('sub.example.com')
+            expect(result.displayURL).toBe('sub.example.com')
+        })
+
+        it('handles URLs with port numbers', () => {
+            const result = formatURL('example.com:8080')
+            expect(result.normalizedURL).toBe('https://example.com:8080')
+            expect(result.displayURL).toBe('example.com')
+        })
+
+        it('handles URLs with query parameters', () => {
+            const result = formatURL('example.com?param=value')
+            expect(result.displayURL).toBe('example.com')
+        })
+
+        it('preserves existing https:// scheme', () => {
+            const result = formatURL('https://example.com')
+            expect(result.normalizedURL).toBe('https://example.com')
+            expect(result.displayURL).toBe('example.com')
+        })
+
+        it('preserves existing http:// scheme', () => {
+            const result = formatURL('http://example.com')
+            expect(result.normalizedURL).toBe('http://example.com')
+            expect(result.displayURL).toBe('example.com')
+        })
+
+        it('preserves ftp:// scheme', () => {
+            const result = formatURL('ftp://files.example.com')
+            expect(result.normalizedURL).toBe('ftp://files.example.com')
+            expect(result.displayURL).toBe('files.example.com')
+        })
+
+        it('handles mailto: URLs correctly', () => {
+            const result = formatURL('mailto:test@example.com')
+            expect(result.normalizedURL).toBe('mailto:test@example.com')
+            // mailto URLs don't parse as web URLs, so displayURL should be the sanitized value
+            expect(result.displayURL).not.toBe('')
+        })
+
+        it('uses full normalized URL when URL parsing fails', () => {
+            const result = formatURL('not-a-valid-url-format')
+            expect(result.normalizedURL).toBe('https://not-a-valid-url-format')
+            // When URL parsing fails, displayURL falls back to the normalized URL
+            // sanitizeUrl may return the value unchanged, so we test that displayURL is not empty
+            expect(result.displayURL).not.toBe('')
+            expect(typeof result.displayURL).toBe('string')
+        })
+
+        it('extracts hostname from URL with www prefix', () => {
+            const result = formatURL('www.example.com')
+            expect(result.displayURL).toBe('www.example.com')
+        })
+
+        it('handles internationalized domain names', () => {
+            const result = formatURL('münchen.de')
+            expect(result.normalizedURL).toBe('https://münchen.de')
+        })
+
+        it('trims whitespace from URLs', () => {
+            const result = formatURL('  example.com  ')
+            expect(result.normalizedURL).toBe('https://example.com')
+            expect(result.displayURL).toBe('example.com')
+        })
+
+        it('handles URLs with authentication info', () => {
+            const result = formatURL('https://user:pass@example.com')
+            expect(result.displayURL).toBe('example.com')
+        })
+
+        it('handles localhost URLs', () => {
+            const result = formatURL('localhost:3000')
+            expect(result.normalizedURL).toBe('https://localhost:3000')
+            expect(result.displayURL).toBe('localhost')
+        })
+
+        it('handles IP addresses', () => {
+            const result = formatURL('192.168.1.1')
+            expect(result.normalizedURL).toBe('https://192.168.1.1')
+            expect(result.displayURL).toBe('192.168.1.1')
+        })
+
+        it('handles IP addresses with ports', () => {
+            const result = formatURL('192.168.1.1:8080')
+            expect(result.normalizedURL).toBe('https://192.168.1.1:8080')
+            expect(result.displayURL).toBe('192.168.1.1')
+        })
+
+        it('handles URLs with fragments and query strings', () => {
+            const result = formatURL('example.com/page?param=value#section')
+            expect(result.displayURL).toBe('example.com')
+        })
+    })
+
+    describe('Edge cases and security', () => {
+        it('handles URLs with special characters in path', () => {
+            const result = formatURL('example.com/path/with%20spaces')
+            expect(result.displayURL).toBe('example.com')
+        })
+
+        it('handles very long URLs', () => {
+            const longPath = 'a'.repeat(1000)
+            const result = formatURL(`example.com/${longPath}`)
+            expect(result.displayURL).toBe('example.com')
+        })
+
+        it('handles URLs with emojis in domain', () => {
+            const result = formatURL('example.com')
+            expect(result.displayURL).toBe('example.com')
+        })
+
+        it('handles multiple slashes in path', () => {
+            const result = formatURL('example.com///path///to///page')
+            expect(result.displayURL).toBe('example.com')
+        })
+
+        it('ensureHttpScheme preserves URL encoding', () => {
+            const encoded = 'example.com/path%20with%20spaces'
+            expect(ensureHttpScheme(encoded)).toBe(`https://${encoded}`)
+        })
+
+        it('formatURL handles already normalized URLs without modification', () => {
+            const url = 'https://example.com/path'
+            const result = formatURL(url)
+            expect(result.normalizedURL).toBe(url)
+        })
+    })
+})

--- a/frontend/assets/meta.user/res/js/fieldsv2/URLInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/URLInput.tsx
@@ -18,9 +18,129 @@
  * The latest code can be found at <https://pydio.com>.
  */
 
-import React from 'react'
-import {TextInput} from '@mantine/core'
-import {InputProps} from "./CommonInputProps";
+import React, { useCallback, useState, useEffect } from 'react'
+import { TextInput } from '@mantine/core'
+import { sanitizeUrl } from "@braintree/sanitize-url"
+import { InputProps } from "./CommonInputProps"
+
+/**
+ * If no scheme is provided, default to https:// to avoid relative links.
+ * Keeps existing schemes (mailto:, ftp:, etc.) untouched.
+ * Distinguishes between URL schemes (http:, ftp:, etc.) and port numbers (domain:8080).
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+export const ensureHttpScheme = (raw: string): string => {
+    const trimmed = String(raw || '').trim()
+    if (!trimmed) {
+        return ''
+    }
+    // Check for valid URL schemes: must start with letter, followed by alphanumeric/+/-.
+    // A valid scheme is followed by :// or : and then non-digits
+    // This distinguishes from port numbers (localhost:8080 has only digits after :)
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) {
+        return trimmed
+    }
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:(?!\d)/.test(trimmed)) {
+        return trimmed
+    }
+    return `https://${trimmed}`
+}
+
+/**
+ * Formats a URL for display and validation
+ * @param {string} url - Raw URL input
+ * @returns {{normalizedURL: string, displayURL: string}} Normalized and display URLs
+ */
+export const formatURL = (url: string): { normalizedURL: string; displayURL: string } => {
+    if (!url || !String(url).trim()) {
+        return { normalizedURL: '', displayURL: '' }
+    }
+    const normalizedURL = ensureHttpScheme(url)
+    const sanitizedURL = sanitizeUrl(normalizedURL)
+
+    if (!sanitizedURL) {
+        return { normalizedURL: '', displayURL: '' }
+    }
+
+    // Extract display text (domain or full URL)
+    let displayURL = sanitizedURL
+    try {
+        const urlObj = new URL(sanitizedURL)
+        displayURL = urlObj.hostname || sanitizedURL
+    } catch (e) {
+        // If URL parsing fails, use sanitized value
+        displayURL = sanitizedURL
+    }
+
+    return {
+        normalizedURL,
+        displayURL,
+    }
+}
+
+/**
+ * URLIcon component for displaying the open-in-new icon
+ */
+interface URLIconProps {
+    fontSize?: number
+}
+
+export const URLIcon: React.FC<URLIconProps> = ({ fontSize = 14 }) => (
+    <span
+        data-testid="open-in-new-icon"
+        className="mdi mdi-open-in-new"
+        style={{ fontSize, color: 'inherit' }}
+    />
+)
+
+/**
+ * URLLinkIcon component - renders a link with icon or just the icon
+ */
+interface URLLinkIconProps {
+    fontSize?: number
+    url: string
+    displayText?: string
+    children?: React.ReactNode
+}
+
+export const URLLinkIcon: React.FC<URLLinkIconProps> = ({
+    fontSize = 14,
+    url,
+    displayText,
+    children,
+}) => {
+    if (!url || !String(url).trim()) {
+        return null
+    }
+    const sanitizedURL = sanitizeUrl(ensureHttpScheme(url))
+    if (!sanitizedURL) {
+        return null
+    }
+
+    const labelText = displayText || children || url
+
+    return (
+        <a
+            href={sanitizedURL}
+            target="_blank"
+            aria-label={`Open ${labelText} in a new tab`}
+            rel="noopener noreferrer"
+            onClick={(e) => {
+                e.stopPropagation()
+            }}
+            style={{
+                color: 'inherit',
+                textDecoration: 'none',
+            }}
+            data-testid="url-link-icon"
+        >
+            {children}
+            <URLIcon fontSize={fontSize} />
+        </a>
+    )
+}
 
 export const URLInput: React.FC<InputProps> = ({
     label,
@@ -31,31 +151,67 @@ export const URLInput: React.FC<InputProps> = ({
     value,
     onChange,
     requestToggleClose,
-    errorText
+    errorText,
 }) => {
+    const [localValue, setLocalValue] = useState(value || '')
+
+    useEffect(() => {
+        setLocalValue(value || '')
+    }, [value])
+
+    const handleChange = useCallback(
+        (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+            const newValue = event.target.value
+            setLocalValue(newValue)
+            onChange(newValue, false)
+        },
+        [onChange]
+    )
+
+    const handleConfirmValue = useCallback(() => {
+        const normalized = ensureHttpScheme(localValue)
+        if (normalized !== localValue) {
+            setLocalValue(normalized)
+            onChange(normalized, false)
+        }
+    }, [localValue, onChange])
+
+    const handleKeyPress = useCallback(
+        (event: React.KeyboardEvent) => {
+            if (event.key === 'Enter') {
+                handleConfirmValue()
+            }
+        },
+        [handleConfirmValue]
+    )
+
     const props = {
         label,
         description,
         required,
-        placeholder,
-        value,
+        placeholder: placeholder || "URL",
+        value: localValue,
         disabled,
         error: errorText,
     }
 
-    const onChangeEvent = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => onChange(e.target.value)
-    const simpleEnter = (event: React.KeyboardEvent) => {
-        if(event.key === 'Enter'){
-            onChange(value, true);
-        }
-    }
+    const hasValue = localValue && localValue.trim() !== ''
+    const hasError = !!errorText
 
-    return <TextInput
-        {...props}
-        onChange={onChangeEvent}
-        onKeyPress={simpleEnter}
-        rightSection={<span className={'mdi mdi-open-in-new'}/>}
-        autoFocus={!!requestToggleClose}
-        onBlur={requestToggleClose}
-    />
- }
+    return (
+        <div style={{ position: 'relative' }}>
+            <TextInput
+                {...props}
+                onChange={handleChange}
+                onKeyPress={handleKeyPress}
+                onBlur={handleConfirmValue}
+                autoFocus={!!requestToggleClose}
+                rightSection={
+                    hasValue && !hasError ? (
+                        <URLLinkIcon fontSize={18} url={localValue} displayText={localValue} />
+                    ) : null
+                }
+            />
+        </div>
+    )
+}


### PR DESCRIPTION
This commit adds URL utility functions and enhances the URLInput component with improved URL handling, validation, and display features.

Detailed Changes:
 - Implementation:
   - Added ensureHttpScheme function that adds https:// scheme to URLs without one while preserving existing schemes.
   - Added formatURL function that normalizes URLs and extracts hostnames for display.
   - Added URLIcon and URLLinkIcon components for displaying clickable URL links with icons.
   - Enhanced URLInput component with local state management, URL normalization on blur/enter, and integrated link icon.
   - Added comprehensive test suite for URL utility functions covering various URL formats and edge cases.
 - Dependencies:
   - Added @braintree/sanitize-url dependency for URL sanitization.