### PR TITLE
feat(meta): add tag_cloud field type support file list view

### DIFF
--- a/frontend/assets/meta.user/res/js/Renderer.tsx
+++ b/frontend/assets/meta.user/res/js/Renderer.tsx
@@ -228,6 +228,9 @@ export default class Renderer{
             case 'tags':
                 out = {renderComponent: Renderer.renderTagsCloud, renderBlock: true, sortType: 'string'}
                 break
+            case 'tag_cloud':
+                out = {renderComponent: Renderer.renderTagsCloud, renderBlock: true, sortType: 'string'}
+                break
             case 'integer':
                 out = {renderComponent: Renderer.renderInteger, sortType: 'number'}
                 break


### PR DESCRIPTION
Added support for a new 'tag_cloud' field type in the metadata renderer, which uses the same rendering component as the existing 'tags' type.

Detailed Changes:
 - Implementation:
   - Added a new case for 'tag_cloud' in Renderer.tsx that maps to the same renderComponent and configuration as the 'tags' type.
   

<img width="726" height="439" alt="Screenshot 2026-02-09 at 18 51 09" src="https://github.com/user-attachments/assets/2a5f936b-4525-424d-98ed-a8c20d835f79" />


