### PR TITLE
fix(search): Fix failing indexer search for Mongo storage

### DIFF
--- a/data/search/dao/indexer_test.go
+++ b/data/search/dao/indexer_test.go
@@ -1082,6 +1082,10 @@ func TestMongoTagsNamespace(t *testing.T) {
 			So(er, ShouldBeNil)
 			So(nn, ShouldHaveLength, 1)
 
+			queryObject = &tree.Query{
+				FreeString: "+Meta.tags:\"value1\"",
+			}
+
 			nn, _, er = performSearch(ctx, server, queryObject)
 			So(er, ShouldBeNil)
 			So(nn, ShouldHaveLength, 2)


### PR DESCRIPTION
- Add needed query for the failed assertion

The assertion added was missing a search query call
[Failing test](https://tc.pyd.io/buildConfiguration/CICD_TcUnitStorageMongoLatest/892589)
test with
`CELLS_TEST_MONGODB_DSN=mongodb://<HOST>:27017/cellstest go test -v -tags=storage ./data/search/dao/...` 