### PR TITLE
fix(ui): display URL on search decoded

### DIFF
--- a/frontend/assets/meta.user/res/js/UserMetaPanel.js
+++ b/frontend/assets/meta.user/res/js/UserMetaPanel.js
@@ -32,7 +32,7 @@ import {muiThemeable} from 'material-ui/styles'
 import {DateTimeField, DateTimeForm} from "./fields/DateTime";
 import BooleanForm from "./fields/BooleanForm";
 // import UrlForm from "./fields/UrlForm";
-import { URLForm } from "./fields/URL";
+import { URLForm, URLField } from "./fields/URL";
 import {IntegerField, IntegerForm} from "./fields/Integer";
 const {ModernTextField} = Pydio.requireLib("hoc")
 const {EmptyStateView} = Pydio.requireLib('components');
@@ -316,6 +316,9 @@ export default class UserMetaPanel extends React.Component{
                     case 'boolean':
                         value = value ? 'Yes' : 'No'
                         realValue = value;
+                        break
+                    case 'url':
+                        value = <URLField node={node} column={column}/>
                         break
                     default:
                         break

--- a/frontend/assets/meta.user/res/js/fields/URL.jsx
+++ b/frontend/assets/meta.user/res/js/fields/URL.jsx
@@ -27,24 +27,10 @@ const { ModernTextField, ThemedModernStyles } = Pydio.requireLib('hoc');
 import { muiThemeable } from 'material-ui/styles'
 import { FontIcon } from 'material-ui'
 import { sanitizeUrl } from "@braintree/sanitize-url";
+import { ensureHttpScheme, formatURL } from '../utils/formatUrl.js';
 
-/**
- * If no scheme is provided, default to http:// to avoid relative links.
- * Keeps existing schemes (mailto:, ftp:, etc.) untouched.
- *
- * @param {string} raw
- * @returns {string}
- */
-const ensureHttpScheme = (raw) => {
-    const trimmed = String(raw || '').trim();
-    if (!trimmed) {
-        return '';
-    }
-    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed)) {
-        return trimmed;
-    }
-    return `https://${trimmed}`;
-};
+export { formatURL };
+
 
 /**
  * @param {{fontSize?: number}} props
@@ -97,34 +83,6 @@ const URLLinkIcon = ({ fontSize, url, displayText, children }) => {
 
 }
 
-const formatURL = (url) => {
-    if (!url || !String(url).trim()) {
-        return <Fragment></Fragment>;
-    }
-    const normalizedURL = ensureHttpScheme(url);
-    const sanitizedURL = sanitizeUrl(normalizedURL);
-
-    if (!sanitizedURL) {
-        return <Fragment></Fragment>;
-    }
-
-    // Validate URL format
-    let displayURL = sanitizedURL;
-
-    // Extract display text (domain or full URL)
-    try {
-        const urlObj = new URL(sanitizedURL);
-        displayURL = urlObj.hostname || sanitizedURL;
-    } catch (e) {
-        // If URL parsing fails, use original value
-        displayURL = sanitizedURL;
-    }
-
-    return {
-        normalizedURL,
-        displayURL,
-    }
-}
 
 /**
  * @param {{getRealValue: () => string}} props

--- a/frontend/assets/meta.user/res/js/fields/URL.spec.jsx
+++ b/frontend/assets/meta.user/res/js/fields/URL.spec.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
-import { URLField, URLForm, formatURL } from './URL';
+import { URLField, URLForm } from './URL';
 
 function createPydioMock() {
     return {
@@ -227,86 +227,3 @@ describe('URLForm', () => {
     });
 });
 
-describe('formatURL', () => {
-    it('should decode asterisks in URL', () => {
-        const result = formatURL('*google.com*');
-        expect(result.displayURL).toBe('*google.com*');
-        expect(result.displayURL).not.toContain('%2A');
-    });
-
-    it('should decode percent-encoded asterisks', () => {
-        const result = formatURL('%2Agoogle.com%2A');
-        expect(result.displayURL).toBe('*google.com*');
-        expect(result.displayURL).not.toContain('%2A');
-    });
-
-    it('should decode spaces in URL', () => {
-        const result = formatURL('hello world.com');
-        // Spaces in hostname cause sanitization to return about:blank
-        expect(result.displayURL).toBe('about:blank');
-        expect(result.normalizedURL).toBe('https://hello world.com');
-    });
-
-    it('should decode special characters like tilde', () => {
-        const result = formatURL('~special~.com');
-        expect(result.displayURL).toBe('~special~.com');
-        expect(result.displayURL).not.toContain('%7E');
-    });
-
-    it('should handle normal HTTPS URL', () => {
-        const result = formatURL('https://google.com');
-        expect(result.displayURL).toBe('google.com');
-        expect(result.normalizedURL).toBe('https://google.com');
-    });
-
-    it('should handle URL with path', () => {
-        const result = formatURL('https://google.com/path');
-        expect(result.displayURL).toBe('google.com');
-        expect(result.normalizedURL).toBe('https://google.com/path');
-    });
-
-    it('should add http scheme when missing', () => {
-        const result = formatURL('example.com');
-        expect(result.normalizedURL).toBe('https://example.com');
-        expect(result.displayURL).toBe('example.com');
-    });
-
-    it('should handle empty string', () => {
-        const result = formatURL('');
-        expect(result.displayURL).toBe('');
-        expect(result.normalizedURL).toBe('');
-    });
-
-    it('should handle null', () => {
-        const result = formatURL(null);
-        expect(result.displayURL).toBe('');
-        expect(result.normalizedURL).toBe('');
-    });
-
-    it('should handle undefined', () => {
-        const result = formatURL(undefined);
-        expect(result.displayURL).toBe('');
-        expect(result.normalizedURL).toBe('');
-    });
-
-    it('should handle malformed URL gracefully', () => {
-        const result = formatURL('not-a-valid-url***');
-        // Should sanitize? Expect normalizedURL to have https:// prefix
-        expect(result.normalizedURL).toBe('https://not-a-valid-url***');
-        // displayURL may be the same as normalizedURL (since parsing fails) but decoded
-        expect(result.displayURL).toBe('not-a-valid-url***');
-    });
-
-    it('should decode percent-encoded input', () => {
-        const result = formatURL('hello%20world.com');
-        // Percent sign in hostname causes sanitization to return about:blank
-        expect(result.displayURL).toBe('about:blank');
-        expect(result.normalizedURL).toBe('https://hello%20world.com');
-    });
-
-    it('should preserve existing scheme like mailto', () => {
-        const result = formatURL('mailto:test@example.com');
-        expect(result.normalizedURL).toBe('mailto:test@example.com');
-        // displayURL likely will be mailto:test@example.com (since hostname extraction fails)
-    });
-});

--- a/frontend/assets/meta.user/res/js/fields/URL.spec.jsx
+++ b/frontend/assets/meta.user/res/js/fields/URL.spec.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
-import { URLField, URLForm } from './URL';
+import { URLField, URLForm, formatURL } from './URL';
 
 function createPydioMock() {
     return {
@@ -224,5 +224,89 @@ describe('URLForm', () => {
         fireEvent.blur(input);
 
         expect(updateValue).toHaveBeenCalledWith('example.com', false);
+    });
+});
+
+describe('formatURL', () => {
+    it('should decode asterisks in URL', () => {
+        const result = formatURL('*google.com*');
+        expect(result.displayURL).toBe('*google.com*');
+        expect(result.displayURL).not.toContain('%2A');
+    });
+
+    it('should decode percent-encoded asterisks', () => {
+        const result = formatURL('%2Agoogle.com%2A');
+        expect(result.displayURL).toBe('*google.com*');
+        expect(result.displayURL).not.toContain('%2A');
+    });
+
+    it('should decode spaces in URL', () => {
+        const result = formatURL('hello world.com');
+        // Spaces in hostname cause sanitization to return about:blank
+        expect(result.displayURL).toBe('about:blank');
+        expect(result.normalizedURL).toBe('https://hello world.com');
+    });
+
+    it('should decode special characters like tilde', () => {
+        const result = formatURL('~special~.com');
+        expect(result.displayURL).toBe('~special~.com');
+        expect(result.displayURL).not.toContain('%7E');
+    });
+
+    it('should handle normal HTTPS URL', () => {
+        const result = formatURL('https://google.com');
+        expect(result.displayURL).toBe('google.com');
+        expect(result.normalizedURL).toBe('https://google.com');
+    });
+
+    it('should handle URL with path', () => {
+        const result = formatURL('https://google.com/path');
+        expect(result.displayURL).toBe('google.com');
+        expect(result.normalizedURL).toBe('https://google.com/path');
+    });
+
+    it('should add http scheme when missing', () => {
+        const result = formatURL('example.com');
+        expect(result.normalizedURL).toBe('https://example.com');
+        expect(result.displayURL).toBe('example.com');
+    });
+
+    it('should handle empty string', () => {
+        const result = formatURL('');
+        expect(result.displayURL).toBe('');
+        expect(result.normalizedURL).toBe('');
+    });
+
+    it('should handle null', () => {
+        const result = formatURL(null);
+        expect(result.displayURL).toBe('');
+        expect(result.normalizedURL).toBe('');
+    });
+
+    it('should handle undefined', () => {
+        const result = formatURL(undefined);
+        expect(result.displayURL).toBe('');
+        expect(result.normalizedURL).toBe('');
+    });
+
+    it('should handle malformed URL gracefully', () => {
+        const result = formatURL('not-a-valid-url***');
+        // Should sanitize? Expect normalizedURL to have https:// prefix
+        expect(result.normalizedURL).toBe('https://not-a-valid-url***');
+        // displayURL may be the same as normalizedURL (since parsing fails) but decoded
+        expect(result.displayURL).toBe('not-a-valid-url***');
+    });
+
+    it('should decode percent-encoded input', () => {
+        const result = formatURL('hello%20world.com');
+        // Percent sign in hostname causes sanitization to return about:blank
+        expect(result.displayURL).toBe('about:blank');
+        expect(result.normalizedURL).toBe('https://hello%20world.com');
+    });
+
+    it('should preserve existing scheme like mailto', () => {
+        const result = formatURL('mailto:test@example.com');
+        expect(result.normalizedURL).toBe('mailto:test@example.com');
+        // displayURL likely will be mailto:test@example.com (since hostname extraction fails)
     });
 });

--- a/frontend/assets/meta.user/res/js/fieldsv2/URLInput.test.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/URLInput.test.tsx
@@ -18,236 +18,143 @@
  * The latest code can be found at <https://pydio.com>.
  */
 
-import { describe, it, expect } from 'vitest'
-import { ensureHttpScheme, formatURL } from './URLInput'
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 
-describe('URL Utility Functions', () => {
-    describe('ensureHttpScheme', () => {
-        it('adds https:// to URLs without a scheme', () => {
-            expect(ensureHttpScheme('example.com')).toBe('https://example.com')
-        })
+import { URLIcon, URLLinkIcon } from './URLInput'
 
-        it('preserves existing http:// scheme', () => {
-            expect(ensureHttpScheme('http://example.com')).toBe('http://example.com')
-        })
-
-        it('preserves existing https:// scheme', () => {
-            expect(ensureHttpScheme('https://example.com')).toBe('https://example.com')
-        })
-
-        it('preserves mailto: scheme', () => {
-            expect(ensureHttpScheme('mailto:test@example.com')).toBe('mailto:test@example.com')
-        })
-
-        it('preserves ftp: scheme', () => {
-            expect(ensureHttpScheme('ftp://example.com')).toBe('ftp://example.com')
-        })
-
-        it('preserves other schemes like tel:', () => {
-            expect(ensureHttpScheme('tel:+1234567890')).toBe('tel:+1234567890')
-        })
-
-        it('preserves custom schemes with multiple characters', () => {
-            expect(ensureHttpScheme('git+https://github.com/repo.git')).toBe(
-                'git+https://github.com/repo.git'
-            )
-        })
-
-        it('handles empty string', () => {
-            expect(ensureHttpScheme('')).toBe('')
-        })
-
-        it('handles null/undefined by treating as empty string', () => {
-            expect(ensureHttpScheme(null as any)).toBe('')
-            expect(ensureHttpScheme(undefined as any)).toBe('')
-        })
-
-        it('trims whitespace before checking scheme', () => {
-            expect(ensureHttpScheme('  example.com  ')).toBe('https://example.com')
-            expect(ensureHttpScheme('  http://example.com  ')).toBe('http://example.com')
-        })
-
-        it('does not add scheme to whitespace-only strings', () => {
-            expect(ensureHttpScheme('   ')).toBe('')
-        })
-
-        it('handles URLs with multiple dots correctly', () => {
-            expect(ensureHttpScheme('example.co.uk')).toBe('https://example.co.uk')
-        })
-
-        it('handles URLs with hyphens in domain', () => {
-            expect(ensureHttpScheme('my-example.com')).toBe('https://my-example.com')
-        })
-
-        it('handles URLs with subdomains', () => {
-            expect(ensureHttpScheme('sub.domain.example.com')).toBe('https://sub.domain.example.com')
-        })
-
-        it('handles URLs with ports', () => {
-            expect(ensureHttpScheme('example.com:8080')).toBe('https://example.com:8080')
-        })
-
-        it('handles URLs with paths', () => {
-            expect(ensureHttpScheme('example.com/path/to/page')).toBe('https://example.com/path/to/page')
-        })
-
-        it('handles URLs with query strings', () => {
-            expect(ensureHttpScheme('example.com?param=value')).toBe('https://example.com?param=value')
-        })
-
-        it('handles URLs with fragments', () => {
-            expect(ensureHttpScheme('example.com#section')).toBe('https://example.com#section')
-        })
+describe('URLIcon Component', () => {
+    beforeEach(() => {
+        cleanup()
     })
 
-    describe('formatURL', () => {
-        it('returns empty strings for empty input', () => {
-            const result = formatURL('')
-            expect(result).toEqual({ normalizedURL: '', displayURL: '' })
-        })
-
-        it('returns empty strings for whitespace-only input', () => {
-            const result = formatURL('   ')
-            expect(result).toEqual({ normalizedURL: '', displayURL: '' })
-        })
-
-        it('normalizes URL and extracts hostname for display', () => {
-            const result = formatURL('example.com')
-            expect(result.normalizedURL).toBe('https://example.com')
-            expect(result.displayURL).toBe('example.com')
-        })
-
-        it('extracts hostname from full URL with path', () => {
-            const result = formatURL('example.com/path/to/page')
-            expect(result.displayURL).toBe('example.com')
-        })
-
-        it('extracts hostname from URL with subdomain', () => {
-            const result = formatURL('sub.example.com')
-            expect(result.displayURL).toBe('sub.example.com')
-        })
-
-        it('handles URLs with port numbers', () => {
-            const result = formatURL('example.com:8080')
-            expect(result.normalizedURL).toBe('https://example.com:8080')
-            expect(result.displayURL).toBe('example.com')
-        })
-
-        it('handles URLs with query parameters', () => {
-            const result = formatURL('example.com?param=value')
-            expect(result.displayURL).toBe('example.com')
-        })
-
-        it('preserves existing https:// scheme', () => {
-            const result = formatURL('https://example.com')
-            expect(result.normalizedURL).toBe('https://example.com')
-            expect(result.displayURL).toBe('example.com')
-        })
-
-        it('preserves existing http:// scheme', () => {
-            const result = formatURL('http://example.com')
-            expect(result.normalizedURL).toBe('http://example.com')
-            expect(result.displayURL).toBe('example.com')
-        })
-
-        it('preserves ftp:// scheme', () => {
-            const result = formatURL('ftp://files.example.com')
-            expect(result.normalizedURL).toBe('ftp://files.example.com')
-            expect(result.displayURL).toBe('files.example.com')
-        })
-
-        it('handles mailto: URLs correctly', () => {
-            const result = formatURL('mailto:test@example.com')
-            expect(result.normalizedURL).toBe('mailto:test@example.com')
-            // mailto URLs don't parse as web URLs, so displayURL should be the sanitized value
-            expect(result.displayURL).not.toBe('')
-        })
-
-        it('uses full normalized URL when URL parsing fails', () => {
-            const result = formatURL('not-a-valid-url-format')
-            expect(result.normalizedURL).toBe('https://not-a-valid-url-format')
-            // When URL parsing fails, displayURL falls back to the normalized URL
-            // sanitizeUrl may return the value unchanged, so we test that displayURL is not empty
-            expect(result.displayURL).not.toBe('')
-            expect(typeof result.displayURL).toBe('string')
-        })
-
-        it('extracts hostname from URL with www prefix', () => {
-            const result = formatURL('www.example.com')
-            expect(result.displayURL).toBe('www.example.com')
-        })
-
-        it('handles internationalized domain names', () => {
-            const result = formatURL('münchen.de')
-            expect(result.normalizedURL).toBe('https://münchen.de')
-        })
-
-        it('trims whitespace from URLs', () => {
-            const result = formatURL('  example.com  ')
-            expect(result.normalizedURL).toBe('https://example.com')
-            expect(result.displayURL).toBe('example.com')
-        })
-
-        it('handles URLs with authentication info', () => {
-            const result = formatURL('https://user:pass@example.com')
-            expect(result.displayURL).toBe('example.com')
-        })
-
-        it('handles localhost URLs', () => {
-            const result = formatURL('localhost:3000')
-            expect(result.normalizedURL).toBe('https://localhost:3000')
-            expect(result.displayURL).toBe('localhost')
-        })
-
-        it('handles IP addresses', () => {
-            const result = formatURL('192.168.1.1')
-            expect(result.normalizedURL).toBe('https://192.168.1.1')
-            expect(result.displayURL).toBe('192.168.1.1')
-        })
-
-        it('handles IP addresses with ports', () => {
-            const result = formatURL('192.168.1.1:8080')
-            expect(result.normalizedURL).toBe('https://192.168.1.1:8080')
-            expect(result.displayURL).toBe('192.168.1.1')
-        })
-
-        it('handles URLs with fragments and query strings', () => {
-            const result = formatURL('example.com/page?param=value#section')
-            expect(result.displayURL).toBe('example.com')
-        })
+    it('renders the icon with default size', () => {
+        render(<URLIcon />)
+        const icon = screen.getByTestId('open-in-new-icon')
+        expect(icon).toBeInTheDocument()
+        expect(icon).toHaveClass('mdi', 'mdi-open-in-new')
     })
 
-    describe('Edge cases and security', () => {
-        it('handles URLs with special characters in path', () => {
-            const result = formatURL('example.com/path/with%20spaces')
-            expect(result.displayURL).toBe('example.com')
-        })
+    it('renders the icon with custom font size', () => {
+        render(<URLIcon fontSize={24} />)
+        const icon = screen.getByTestId('open-in-new-icon')
+        expect(icon.style.fontSize).toBe('24px')
+    })
 
-        it('handles very long URLs', () => {
-            const longPath = 'a'.repeat(1000)
-            const result = formatURL(`example.com/${longPath}`)
-            expect(result.displayURL).toBe('example.com')
-        })
+    it('inherits color from parent', () => {
+        render(<URLIcon fontSize={18} />)
+        const icon = screen.getByTestId('open-in-new-icon')
+        expect(icon.style.color).toBe('inherit')
+    })
+})
 
-        it('handles URLs with emojis in domain', () => {
-            const result = formatURL('example.com')
-            expect(result.displayURL).toBe('example.com')
-        })
+describe('URLLinkIcon Component', () => {
+    beforeEach(() => {
+        cleanup()
+    })
 
-        it('handles multiple slashes in path', () => {
-            const result = formatURL('example.com///path///to///page')
-            expect(result.displayURL).toBe('example.com')
-        })
+    it('returns null for empty URL', () => {
+        const { container } = render(<URLLinkIcon url="" />)
+        expect(container.firstChild).toBeNull()
+    })
 
-        it('ensureHttpScheme preserves URL encoding', () => {
-            const encoded = 'example.com/path%20with%20spaces'
-            expect(ensureHttpScheme(encoded)).toBe(`https://${encoded}`)
-        })
+    it('returns null for whitespace-only URL', () => {
+        const { container } = render(<URLLinkIcon url="   " />)
+        expect(container.firstChild).toBeNull()
+    })
 
-        it('formatURL handles already normalized URLs without modification', () => {
-            const url = 'https://example.com/path'
-            const result = formatURL(url)
-            expect(result.normalizedURL).toBe(url)
-        })
+    it('renders a link with icon for valid URL', () => {
+        render(<URLLinkIcon url="example.com" />)
+        const link = screen.getByTestId('url-link-icon')
+        expect(link).toBeInTheDocument()
+        expect(link).toHaveAttribute('target', '_blank')
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
+    it('uses sanitized and normalized URL as href', () => {
+        render(<URLLinkIcon url="example.com" />)
+        const link = screen.getByTestId('url-link-icon')
+        // sanitizeUrl may add a trailing slash
+        expect(link.getAttribute('href')).toMatch(/^https:\/\/example\.com\/?$/)
+    })
+
+    it('uses custom display text in aria-label', () => {
+        render(<URLLinkIcon url="example.com" displayText="My Website" />)
+        const link = screen.getByTestId('url-link-icon')
+        expect(link.getAttribute('aria-label')).toBe('Open My Website in a new tab')
+    })
+
+    it('uses URL as fallback for aria-label when no display text provided', () => {
+        render(<URLLinkIcon url="example.com" />)
+        const link = screen.getByTestId('url-link-icon')
+        expect(link.getAttribute('aria-label')).toBe('Open example.com in a new tab')
+    })
+
+    it('renders children inside the link', () => {
+        render(
+            <URLLinkIcon url="example.com">
+                <span>Click me</span>
+            </URLLinkIcon>
+        )
+        expect(screen.getByText('Click me')).toBeInTheDocument()
+    })
+
+    it('includes the icon after children', () => {
+        const { container } = render(
+            <URLLinkIcon url="example.com">
+                <span>Click me</span>
+            </URLLinkIcon>
+        )
+        const link = container.querySelector('[data-testid="url-link-icon"]')
+        expect(link).toBeInTheDocument()
+        const icon = link?.querySelector('[data-testid="open-in-new-icon"]')
+        expect(icon).toBeInTheDocument()
+    })
+
+    it('stops click propagation when clicked', () => {
+        const handleClick = vi.fn()
+        const { container } = render(
+            <div onClick={handleClick}>
+                <URLLinkIcon url="example.com" />
+            </div>
+        )
+        const link = screen.getByTestId('url-link-icon')
+        fireEvent.click(link)
+        expect(handleClick).not.toHaveBeenCalled()
+    })
+
+    it('handles custom font size for icon', () => {
+        const { container } = render(<URLLinkIcon url="example.com" fontSize={24} />)
+        const icon = container.querySelector('[data-testid="open-in-new-icon"]')
+        expect(icon?.style.fontSize).toBe('24px')
+    })
+
+    it('sanitizes malicious URLs to about:blank', () => {
+        render(
+            <URLLinkIcon url="javascript:alert('xss')" />
+        )
+        const link = screen.getByTestId('url-link-icon')
+        // sanitizeUrl converts malicious URLs to about:blank for safety
+        expect(link.getAttribute('href')).toBe('about:blank')
+    })
+
+    it('handles https scheme URLs', () => {
+        render(<URLLinkIcon url="https://example.com" />)
+        const link = screen.getByTestId('url-link-icon')
+        // sanitizeUrl may add a trailing slash
+        expect(link.getAttribute('href')).toMatch(/^https:\/\/example\.com\/?$/)
+    })
+
+    it('handles ftp scheme URLs', () => {
+        render(<URLLinkIcon url="ftp://files.example.com" />)
+        const link = screen.getByTestId('url-link-icon')
+        expect(link.getAttribute('href')).toBe('ftp://files.example.com')
+    })
+
+    it('handles mailto scheme URLs', () => {
+        render(<URLLinkIcon url="mailto:test@example.com" />)
+        const link = screen.getByTestId('url-link-icon')
+        expect(link.getAttribute('href')).toBe('mailto:test@example.com')
     })
 })

--- a/frontend/assets/meta.user/res/js/fieldsv2/URLInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/URLInput.tsx
@@ -21,64 +21,9 @@
 import React, { useCallback, useState, useEffect } from 'react'
 import { TextInput } from '@mantine/core'
 import { sanitizeUrl } from "@braintree/sanitize-url"
+import { ensureHttpScheme, formatURL } from '../utils/formatUrl.js'
 import { InputProps } from "./CommonInputProps"
-
-/**
- * If no scheme is provided, default to https:// to avoid relative links.
- * Keeps existing schemes (mailto:, ftp:, etc.) untouched.
- * Distinguishes between URL schemes (http:, ftp:, etc.) and port numbers (domain:8080).
- *
- * @param {string} raw
- * @returns {string}
- */
-export const ensureHttpScheme = (raw: string): string => {
-    const trimmed = String(raw || '').trim()
-    if (!trimmed) {
-        return ''
-    }
-    // Check for valid URL schemes: must start with letter, followed by alphanumeric/+/-.
-    // A valid scheme is followed by :// or : and then non-digits
-    // This distinguishes from port numbers (localhost:8080 has only digits after :)
-    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) {
-        return trimmed
-    }
-    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:(?!\d)/.test(trimmed)) {
-        return trimmed
-    }
-    return `https://${trimmed}`
-}
-
-/**
- * Formats a URL for display and validation
- * @param {string} url - Raw URL input
- * @returns {{normalizedURL: string, displayURL: string}} Normalized and display URLs
- */
-export const formatURL = (url: string): { normalizedURL: string; displayURL: string } => {
-    if (!url || !String(url).trim()) {
-        return { normalizedURL: '', displayURL: '' }
-    }
-    const normalizedURL = ensureHttpScheme(url)
-    const sanitizedURL = sanitizeUrl(normalizedURL)
-
-    if (!sanitizedURL) {
-        return { normalizedURL: '', displayURL: '' }
-    }
-
-    // Extract display text (domain or full URL)
-    let displayURL = sanitizedURL
-    try {
-        const urlObj = new URL(sanitizedURL)
-        displayURL = urlObj.hostname || sanitizedURL
-    } catch (e) {
-        // If URL parsing fails, use sanitized value
-        displayURL = sanitizedURL
-    }
-
-    return {
-        normalizedURL,
-        displayURL,
-    }
-}
+export { ensureHttpScheme, formatURL };
 
 /**
  * URLIcon component for displaying the open-in-new icon

--- a/frontend/assets/meta.user/res/js/utils/formatUrl.js
+++ b/frontend/assets/meta.user/res/js/utils/formatUrl.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2007-2021 Charles du Jeu - Abstrium SAS <team (at) pyd.io>
+ * This file is part of Pydio.
+ *
+ * Pydio is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+import { sanitizeUrl } from "@braintree/sanitize-url";
+
+/**
+ * If no scheme is provided, default to https:// to avoid relative links.
+ * Keeps existing schemes (mailto:, ftp:, etc.) untouched.
+ * Distinguishes between URL schemes (http:, ftp:, etc.) and port numbers (domain:8080).
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+export const ensureHttpScheme = (raw) => {
+    const trimmed = String(raw || '').trim();
+    if (!trimmed) {
+        return '';
+    }
+    // Check for valid URL schemes: must start with letter, followed by alphanumeric/+/-.
+    // A valid scheme is followed by :// or : and then non-digits
+    // This distinguishes from port numbers (localhost:8080 has only digits after :)
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) {
+        return trimmed;
+    }
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:(?!\d)/.test(trimmed)) {
+        return trimmed;
+    }
+    return `https://${trimmed}`;
+};
+
+/**
+ * Formats a URL for display and validation
+ * @param {string} url - Raw URL input
+ * @returns {{normalizedURL: string, displayURL: string}} Normalized and display URLs
+ */
+export const formatURL = (url) => {
+    if (!url || !String(url).trim()) {
+        return { normalizedURL: '', displayURL: '' };
+    }
+    const normalizedURL = ensureHttpScheme(url);
+    const sanitizedURL = sanitizeUrl(normalizedURL);
+
+    if (!sanitizedURL) {
+        return { normalizedURL: '', displayURL: '' };
+    }
+
+    // Extract display text (domain or full URL)
+    let displayURL = sanitizedURL;
+    try {
+        const urlObj = new URL(sanitizedURL);
+        displayURL = urlObj.hostname || sanitizedURL;
+    } catch (e) {
+        // If URL parsing fails, use sanitized value
+        displayURL = sanitizedURL;
+    }
+
+    // Decode percent-encoded characters for clean display
+    try {
+        displayURL = decodeURIComponent(displayURL);
+    } catch (e) {
+        // If decoding fails, keep as-is
+    }
+
+    return {
+        normalizedURL,
+        displayURL,
+    };
+};

--- a/frontend/assets/meta.user/res/js/utils/formatUrl.spec.js
+++ b/frontend/assets/meta.user/res/js/utils/formatUrl.spec.js
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest';
+import { ensureHttpScheme, formatURL } from './formatUrl.js';
+
+describe('ensureHttpScheme', () => {
+    it('adds https:// to URLs without a scheme', () => {
+        expect(ensureHttpScheme('example.com')).toBe('https://example.com');
+    });
+
+    it('preserves existing http:// scheme', () => {
+        expect(ensureHttpScheme('http://example.com')).toBe('http://example.com');
+    });
+
+    it('preserves existing https:// scheme', () => {
+        expect(ensureHttpScheme('https://example.com')).toBe('https://example.com');
+    });
+
+    it('preserves mailto: scheme', () => {
+        expect(ensureHttpScheme('mailto:test@example.com')).toBe('mailto:test@example.com');
+    });
+
+    it('preserves ftp: scheme', () => {
+        expect(ensureHttpScheme('ftp://example.com')).toBe('ftp://example.com');
+    });
+
+    it('preserves other schemes like tel:', () => {
+        expect(ensureHttpScheme('tel:+1234567890')).toBe('tel:+1234567890');
+    });
+
+    it('preserves custom schemes with multiple characters', () => {
+        expect(ensureHttpScheme('git+https://github.com/repo.git')).toBe(
+            'git+https://github.com/repo.git'
+        );
+    });
+
+    it('handles empty string', () => {
+        expect(ensureHttpScheme('')).toBe('');
+    });
+
+    it('handles null/undefined by treating as empty string', () => {
+        expect(ensureHttpScheme(null)).toBe('');
+        expect(ensureHttpScheme(undefined)).toBe('');
+    });
+
+    it('trims whitespace before checking scheme', () => {
+        expect(ensureHttpScheme('  example.com  ')).toBe('https://example.com');
+        expect(ensureHttpScheme('  http://example.com  ')).toBe('http://example.com');
+    });
+
+    it('does not add scheme to whitespace-only strings', () => {
+        expect(ensureHttpScheme('   ')).toBe('');
+    });
+
+    it('handles URLs with multiple dots correctly', () => {
+        expect(ensureHttpScheme('example.co.uk')).toBe('https://example.co.uk');
+    });
+
+    it('handles URLs with hyphens in domain', () => {
+        expect(ensureHttpScheme('my-example.com')).toBe('https://my-example.com');
+    });
+
+    it('handles URLs with subdomains', () => {
+        expect(ensureHttpScheme('sub.domain.example.com')).toBe('https://sub.domain.example.com');
+    });
+
+    it('handles URLs with ports', () => {
+        expect(ensureHttpScheme('example.com:8080')).toBe('https://example.com:8080');
+    });
+
+    it('handles URLs with paths', () => {
+        expect(ensureHttpScheme('example.com/path/to/page')).toBe('https://example.com/path/to/page');
+    });
+
+    it('handles URLs with query strings', () => {
+        expect(ensureHttpScheme('example.com?param=value')).toBe('https://example.com?param=value');
+    });
+
+    it('handles URLs with fragments', () => {
+        expect(ensureHttpScheme('example.com#section')).toBe('https://example.com#section');
+    });
+});
+
+describe('formatURL', () => {
+    it('returns empty strings for empty input', () => {
+        const result = formatURL('');
+        expect(result).toEqual({ normalizedURL: '', displayURL: '' });
+    });
+
+    it('returns empty strings for whitespace-only input', () => {
+        const result = formatURL('   ');
+        expect(result).toEqual({ normalizedURL: '', displayURL: '' });
+    });
+
+    it('normalizes URL and extracts hostname for display', () => {
+        const result = formatURL('example.com');
+        expect(result.normalizedURL).toBe('https://example.com');
+        expect(result.displayURL).toBe('example.com');
+    });
+
+    it('extracts hostname from full URL with path', () => {
+        const result = formatURL('example.com/path/to/page');
+        expect(result.displayURL).toBe('example.com');
+    });
+
+    it('extracts hostname from URL with subdomain', () => {
+        const result = formatURL('sub.example.com');
+        expect(result.displayURL).toBe('sub.example.com');
+    });
+
+    it('handles URLs with port numbers', () => {
+        const result = formatURL('example.com:8080');
+        expect(result.normalizedURL).toBe('https://example.com:8080');
+        expect(result.displayURL).toBe('example.com');
+    });
+
+    it('handles URLs with query parameters', () => {
+        const result = formatURL('example.com?param=value');
+        expect(result.displayURL).toBe('example.com');
+    });
+
+    it('preserves existing https:// scheme', () => {
+        const result = formatURL('https://example.com');
+        expect(result.normalizedURL).toBe('https://example.com');
+        expect(result.displayURL).toBe('example.com');
+    });
+
+    it('preserves existing http:// scheme', () => {
+        const result = formatURL('http://example.com');
+        expect(result.normalizedURL).toBe('http://example.com');
+        expect(result.displayURL).toBe('example.com');
+    });
+
+    it('preserves ftp:// scheme', () => {
+        const result = formatURL('ftp://files.example.com');
+        expect(result.normalizedURL).toBe('ftp://files.example.com');
+        expect(result.displayURL).toBe('files.example.com');
+    });
+
+    it('handles mailto: URLs correctly', () => {
+        const result = formatURL('mailto:test@example.com');
+        expect(result.normalizedURL).toBe('mailto:test@example.com');
+        // mailto URLs don't parse as web URLs, so displayURL should be the sanitized value
+        expect(result.displayURL).not.toBe('');
+    });
+
+    it('uses full normalized URL when URL parsing fails', () => {
+        const result = formatURL('not-a-valid-url-format');
+        expect(result.normalizedURL).toBe('https://not-a-valid-url-format');
+        // When URL parsing fails, displayURL falls back to the normalized URL
+        // sanitizeUrl may return the value unchanged, so we test that displayURL is not empty
+        expect(result.displayURL).not.toBe('');
+        expect(typeof result.displayURL).toBe('string');
+    });
+
+    it('extracts hostname from URL with www prefix', () => {
+        const result = formatURL('www.example.com');
+        expect(result.displayURL).toBe('www.example.com');
+    });
+
+    it('handles internationalized domain names', () => {
+        const result = formatURL('münchen.de');
+        expect(result.normalizedURL).toBe('https://münchen.de');
+    });
+
+    it('trims whitespace from URLs', () => {
+        const result = formatURL('  example.com  ');
+        expect(result.normalizedURL).toBe('https://example.com');
+        expect(result.displayURL).toBe('example.com');
+    });
+
+    it('handles URLs with authentication info', () => {
+        const result = formatURL('https://user:pass@example.com');
+        expect(result.displayURL).toBe('example.com');
+    });
+
+    it('handles localhost URLs', () => {
+        const result = formatURL('localhost:3000');
+        expect(result.normalizedURL).toBe('https://localhost:3000');
+        expect(result.displayURL).toBe('localhost');
+    });
+
+    it('handles IP addresses', () => {
+        const result = formatURL('192.168.1.1');
+        expect(result.normalizedURL).toBe('https://192.168.1.1');
+        expect(result.displayURL).toBe('192.168.1.1');
+    });
+
+    it('handles IP addresses with ports', () => {
+        const result = formatURL('192.168.1.1:8080');
+        expect(result.normalizedURL).toBe('https://192.168.1.1:8080');
+        expect(result.displayURL).toBe('192.168.1.1');
+    });
+
+    it('handles URLs with fragments and query strings', () => {
+        const result = formatURL('example.com/page?param=value#section');
+        expect(result.displayURL).toBe('example.com');
+    });
+});
+
+describe('formatURL - Edge cases and security', () => {
+    it('handles URLs with special characters in path', () => {
+        const result = formatURL('example.com/path/with%20spaces');
+        expect(result.displayURL).toBe('example.com');
+    });
+
+    it('handles very long URLs', () => {
+        const longPath = 'a'.repeat(1000);
+        const result = formatURL(`example.com/${longPath}`);
+        expect(result.displayURL).toBe('example.com');
+    });
+
+    it('handles URLs with emojis in domain', () => {
+        const result = formatURL('example.com');
+        expect(result.displayURL).toBe('example.com');
+    });
+
+    it('handles multiple slashes in path', () => {
+        const result = formatURL('example.com///path///to///page');
+        expect(result.displayURL).toBe('example.com');
+    });
+
+    it('ensureHttpScheme preserves URL encoding', () => {
+        const encoded = 'example.com/path%20with%20spaces';
+        expect(ensureHttpScheme(encoded)).toBe(`https://${encoded}`);
+    });
+
+    it('formatURL handles already normalized URLs without modification', () => {
+        const url = 'https://example.com/path';
+        const result = formatURL(url);
+        expect(result.normalizedURL).toBe(url);
+    });
+});
+
+describe('formatURL - Decoding', () => {
+    it('should decode asterisks in URL', () => {
+        const result = formatURL('*google.com*');
+        expect(result.displayURL).toBe('*google.com*');
+        expect(result.displayURL).not.toContain('%2A');
+    });
+
+    it('should decode percent-encoded asterisks', () => {
+        const result = formatURL('%2Agoogle.com%2A');
+        expect(result.displayURL).toBe('*google.com*');
+        expect(result.displayURL).not.toContain('%2A');
+    });
+
+    it('should decode spaces in URL', () => {
+        const result = formatURL('hello world.com');
+        // Spaces in hostname cause sanitization to return about:blank
+        expect(result.displayURL).toBe('about:blank');
+        expect(result.normalizedURL).toBe('https://hello world.com');
+    });
+
+    it('should decode special characters like tilde', () => {
+        const result = formatURL('~special~.com');
+        expect(result.displayURL).toBe('~special~.com');
+        expect(result.displayURL).not.toContain('%7E');
+    });
+
+    it('should decode percent-encoded input', () => {
+        const result = formatURL('hello%20world.com');
+        // Percent sign in hostname causes sanitization to return about:blank
+        expect(result.displayURL).toBe('about:blank');
+        expect(result.normalizedURL).toBe('https://hello%20world.com');
+    });
+
+    it('should handle malformed URL gracefully', () => {
+        const result = formatURL('not-a-valid-url***');
+        // Should sanitize? Expect normalizedURL to have https:// prefix
+        expect(result.normalizedURL).toBe('https://not-a-valid-url***');
+        // displayURL may be the same as normalizedURL (since parsing fails) but decoded
+        expect(result.displayURL).toBe('not-a-valid-url***');
+    });
+
+    it('should preserve existing scheme like mailto', () => {
+        const result = formatURL('mailto:test@example.com');
+        expect(result.normalizedURL).toBe('mailto:test@example.com');
+        // displayURL likely will be mailto:test@example.com (since hostname extraction fails)
+    });
+});


### PR DESCRIPTION
This commit adds URL field display in the UserMetaPanel and extracts URL formatting utilities to a shared module.

Detailed Changes:
 - Implementation:
   - Added URLField import and display case for 'url' type in UserMetaPanel.js.
   - Moved ensureHttpScheme and formatURL functions from URL.jsx and URLInput.tsx to a new shared module formatUrl.js.
   - Updated URL.jsx and URLInput.tsx to import from the new formatUrl.js module.
   - Added decodeURIComponent to formatURL for cleaner display of percent-encoded characters.
 - Tests:
   - Added new test suite for formatURL function in URL.spec.jsx.
