### PR TITLE
fix: metadata improvements allow empty val

### DIFF
--- a/frontend/assets/meta.user/res/js/context/metadata.test.tsx
+++ b/frontend/assets/meta.user/res/js/context/metadata.test.tsx
@@ -15,29 +15,8 @@ vi.mock('../MetaClient', () => ({
     }
 }))
 
-// Mock ajv and ajv-formats
-const { mockCompile, mockAjv, mockAddFormats } = vi.hoisted(() => {
-    const mockCompile: Mock<() => any> = vi.fn()
-    const mockAjv: Mock<() => any> = vi.fn(function() {
-        return {
-            compile: mockCompile
-        }
-    })
-    const mockAddFormats: Mock<() => any> = vi.fn()
-    return { mockCompile, mockAjv, mockAddFormats }
-})
-vi.mock('ajv', () => ({
-    default: mockAjv,
-    JSONSchemaType: {},
-    ValidateFunction: {},
-    __esModule: true
-}))
-vi.mock('ajv-formats', () => ({
-    default: mockAddFormats
-}))
-
 import MetaClient from '../MetaClient'
-import { MetadataContextProvider, useMetadataContext, MetadataContext } from './metadata'
+import { MetadataContextProvider, useMetadataContext } from './metadata'
 
 interface MockNode {
   getMetadata: Mock<() => Map<string, any>>;
@@ -62,17 +41,14 @@ describe('MetadataContext', () => {
     let mockNode: MockNode
     let mockSaveMeta: Mock<(formData: Map<string, any>) => Promise<any>>
     let mockOnDataChanged: Mock<(formData: Map<string, any>, isValid: boolean) => void>
-    let mockValidator: Mock<any> & { errors: any }
 
     beforeEach(() => {
         mockNode = createMockNode()
         mockSaveMeta = vi.fn(() => Promise.resolve())
         mockOnDataChanged = vi.fn()
-        mockValidator = vi.fn(() => ({ isValid: true, errors: {} })) as Mock<any> & { errors: any }
-        mockCompile.mockReturnValue(mockValidator)
         // Setup default MetaClient mock
         MetaClient.getInstance.mockReturnValue({
-            getNamespaceSchema: vi.fn(() => Promise.resolve({ JsonSchema: null }))
+            getNamespaceSchema: vi.fn(() => Promise.resolve({ JsonSchema: testSchema }))
         })
         vi.clearAllMocks()
     })
@@ -80,8 +56,6 @@ describe('MetadataContext', () => {
     afterEach(() => {
         vi.restoreAllMocks()
     })
-
-
 
     describe('MetadataContextProvider', () => {
         it('renders children and provides context', () => {
@@ -144,20 +118,11 @@ describe('MetadataContext', () => {
             await waitFor(() => {
                 expect(mockGetNamespaceSchema).toHaveBeenCalled()
             })
-            // Should set jsonSchema in state
-            // We can't directly access state, but we can check that compile was called
-            await waitFor(() => {
-                expect(mockCompile).toHaveBeenCalledWith(testSchema)
-            })
         })
 
-        it('updates formState when node path changes', async () => {
-            const metadata = new Map([['key', 'value']])
+        it('updates formState when node metadata changes', async () => {
+            const metadata = new Map([['usermeta-text', 'hello']])
             mockNode.getMetadata.mockReturnValue(metadata)
-
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
 
             const { result } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
@@ -172,27 +137,15 @@ describe('MetadataContext', () => {
                 )
             })
 
-            // Set schema to initialize validator
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
+            await waitFor(() => {
+                expect(mockOnDataChanged).toHaveBeenCalled()
             })
 
-            // Set the formState directly (simulating what the effect does)
-            act(() => {
-                result.current.actions.setFormState(metadata)
-            })
-
-            // Verify onDataChanged was called with the cleaned formState (same data as input since no empty keys)
-            expect(mockOnDataChanged).toHaveBeenCalled()
             const callArgs = mockOnDataChanged.mock.calls[mockOnDataChanged.mock.calls.length - 1]
-            expect(callArgs[0].get('key')).toBe('value')
+            expect(callArgs[0].get('usermeta-text')).toBe('hello')
         })
 
         it('calls onDataChanged when formState changes', async () => {
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
-
             const { result } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
                     <MetadataContextProvider
@@ -206,24 +159,19 @@ describe('MetadataContext', () => {
                 )
             })
 
-            // Set schema to initialize validator
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
-            })
-
-            const newFormState = new Map([['newKey', 'newValue']])
+            mockOnDataChanged.mockClear()
+            const newFormState = new Map([['usermeta-text', 'hello']])
             act(() => {
                 result.current.actions.setFormState(newFormState)
             })
 
-            expect(mockOnDataChanged).toHaveBeenCalledWith(newFormState, expect.any(Boolean))
+            expect(mockOnDataChanged).toHaveBeenCalled()
+            const [formState, isValid] = mockOnDataChanged.mock.calls[0]
+            expect(formState.get('usermeta-text')).toBe('hello')
+            expect(typeof isValid).toBe('boolean')
         })
 
-        it('validates and saves when shouldSave becomes true', async () => {
-            // Setup validator to pass
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
-
+        it('validates data using the schema', async () => {
             const { result } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
                     <MetadataContextProvider
@@ -237,20 +185,180 @@ describe('MetadataContext', () => {
                 )
             })
 
-            // Set jsonSchema to trigger validator creation
+            // Valid data - all required fields present with correct format
+            mockOnDataChanged.mockClear()
+            const validData = new Map([
+                ['usermeta-text', 'hello'],
+                ['usermeta-paragraph', 'this is a paragraph'],
+                ['usermeta-number', '5'],
+                ['usermeta-datetime', '2024-01-01T00:00:00Z']
+            ])
             act(() => {
-                result.current.actions.setJsonSchema(testSchema)
+                result.current.actions.setFormState(validData)
             })
 
-            // Set formState
-            act(() => {
-                result.current.actions.setFormState(new Map([['usermeta-text', 'valid']]))
-            })
-
-            // After validation passes, errors should be empty object
             await waitFor(() => {
-                expect(result.current.state.errors).toEqual({})
-                expect(Object.keys(result.current.state.errors).length).toBe(0)
+                const [, isValid] = mockOnDataChanged.mock.calls[mockOnDataChanged.mock.calls.length - 1]
+                expect(isValid).toBe(true)
+            })
+        })
+
+        it('detects validation errors in required fields', async () => {
+            const { result } = renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{}}
+                        onDataChanged={mockOnDataChanged}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            // Missing required fields - should fail validation
+            mockOnDataChanged.mockClear()
+            const incompleteData = new Map([
+                ['usermeta-text', 'hello']
+                // Missing other required fields
+            ])
+            act(() => {
+                result.current.actions.setFormState(incompleteData)
+            })
+
+            await waitFor(() => {
+                const [, isValid] = mockOnDataChanged.mock.calls[mockOnDataChanged.mock.calls.length - 1]
+                expect(isValid).toBe(false)
+            })
+        })
+
+        it('removes empty string values before validation', async () => {
+            const { result } = renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{}}
+                        onDataChanged={mockOnDataChanged}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            mockOnDataChanged.mockClear()
+            // Form state with empty values mixed with valid data
+            const formStateWithEmptyValues = new Map([
+                ['usermeta-text', 'hello'],
+                ['usermeta-paragraph', ''],  // empty - should be removed for validation
+                ['usermeta-number', ''],     // empty - should be removed for validation
+                ['usermeta-datetime', 'should-remain-for-callback']
+            ])
+
+            act(() => {
+                result.current.actions.setFormState(formStateWithEmptyValues)
+            })
+
+            // Original formState should be preserved in onDataChanged (with empty values)
+            expect(mockOnDataChanged).toHaveBeenCalled()
+            const [callbackFormState] = mockOnDataChanged.mock.calls[mockOnDataChanged.mock.calls.length - 1]
+            expect(callbackFormState.get('usermeta-paragraph')).toBe('')
+            expect(callbackFormState.get('usermeta-number')).toBe('')
+            expect(callbackFormState.size).toBe(4)
+        })
+
+        it('removes empty string keys before validation', async () => {
+            const { result } = renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{}}
+                        onDataChanged={mockOnDataChanged}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            mockOnDataChanged.mockClear()
+            // Form state with empty key
+            const formStateWithEmptyKey = new Map([
+                ['usermeta-text', 'hello'],
+                ['', 'should-be-removed-for-validation'],
+                ['usermeta-paragraph', 'paragraph text']
+            ])
+
+            act(() => {
+                result.current.actions.setFormState(formStateWithEmptyKey)
+            })
+
+            // Original formState should be preserved in callback (with empty key)
+            expect(mockOnDataChanged).toHaveBeenCalled()
+            const [callbackFormState] = mockOnDataChanged.mock.calls[0]
+            expect(callbackFormState.has('')).toBe(true)
+            expect(callbackFormState.size).toBe(3)
+        })
+
+        it('removes whitespace-only values before validation', async () => {
+            const { result } = renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{}}
+                        onDataChanged={mockOnDataChanged}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            mockOnDataChanged.mockClear()
+            // Form state with whitespace-only values
+            const formStateWithWhitespace = new Map([
+                ['usermeta-text', 'hello'],
+                ['usermeta-paragraph', '   '],    // whitespace - should be removed for validation
+                ['usermeta-number', '\t\n'],     // whitespace - should be removed for validation
+                ['usermeta-datetime', 'test']
+            ])
+
+            act(() => {
+                result.current.actions.setFormState(formStateWithWhitespace)
+            })
+
+            // Original formState should be preserved in callback
+            expect(mockOnDataChanged).toHaveBeenCalled()
+            const [callbackFormState] = mockOnDataChanged.mock.calls[0]
+            expect(callbackFormState.get('usermeta-paragraph')).toBe('   ')
+            expect(callbackFormState.get('usermeta-number')).toBe('\t\n')
+            expect(callbackFormState.size).toBe(4)
+        })
+
+        it('validates and saves when shouldSave becomes true with valid data', async () => {
+            const { result } = renderHook(() => useMetadataContext(), {
+                wrapper: ({ children }) => (
+                    <MetadataContextProvider
+                        node={mockNode}
+                        saveMeta={mockSaveMeta}
+                        value={{}}
+                        onDataChanged={mockOnDataChanged}
+                    >
+                        {children}
+                    </MetadataContextProvider>
+                )
+            })
+
+            // Set valid data
+            const validData = new Map([
+                ['usermeta-text', 'hello'],
+                ['usermeta-paragraph', 'this is a paragraph'],
+                ['usermeta-number', '5'],
+                ['usermeta-datetime', '2024-01-01T00:00:00Z']
+            ])
+            act(() => {
+                result.current.actions.setFormState(validData)
             })
 
             // Trigger save
@@ -259,58 +367,13 @@ describe('MetadataContext', () => {
             })
 
             await waitFor(() => {
-                expect(mockSaveMeta).toHaveBeenCalled()
+                expect(mockSaveMeta).toHaveBeenCalledWith(validData)
                 expect(result.current.state.saving).toBe(false)
                 expect(result.current.state.shouldSave).toBe(false)
             })
         })
 
-        it('does not save when validation fails and savePartially is false', async () => {
-            // Setup validator to fail
-            mockValidator.mockReturnValue(false)
-            mockValidator.errors = [
-                { instancePath: '/usermeta-text', schemaPath: '#/properties/usermeta-text/minLength', message: 'must be at least 3 characters', params: {} }
-            ]
-
-            const { result } = renderHook(() => useMetadataContext(), {
-                wrapper: ({ children }) => (
-                    <MetadataContextProvider
-                        node={mockNode}
-                        saveMeta={mockSaveMeta}
-                        value={{}}
-                        onDataChanged={mockOnDataChanged}
-                        savePartially={false}
-                    >
-                        {children}
-                    </MetadataContextProvider>
-                )
-            })
-
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
-            })
-
-            act(() => {
-                result.current.actions.setFormState(new Map([['usermeta-text', 'ab']]))
-            })
-
-            act(() => {
-                result.current.actions.setShouldSave(true)
-            })
-
-            await waitFor(() => {
-                expect(mockSaveMeta).not.toHaveBeenCalled()
-                const errors = result.current.state.errors
-                // errors could be Map or plain object
-                const error = errors.get ? errors.get('usermeta-text') : errors['usermeta-text']
-                expect(error).toEqual(expect.any(String))
-            })
-        })
-
         it('saves even when validation fails if savePartially is true', async () => {
-            mockValidator.mockReturnValue(false)
-            mockValidator.errors = []
-
             const { result } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
                     <MetadataContextProvider
@@ -325,161 +388,26 @@ describe('MetadataContext', () => {
                 )
             })
 
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
-            })
-
-            act(() => {
-                result.current.actions.setFormState(new Map([['usermeta-text', 'ab']]))
-            })
-
-            act(() => {
-                result.current.actions.setShouldSave(true)
-            })
-
-            await waitFor(() => {
-                expect(mockSaveMeta).toHaveBeenCalled()
-            })
-        })
-
-        it('blocks save when savePartially is false and validation fails', async () => {
-            // Setup validator to fail with specific error
-            mockValidator.mockReturnValue(false)
-            mockValidator.errors = [
-                { instancePath: '/usermeta-text', schemaPath: '#/properties/usermeta-text/minLength', message: 'must be at least 3 characters', params: {} }
-            ]
-
-            const { result } = renderHook(() => useMetadataContext(), {
-                wrapper: ({ children }) => (
-                    <MetadataContextProvider
-                        node={mockNode}
-                        saveMeta={mockSaveMeta}
-                        value={{}}
-                        onDataChanged={mockOnDataChanged}
-                        savePartially={false}
-                    >
-                        {children}
-                    </MetadataContextProvider>
-                )
-            })
-
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
-            })
-
             // Set invalid data
-            act(() => {
-                result.current.actions.setFormState(new Map([['usermeta-text', 'x']]))
-            })
-
-            // Try to save
-            mockSaveMeta.mockClear()
-            act(() => {
-                result.current.actions.setShouldSave(true)
-            })
-
-            // Wait and verify save was NOT called
-            await waitFor(() => {
-                expect(mockSaveMeta).not.toHaveBeenCalled()
-                expect(result.current.state.saving).toBe(false)
-                expect(result.current.state.shouldSave).toBe(true) // Should remain true since save was blocked
-            })
-        })
-
-        it('savePartially defaults to false when not provided', async () => {
-            // Setup validator to fail
-            mockValidator.mockReturnValue(false)
-            mockValidator.errors = [
-                { instancePath: '/usermeta-text', schemaPath: '#/properties/usermeta-text/minLength', message: 'must be at least 3 characters', params: {} }
-            ]
-
-            const { result } = renderHook(() => useMetadataContext(), {
-                wrapper: ({ children }) => (
-                    <MetadataContextProvider
-                        node={mockNode}
-                        saveMeta={mockSaveMeta}
-                        value={{}}
-                        onDataChanged={mockOnDataChanged}
-                        // No savePartially prop - should default to false
-                    >
-                        {children}
-                    </MetadataContextProvider>
-                )
-            })
-
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
-            })
-
-            // Set invalid data
-            act(() => {
-                result.current.actions.setFormState(new Map([['usermeta-text', 'no']]))
-            })
-
-            mockSaveMeta.mockClear()
-            act(() => {
-                result.current.actions.setShouldSave(true)
-            })
-
-            // Should NOT save (default is false)
-            await waitFor(() => {
-                expect(mockSaveMeta).not.toHaveBeenCalled()
-            })
-        })
-
-        it('allows save when savePartially is true even with validation errors', async () => {
-            // Setup validator to fail with errors
-            mockValidator.mockReturnValue(false)
-            mockValidator.errors = [
-                { instancePath: '/field1', schemaPath: '#/properties/field1/type', message: 'must be string', params: {} },
-                { instancePath: '/field2', schemaPath: '#/properties/field2/minLength', message: 'must be at least 5 characters', params: {} }
-            ]
-
-            const { result } = renderHook(() => useMetadataContext(), {
-                wrapper: ({ children }) => (
-                    <MetadataContextProvider
-                        node={mockNode}
-                        saveMeta={mockSaveMeta}
-                        value={{}}
-                        onDataChanged={mockOnDataChanged}
-                        savePartially={true}
-                    >
-                        {children}
-                    </MetadataContextProvider>
-                )
-            })
-
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
-            })
-
-            // Set data with validation errors
             const invalidData = new Map([
-                ['field1', 123], // wrong type
-                ['field2', 'abc'] // too short
+                ['usermeta-text', 'h']  // too short
             ])
             act(() => {
                 result.current.actions.setFormState(invalidData)
             })
 
+            // Trigger save
             mockSaveMeta.mockClear()
             act(() => {
                 result.current.actions.setShouldSave(true)
             })
 
-            // Should save despite errors
             await waitFor(() => {
                 expect(mockSaveMeta).toHaveBeenCalledWith(invalidData)
-                expect(result.current.state.saving).toBe(false)
-                expect(result.current.state.shouldSave).toBe(false)
             })
         })
 
-        it('removes empty string keys from formState', () => {
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
-
+        it('preserves original formState in callbacks while cleaning only for validation', async () => {
             const { result } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
                     <MetadataContextProvider
@@ -493,277 +421,32 @@ describe('MetadataContext', () => {
                 )
             })
 
-            // Set schema to initialize validator
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
-            })
-
             mockOnDataChanged.mockClear()
-
-            // Create formState with an empty string key
-            const formStateWithEmptyKey = new Map([
-                ['key1', 'value1'],
-                ['', 'emptyKeyValue'],
-                ['key2', 'value2']
-            ])
-
-            act(() => {
-                result.current.actions.setFormState(formStateWithEmptyKey)
-            })
-
-            // Verify onDataChanged was called
-            expect(mockOnDataChanged).toHaveBeenCalled()
-            const cleanedState = mockOnDataChanged.mock.calls[0][0]
-
-            // The cleaned formState should not contain the empty key
-            expect(cleanedState.has('')).toBe(false)
-            expect(cleanedState.get('key1')).toBe('value1')
-            expect(cleanedState.get('key2')).toBe('value2')
-            expect(cleanedState.size).toBe(2)
-        })
-
-        it('does not preserve entries with empty string values', () => {
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
-
-            const { result } = renderHook(() => useMetadataContext(), {
-                wrapper: ({ children }) => (
-                    <MetadataContextProvider
-                        node={mockNode}
-                        saveMeta={mockSaveMeta}
-                        value={{}}
-                        onDataChanged={mockOnDataChanged}
-                    >
-                        {children}
-                    </MetadataContextProvider>
-                )
-            })
-
-            // Set schema to initialize validator
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
-            })
-
-            mockOnDataChanged.mockClear()
-
-            // Create formState with empty string VALUE (not key)
-            const formStateWithEmptyValue = new Map([
-                ['key1', 'value1'],
-                ['key2', ''],  // empty value, but valid key
-                ['key3', 'value3']
-            ])
-
-            act(() => {
-                result.current.actions.setFormState(formStateWithEmptyValue)
-            })
-
-            // Verify onDataChanged was called
-            expect(mockOnDataChanged).toHaveBeenCalled()
-            const cleanedState = mockOnDataChanged.mock.calls[0][0]
-
-            // All keys should be preserved, including the one with empty value
-            expect(cleanedState.get('key1')).toBe('value1')
-            expect(cleanedState.has('key2')).toBe(false)
-            expect(cleanedState.get('key3')).toBe('value3')
-            expect(cleanedState.size).toBe(2)
-        })
-
-        it('keeps all valid non-empty keys intact', () => {
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
-
-            const { result } = renderHook(() => useMetadataContext(), {
-                wrapper: ({ children }) => (
-                    <MetadataContextProvider
-                        node={mockNode}
-                        saveMeta={mockSaveMeta}
-                        value={{}}
-                        onDataChanged={mockOnDataChanged}
-                    >
-                        {children}
-                    </MetadataContextProvider>
-                )
-            })
-
-            // Set schema to initialize validator
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
-            })
-
-            mockOnDataChanged.mockClear()
-
-            const formState = new Map([
+            // Mix of empty keys, empty values, and valid data
+            const mixedFormState = new Map([
                 ['usermeta-text', 'hello'],
-                ['key-with-dash', 'value'],
-                ['key_with_underscore', 'value'],
-                ['123numerickey', 'value']
+                ['', 'empty-key-value'],
+                ['usermeta-paragraph', ''],
+                ['usermeta-number', '5'],
+                ['usermeta-datetime', '2024-01-01T00:00:00Z']
             ])
 
             act(() => {
-                result.current.actions.setFormState(formState)
+                result.current.actions.setFormState(mixedFormState)
             })
 
-            // Verify onDataChanged was called
+            // The callback should receive the exact original state
             expect(mockOnDataChanged).toHaveBeenCalled()
-            const cleanedState = mockOnDataChanged.mock.calls[0][0]
-
-            // All valid keys should be preserved
-            expect(cleanedState.get('usermeta-text')).toBe('hello')
-            expect(cleanedState.get('key-with-dash')).toBe('value')
-            expect(cleanedState.get('key_with_underscore')).toBe('value')
-            expect(cleanedState.get('123numerickey')).toBe('value')
-            expect(cleanedState.size).toBe(4)
-        })
-
-        it('passes cleaned formState to onDataChanged callback', () => {
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
-
-            const { result } = renderHook(() => useMetadataContext(), {
-                wrapper: ({ children }) => (
-                    <MetadataContextProvider
-                        node={mockNode}
-                        saveMeta={mockSaveMeta}
-                        value={{}}
-                        onDataChanged={mockOnDataChanged}
-                    >
-                        {children}
-                    </MetadataContextProvider>
-                )
-            })
-
-            // Set schema to initialize validator
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
-            })
-
-            const formStateWithEmptyKey = new Map([
-                ['key1', 'value1'],
-                ['', 'emptyKeyValue'],
-                ['key2', 'value2']
-            ])
-
-            act(() => {
-                result.current.actions.setFormState(formStateWithEmptyKey)
-            })
-
-            // Verify onDataChanged was called with cleaned formState
-            expect(mockOnDataChanged).toHaveBeenCalled()
-            const callArgs = mockOnDataChanged.mock.calls[mockOnDataChanged.mock.calls.length - 1]
-            const cleanedFormState = callArgs[0]
-
-            // The callback should receive formState without empty keys
-            expect(cleanedFormState.has('')).toBe(false)
-            expect(cleanedFormState.get('key1')).toBe('value1')
-            expect(cleanedFormState.get('key2')).toBe('value2')
-            expect(cleanedFormState.size).toBe(2)
-        })
-    })
-
-    describe('useMetadataContext', () => {
-        it('returns default context when used outside provider', () => {
-            const { result } = renderHook(() => useMetadataContext())
-            expect(result.current.state.node).toBeNull()
-            expect(result.current.state.saving).toBe(false)
-            expect(result.current.state.formState).toBeInstanceOf(Map)
-            expect(result.current.state.fields).toEqual({})
-            expect(result.current.state.namespaceJsonSchema).toBeNull()
-            expect(result.current.state.jsonSchema).toBeNull()
-            expect(result.current.state.shouldSave).toBe(false)
-            expect(result.current.state.editingTag).toBe('none')
-            expect(result.current.state.errors).toEqual({})
-            // dispatch and actions should be noop functions
-            expect(typeof result.current.dispatch).toBe('function')
-            expect(typeof result.current.actions.setSaving).toBe('function')
-        })
-
-        it('returns provider context when inside provider', () => {
-            const { result } = renderHook(() => useMetadataContext(), {
-                wrapper: ({ children }) => (
-                    <MetadataContextProvider
-                        node={mockNode}
-                        saveMeta={mockSaveMeta}
-                        value={{}}
-                        onDataChanged={mockOnDataChanged}
-                    >
-                        {children}
-                    </MetadataContextProvider>
-                )
-            })
-
-            expect(result.current.state.node).toBe(mockNode)
-            expect(typeof result.current.dispatch).toBe('function')
-            expect(typeof result.current.actions.setSaving).toBe('function')
-        })
-
-        it('actions update state via dispatch', () => {
-            // Setup validator first
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
-
-            const { result } = renderHook(() => useMetadataContext(), {
-                wrapper: ({ children }) => (
-                    <MetadataContextProvider
-                        node={mockNode}
-                        saveMeta={mockSaveMeta}
-                        value={{}}
-                        onDataChanged={mockOnDataChanged}
-                    >
-                        {children}
-                    </MetadataContextProvider>
-                )
-            })
-
-            act(() => {
-                result.current.actions.setSaving(true)
-            })
-            expect(result.current.state.saving).toBe(true)
-
-            act(() => {
-                result.current.actions.setFields({ foo: 'bar' })
-            })
-            expect(result.current.state.fields).toEqual({ foo: 'bar' })
-
-            // Set schema first to initialize validator
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
-            })
-            expect(result.current.state.jsonSchema).toBe(testSchema)
-
-            const newFormState = new Map([['key', 'val']])
-            mockOnDataChanged.mockClear()
-            act(() => {
-                result.current.actions.setFormState(newFormState)
-            })
-            // After cleaning empty keys, the formState should contain the same data
-            // Verify via the onDataChanged callback since that's what gets called
-            expect(mockOnDataChanged).toHaveBeenCalled()
-            const callArgs = mockOnDataChanged.mock.calls[0]
-            expect(callArgs[0].get('key')).toBe('val')
-            expect(callArgs[0].size).toBe(1)
-
-            act(() => {
-                result.current.actions.setNamespaceJsonSchema(testSchema)
-            })
-            expect(result.current.state.namespaceJsonSchema).toBe(testSchema)
-
-            act(() => {
-                result.current.actions.setShouldSave(true)
-            })
-            expect(result.current.state.shouldSave).toBe(true)
+            const [callbackState] = mockOnDataChanged.mock.calls[0]
+            expect(callbackState).toBe(mixedFormState)  // Same reference
+            expect(callbackState.has('')).toBe(true)
+            expect(callbackState.get('usermeta-paragraph')).toBe('')
+            expect(callbackState.size).toBe(5)
         })
 
         it('observes node_replaced event and updates formState when node is replaced', async () => {
-            // Setup initial node with metadata
-            const initialMetadata = new Map([['key1', 'value1']])
+            const initialMetadata = new Map([['usermeta-text', 'initial']])
             mockNode.getMetadata.mockReturnValue(initialMetadata)
-
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
 
             const { result } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
@@ -783,13 +466,9 @@ describe('MetadataContext', () => {
         })
 
         it('fires node_replaced event handler with new node metadata', async () => {
-            const initialMetadata = new Map([['key1', 'value1']])
-            const newMetadata = new Map([['key2', 'value2']])
+            const initialMetadata = new Map([['usermeta-text', 'initial']])
+            const newMetadata = new Map([['usermeta-text', 'updated']])
             mockNode.getMetadata.mockReturnValue(initialMetadata)
-
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
 
             const { result } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
@@ -802,11 +481,6 @@ describe('MetadataContext', () => {
                         {children}
                     </MetadataContextProvider>
                 )
-            })
-
-            // Set schema to initialize validator
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
             })
 
             // Get the callback that was passed to node.observe
@@ -832,17 +506,15 @@ describe('MetadataContext', () => {
 
             // Verify that onDataChanged was called with the new metadata
             await waitFor(() => {
-                expect(mockOnDataChanged).toHaveBeenCalledWith(newMetadata, expect.any(Boolean))
+                expect(mockOnDataChanged).toHaveBeenCalled()
+                const [callbackState] = mockOnDataChanged.mock.calls[0]
+                expect(callbackState.get('usermeta-text')).toBe('updated')
             })
         })
 
         it('cleans up node_replaced observer on unmount', () => {
-            const initialMetadata = new Map([['key1', 'value1']])
+            const initialMetadata = new Map([['usermeta-text', 'initial']])
             mockNode.getMetadata.mockReturnValue(initialMetadata)
-
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
 
             const { unmount } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
@@ -874,12 +546,8 @@ describe('MetadataContext', () => {
         })
 
         it('handles new node being null in node_replaced callback', async () => {
-            const initialMetadata = new Map([['key1', 'value1']])
+            const initialMetadata = new Map([['usermeta-text', 'initial']])
             mockNode.getMetadata.mockReturnValue(initialMetadata)
-
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
 
             const { result } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
@@ -892,11 +560,6 @@ describe('MetadataContext', () => {
                         {children}
                     </MetadataContextProvider>
                 )
-            })
-
-            // Set schema to initialize validator
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
             })
 
             // Get the callback
@@ -917,15 +580,11 @@ describe('MetadataContext', () => {
         })
 
         it('handles multiple rapid node replacements', async () => {
-            const initialMetadata = new Map([['key1', 'value1']])
-            const metadata2 = new Map([['key2', 'value2']])
-            const metadata3 = new Map([['key3', 'value3']])
+            const metadata1 = new Map([['usermeta-text', 'first']])
+            const metadata2 = new Map([['usermeta-text', 'second']])
+            const metadata3 = new Map([['usermeta-text', 'third']])
 
-            mockNode.getMetadata.mockReturnValue(initialMetadata)
-
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
+            mockNode.getMetadata.mockReturnValue(metadata1)
 
             const { result } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
@@ -938,11 +597,6 @@ describe('MetadataContext', () => {
                         {children}
                     </MetadataContextProvider>
                 )
-            })
-
-            // Set schema to initialize validator
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
             })
 
             // Get the callback
@@ -966,22 +620,29 @@ describe('MetadataContext', () => {
             // Should have been called twice, with the last metadata winning
             await waitFor(() => {
                 expect(mockOnDataChanged).toHaveBeenCalledTimes(2)
-                // Last call should have node3's metadata - compare by Map content
-                const lastCall = mockOnDataChanged.mock.calls[mockOnDataChanged.mock.calls.length - 1]
+                // Last call should have node3's metadata
+                const lastCall = mockOnDataChanged.mock.calls[1]
                 const lastMetadata = lastCall[0]
-                expect(lastMetadata.get('key3')).toBe('value3')
-                expect(lastMetadata.size).toBe(1)
+                expect(lastMetadata.get('usermeta-text')).toBe('third')
             })
         })
+    })
 
-        it('skips unnecessary updates when metadata is identical', async () => {
-            const sharedMetadata = new Map([['key1', 'value1']])
-            mockNode.getMetadata.mockReturnValue(sharedMetadata)
+    describe('useMetadataContext', () => {
+        it('returns default context when used outside provider', () => {
+            const { result } = renderHook(() => useMetadataContext())
+            expect(result.current.state.node).toBeNull()
+            expect(result.current.state.saving).toBe(false)
+            expect(result.current.state.formState).toBeInstanceOf(Map)
+            expect(result.current.state.fields).toEqual({})
+            expect(result.current.state.namespaceJsonSchema).toBeNull()
+            expect(result.current.state.jsonSchema).toBeNull()
+            expect(result.current.state.shouldSave).toBe(false)
+            expect(result.current.state.editingTag).toBe('none')
+            expect(result.current.state.errors).toEqual({})
+        })
 
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
-
+        it('returns provider context when inside provider', () => {
             const { result } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
                     <MetadataContextProvider
@@ -995,44 +656,12 @@ describe('MetadataContext', () => {
                 )
             })
 
-            // Set schema to initialize validator
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
-            })
-
-            // Get the callback
-            const observeCall = mockNode.observe.mock.calls.find(
-                (call) => call[0] === 'node_replaced'
-            )
-            const nodeReplacedCallback = observeCall![1]
-
-            mockOnDataChanged.mockClear()
-
-            // Create node with same metadata
-            const newNode = createMockNode({
-                getMetadata: vi.fn(() => sharedMetadata)
-            })
-
-            // Fire replacement
-            act(() => {
-                nodeReplacedCallback(newNode)
-            })
-
-            // Should still call onDataChanged (we don't do equality checking in current impl)
-            // This tests current behavior - optimization could be added later
-            await waitFor(() => {
-                expect(mockOnDataChanged).toHaveBeenCalledWith(sharedMetadata, expect.any(Boolean))
-            })
+            expect(result.current.state.node).toBe(mockNode)
+            expect(typeof result.current.dispatch).toBe('function')
+            expect(typeof result.current.actions.setSaving).toBe('function')
         })
 
-        it('handles same node being replaced with itself', async () => {
-            const metadata = new Map([['key1', 'value1']])
-            mockNode.getMetadata.mockReturnValue(metadata)
-
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
-
+        it('actions update state via dispatch', () => {
             const { result } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
                     <MetadataContextProvider
@@ -1046,95 +675,31 @@ describe('MetadataContext', () => {
                 )
             })
 
-            // Set schema to initialize validator
             act(() => {
-                result.current.actions.setJsonSchema(testSchema)
+                result.current.actions.setSaving(true)
             })
+            expect(result.current.state.saving).toBe(true)
 
-            // Get the callback
-            const observeCall = mockNode.observe.mock.calls.find(
-                (call) => call[0] === 'node_replaced'
-            )
-            const nodeReplacedCallback = observeCall![1]
-
-            mockOnDataChanged.mockClear()
-
-            // Replace with the same node
             act(() => {
-                nodeReplacedCallback(mockNode)
+                result.current.actions.setFields({ foo: 'bar' })
             })
+            expect(result.current.state.fields).toEqual({ foo: 'bar' })
 
-            // Should still update (no identity check in current impl)
-            await waitFor(() => {
-                expect(mockOnDataChanged).toHaveBeenCalledWith(metadata, expect.any(Boolean))
+            act(() => {
+                result.current.actions.setShouldSave(true)
             })
+            expect(result.current.state.shouldSave).toBe(true)
         })
 
-        it('properly registers callback with current node reference', async () => {
-            // This test verifies that the onNodeReplaced callback is registered with the
-            // current node instance and not stale references
-            const metadata1 = new Map([['key1', 'value1']])
-            mockNode.getMetadata.mockReturnValue(metadata1)
-
-            // Setup validator
-            mockValidator.mockReturnValue(true)
-            mockValidator.errors = null
-
-            const { result } = renderHook(() => useMetadataContext(), {
-                wrapper: ({ children }) => (
-                    <MetadataContextProvider
-                        node={mockNode}
-                        saveMeta={mockSaveMeta}
-                        value={{}}
-                        onDataChanged={mockOnDataChanged}
-                    >
-                        {children}
-                    </MetadataContextProvider>
-                )
-            })
-
-            // Set schema to initialize validator
-            act(() => {
-                result.current.actions.setJsonSchema(testSchema)
-            })
-
-            // Verify the observer was registered exactly once
-            expect(mockNode.observe).toHaveBeenCalledTimes(1)
-            expect(mockNode.observe).toHaveBeenCalledWith('node_replaced', expect.any(Function))
-
-            // Get the registered callback
-            const callback = mockNode.observe.mock.calls[0][1]
-
-            mockOnDataChanged.mockClear()
-
-            // Create a new node and invoke the callback with it
-            const newNode = createMockNode({
-                getMetadata: vi.fn(() => new Map([['newKey', 'newValue']]))
-            })
-
-            act(() => {
-                callback(newNode)
-            })
-
-            // Verify the callback used the new node's metadata
-            await waitFor(() => {
-                expect(mockOnDataChanged).toHaveBeenCalled()
-                const callArgs = mockOnDataChanged.mock.calls[0][0]
-                expect(callArgs.get('newKey')).toBe('newValue')
-            })
-        })
-
-        it('updates formState without validation when no jsonSchema is set', async () => {
-            // Even without a schema, formState should update
-            // The validator defaults to noopValidator which always returns isValid: true
-            const metadata = new Map([['key1', 'value1']])
-            mockNode.getMetadata.mockReturnValue(metadata)
-
-            // Don't set up a schema - simulate getNamespaceSchema returning null
+        it('updates formState without validation when no jsonSchema is loaded', async () => {
+            // Setup MetaClient to return null schema
             MetaClient.getInstance.mockReturnValue({
                 getNamespaceSchema: vi.fn(() => Promise.resolve(null))
             })
 
+            const metadata = new Map([['usermeta-text', 'hello']])
+            mockNode.getMetadata.mockReturnValue(metadata)
+
             const { result } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
                     <MetadataContextProvider
@@ -1150,21 +715,23 @@ describe('MetadataContext', () => {
 
             mockOnDataChanged.mockClear()
 
-            // Set form state without schema - should still work with noopValidator
+            // Set form state without schema - should still work
             act(() => {
                 result.current.actions.setFormState(metadata)
             })
 
-            // onDataChanged SHOULD be called with isValid: true (noopValidator result)
-            expect(mockOnDataChanged).toHaveBeenCalledWith(metadata, true)
+            // onDataChanged SHOULD be called (with noopValidator)
+            expect(mockOnDataChanged).toHaveBeenCalled()
+            const [, isValid] = mockOnDataChanged.mock.calls[0]
+            expect(isValid).toBe(true)  // noopValidator always returns true
         })
 
         it('switches from noopValidator to real validator when jsonSchema becomes available', async () => {
-            const metadata = new Map([['key1', 'value1']])
-            mockNode.getMetadata.mockReturnValue(metadata)
-
-            // Setup validator
-            mockValidator.mockReturnValue({ isValid: true, errors: {} })
+            // Initially return null schema
+            const mockGetNamespaceSchema = vi.fn(() => Promise.resolve(null))
+            MetaClient.getInstance.mockReturnValue({
+                getNamespaceSchema: mockGetNamespaceSchema
+            })
 
             const { result } = renderHook(() => useMetadataContext(), {
                 wrapper: ({ children }) => (
@@ -1181,33 +748,34 @@ describe('MetadataContext', () => {
 
             // Initially no schema, uses noopValidator
             mockOnDataChanged.mockClear()
+            const incompleteData = new Map([['usermeta-text', 'hello']])
             act(() => {
-                result.current.actions.setFormState(metadata)
+                result.current.actions.setFormState(incompleteData)
             })
-            // noopValidator still calls onDataChanged with isValid: true
-            expect(mockOnDataChanged).toHaveBeenCalledWith(metadata, true)
+            // noopValidator returns true regardless
+            const [, isValidWithoutSchema] = mockOnDataChanged.mock.calls[0]
+            expect(isValidWithoutSchema).toBe(true)
 
-            // Now set schema - replaces noopValidator with real validator
+            // Now manually set the real schema
             mockOnDataChanged.mockClear()
             act(() => {
                 result.current.actions.setJsonSchema(testSchema)
             })
 
-            // Wait for the effect that initializes real validator and calls setFormState
+            // Wait for effect to set up real validator
             await waitFor(() => {
-                expect(mockCompile).toHaveBeenCalledWith(testSchema)
+                expect(result.current.state.jsonSchema).toBe(testSchema)
             })
 
             // Now setFormState uses the real validator
             mockOnDataChanged.mockClear()
-            const newMetadata = new Map([['key2', 'value2']])
             act(() => {
-                result.current.actions.setFormState(newMetadata)
+                result.current.actions.setFormState(incompleteData)
             })
 
-            // Check that onDataChanged was called (might be called twice due to the effect)
-            expect(mockOnDataChanged).toHaveBeenCalled()
-            expect(mockValidator).toHaveBeenCalled()
+            // Real validator should fail because required fields are missing
+            const [, isValidWithSchema] = mockOnDataChanged.mock.calls[0]
+            expect(isValidWithSchema).toBe(false)
         })
     })
 })

--- a/frontend/assets/meta.user/res/js/context/metadata.test.tsx
+++ b/frontend/assets/meta.user/res/js/context/metadata.test.tsx
@@ -522,7 +522,7 @@ describe('MetadataContext', () => {
             expect(cleanedState.size).toBe(2)
         })
 
-        it('preserves entries with empty string values', () => {
+        it('does not preserve entries with empty string values', () => {
             // Setup validator
             mockValidator.mockReturnValue(true)
             mockValidator.errors = null
@@ -564,9 +564,9 @@ describe('MetadataContext', () => {
 
             // All keys should be preserved, including the one with empty value
             expect(cleanedState.get('key1')).toBe('value1')
-            expect(cleanedState.get('key2')).toBe('')
+            expect(cleanedState.has('key2')).toBe(false)
             expect(cleanedState.get('key3')).toBe('value3')
-            expect(cleanedState.size).toBe(3)
+            expect(cleanedState.size).toBe(2)
         })
 
         it('keeps all valid non-empty keys intact', () => {
@@ -1071,7 +1071,7 @@ describe('MetadataContext', () => {
         })
 
         it('properly registers callback with current node reference', async () => {
-            // This test verifies that the onNodeReplaced callback is registered with the 
+            // This test verifies that the onNodeReplaced callback is registered with the
             // current node instance and not stale references
             const metadata1 = new Map([['key1', 'value1']])
             mockNode.getMetadata.mockReturnValue(metadata1)

--- a/frontend/assets/meta.user/res/js/context/metadata.tsx
+++ b/frontend/assets/meta.user/res/js/context/metadata.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import MetaClient from "../MetaClient";
-import { mapErrors, formatSpecialCasesForValidation, buildValidator } from './utils/validators';
+import { buildValidator } from './utils/validators';
 import type { Validator } from './utils/validators';
 
 // FIXME: Properly type this
@@ -95,10 +95,15 @@ const noop = (...args: any[]) => {}
 // Validator that accepts everything without validation
 const noopValidator: Validator = (formState: Map<string, any>) => ({ isValid: true, errors: {} })
 
+const isEmpty = (value: any) =>
+    value === null
+        || value === undefined
+        || (`${value}`).trim().length === 0
+
 // Helper function to remove entries with empty string keys from a Map
 const removeEmptyKeys = (formState: Map<string, any>): Map<string, any> => {
     const cleanedMap = new Map<string, any>()
-    formState.forEach((v, k) => k && v && cleanedMap.set(k, v))
+    formState.forEach((v, k) => k && !isEmpty(v) && cleanedMap.set(k, v))
     return cleanedMap
 }
 

--- a/frontend/assets/meta.user/res/js/context/metadata.tsx
+++ b/frontend/assets/meta.user/res/js/context/metadata.tsx
@@ -155,18 +155,18 @@ export const MetadataContextProvider = ({
         setSaving: (saving) => dispatch({ type: 'set_saving', saving }),
 
         setFormState: (formState) => {
-            // Remove entries with empty string keys
-            const cleanedFormState = removeEmptyKeys(formState);
-
-            let { isValid, errors } = validatorRef.current(cleanedFormState);
+            let { isValid, errors } = validatorRef.current(
+                // NODE: To validate and show the currect message "field is required"
+                removeEmptyKeys(formState)
+            );
             dispatch({ type: 'set_errors', errors })
 
-            dispatch({ type: 'set_form_state', formState: cleanedFormState })
+            dispatch({ type: 'set_form_state', formState })
 
             // NOTE: For parents that require holding state because we can't
             // wrap them with a provider.
             // eg. frontend/assets/meta.user/res/js/InfoPanel.js#92-95
-            if (onDataChanged) onDataChanged(cleanedFormState, isValid)
+            if (onDataChanged) onDataChanged(formState, isValid)
         },
 
         setShouldSave: (shouldSave) => dispatch({ type: 'set_should_save', shouldSave }),

--- a/frontend/assets/meta.user/res/js/context/metadata.tsx
+++ b/frontend/assets/meta.user/res/js/context/metadata.tsx
@@ -98,11 +98,7 @@ const noopValidator: Validator = (formState: Map<string, any>) => ({ isValid: tr
 // Helper function to remove entries with empty string keys from a Map
 const removeEmptyKeys = (formState: Map<string, any>): Map<string, any> => {
     const cleanedMap = new Map<string, any>()
-    formState.forEach((value, key) => {
-        if (key !== '') {
-            cleanedMap.set(key, value)
-        }
-    })
+    formState.forEach((v, k) => k && v && cleanedMap.set(k, v))
     return cleanedMap
 }
 

--- a/idm/meta/grpc/handler.go
+++ b/idm/meta/grpc/handler.go
@@ -86,6 +86,12 @@ func (h *Handler) UpdateUserMeta(ctx context.Context, request *idm.UpdateUserMet
 		if request.Operation == idm.UpdateUserMetaRequest_PUT {
 			// Check JsonValue is valid json
 			var data interface{}
+			var val = metaData.GetJsonValue()
+			// NOTE: there might be case where value comes empty for empty
+			if val == "" {
+				continue
+			}
+
 			if er := json.Unmarshal([]byte(metaData.GetJsonValue()), &data); er != nil {
 				return nil, fmt.Errorf("make sure to use JSON format for metadata: %s", er.Error())
 			}

--- a/idm/meta/grpc/handler.go
+++ b/idm/meta/grpc/handler.go
@@ -86,11 +86,6 @@ func (h *Handler) UpdateUserMeta(ctx context.Context, request *idm.UpdateUserMet
 		if request.Operation == idm.UpdateUserMetaRequest_PUT {
 			// Check JsonValue is valid json
 			var data interface{}
-			var val = metaData.GetJsonValue()
-			// NOTE: there might be case where value comes empty for empty
-			if val == "" {
-				continue
-			}
 
 			if er := json.Unmarshal([]byte(metaData.GetJsonValue()), &data); er != nil {
 				return nil, fmt.Errorf("make sure to use JSON format for metadata: %s", er.Error())


### PR DESCRIPTION
When sending request with empty values within the JsonSchema it was failing and returning 500. Ideally API's shouldn't return system failure for request values. 

Example of problematic request
```bash
curl -k 'https://cells.localhost/a/user-meta/update' \
  -X 'PUT' \
  -H 'authorization: Bearer <token>' \
  -H 'accept: application/json' \
  -H 'accept-language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/json' \
  --data-raw '{"MetaDatas":[{"NodeUuid":"482b9eaf-e339-4d30-8de2-706b815c07df","Namespace":"usermeta-tags","JsonValue":"\"Important,To delete\"","Policies":[{"Action":"READ","Effect":"allow","Subject":"*"},{"Action":"WRITE","Effect":"allow","Subject":"*"}]},{"NodeUuid":"482b9eaf-e339-4d30-8de2-706b815c07df","Namespace":"usermeta-text","JsonValue":"\"adwa\"","Policies":[{"Action":"READ","Effect":"allow","Subject":"*"},{"Action":"WRITE","Effect":"allow","Subject":"*"}]},{"NodeUuid":"482b9eaf-e339-4d30-8de2-706b815c07df","Namespace":"usermeta-long-text","JsonValue":"\"awdawd a \"","Policies":[{"Action":"READ","Effect":"allow","Subject":"*"},{"Action":"WRITE","Effect":"allow","Subject":"*"}]},{"NodeUuid":"482b9eaf-e339-4d30-8de2-706b815c07df","Namespace":"usermeta-number","JsonValue":"2","Policies":[{"Action":"READ","Effect":"allow","Subject":"*"},{"Action":"WRITE","Effect":"allow","Subject":"*"}]},{"NodeUuid":"482b9eaf-e339-4d30-8de2-706b815c07df","Namespace":"usermeta-boolean","JsonValue":"false","Policies":[{"Action":"READ","Effect":"allow","Subject":"*"},{"Action":"WRITE","Effect":"allow","Subject":"*"}]},{"NodeUuid":"482b9eaf-e339-4d30-8de2-706b815c07df","Namespace":"usermeta-datetime","JsonValue":"1766966400","Policies":[{"Action":"READ","Effect":"allow","Subject":"*"},{"Action":"WRITE","Effect":"allow","Subject":"*"}]},{"NodeUuid":"482b9eaf-e339-4d30-8de2-706b815c07df","Namespace":"usermeta-url","JsonValue":"\"https://fooba.rcom\"","Policies":[{"Action":"READ","Effect":"allow","Subject":"*"},{"Action":"WRITE","Effect":"allow","Subject":"*"}]},{"NodeUuid":"482b9eaf-e339-4d30-8de2-706b815c07df","Namespace":"usermeta-no-minimum-text","JsonValue":"\"22\"","Policies":[{"Action":"READ","Effect":"allow","Subject":"*"},{"Action":"WRITE","Effect":"allow","Subject":"*"}]},{"NodeUuid":"482b9eaf-e339-4d30-8de2-706b815c07df","Namespace":"usermeta-short-text","JsonValue":"\"aaa\"","Policies":[{"Action":"READ","Effect":"allow","Subject":"*"},{"Action":"WRITE","Effect":"allow","Subject":"*"}]},{"NodeUuid":"482b9eaf-e339-4d30-8de2-706b815c07df","Namespace":"usermeta-long-text-1770636189604","JsonValue":"\"wadd\"","Policies":[{"Action":"READ","Effect":"allow","Subject":"*"},{"Action":"WRITE","Effect":"allow","Subject":"*"}]},{"NodeUuid":"482b9eaf-e339-4d30-8de2-706b815c07df","Namespace":"usermeta-long-text-1770636284397","Policies":[{"Action":"READ","Effect":"allow","Subject":"*"},{"Action":"WRITE","Effect":"allow","Subject":"*"}]}],"Operation":"PUT"}'

```
