### PR TITLE
fix(migrations): Improve migraiton fix for user meta

### DIFF
--- a/idm/oauth/dao/sql/pat-sql.go
+++ b/idm/oauth/dao/sql/pat-sql.go
@@ -52,17 +52,17 @@ func sha256Hash(input string) string {
 }
 
 type PersonalToken struct {
-	UUID              string       `gorm:"column:uuid; primaryKey; type:varchar(36) not null;"`
-	AccessToken       string       `gorm:"column:access_token;type:varchar(128) not null;unique;"`
+	UUID              string       `gorm:"column:uuid;primaryKey;type:varchar(36);not null;"`
+	AccessToken       string       `gorm:"column:access_token;type:varchar(128);not null;unique;"`
 	Type              auth.PatType `gorm:"column:pat_type;"`
-	Label             string       `gorm:"column:label;type:varchar(255) null;"`
-	UserUUID          string       `gorm:"column:user_uuid;type:varchar(255) not null;index;"`
-	UserLogin         string       `gorm:"column:user_login;type:varchar(255) not null;index;"`
+	Label             string       `gorm:"column:label;type:varchar(255);"`
+	UserUUID          string       `gorm:"column:user_uuid;type:varchar(255);not null;index;"`
+	UserLogin         string       `gorm:"column:user_login;type:varchar(255);not null;index;"`
 	SecretPair        string       `gorm:"column:secret_pair;type:varchar(255);"`
 	RevocationKey     string       `gorm:"column:revocation_key;type:varchar(255);index;"`
-	AutoRefreshWindow int32        `gorm:"column:auto_refresh;type: int default 0 null;"`
+	AutoRefreshWindow int32        `gorm:"column:auto_refresh;type:int;default:0;"`
 	ExpiresAt         time.Time    `gorm:"column:expire_at;"`
-	CreatedBy         string       `gorm:"column:created_by;type:varchar(128) null;"`
+	CreatedBy         string       `gorm:"column:created_by;type:varchar(128);"`
 	Scopes            string       `gorm:"column:scopes;"`
 	UpdatedAt         time.Time    `gorm:"autoUpdateTime"`
 	CreatedAt         time.Time    `gorm:"autoCreateTime"`


### PR DESCRIPTION
- Fixes for Personal token sql syntax db migration on upgrade with Postgres
```
[GRPC]/service.MigrateService/Migrate cannot update service version for pydio.grpc.token (ERROR: syntax error at or near "not" (SQLSTATE 42601))
``` 