### PR TITLE
fix(namespace): Fix where clause in Del method

### DIFF
--- a/idm/meta/dao/sql/ns-sql.go
+++ b/idm/meta/dao/sql/ns-sql.go
@@ -201,7 +201,8 @@ func (s *nsSqlImpl) Upsert(ctx context.Context, ns *idm.UserMetaNamespace) (erro
 func (s *nsSqlImpl) Del(ctx context.Context, ns *idm.UserMetaNamespace) (e error) {
 	whereClause := (&MetaNamespace{}).From(ns)
 
-	tx := s.Session(ctx).Where(whereClause).Delete(&MetaNamespace{})
+	tx := s.Session(ctx).Where(&MetaNamespace{Namespace: whereClause.Namespace}).Delete(&MetaNamespace{})
+
 	if tx.Error != nil {
 		return nsTag(tx.Error)
 	}

--- a/idm/meta/dao/sql/ns-sql_test.go
+++ b/idm/meta/dao/sql/ns-sql_test.go
@@ -54,7 +54,11 @@ func TestNSCrud(t *testing.T) {
 		Convey("Create Meta Namespace", t, func() {
 			mockDAO, er := manager.Resolve[meta.NamespaceDAO](ctx)
 			So(er, ShouldBeNil)
-
+			//count initial namespaces
+			initial, er := mockDAO.List(ctx)
+			So(er, ShouldBeNil)
+			// Only bookmark namespace should be present
+			So(initial, ShouldHaveLength, 1)
 			// Insert a meta
 			err, _ := mockDAO.Upsert(ctx, &idm.UserMetaNamespace{
 				Namespace:      "namespace",
@@ -82,7 +86,8 @@ func TestNSCrud(t *testing.T) {
 			// List meta for the node
 			result2, er := mockDAO.List(ctx)
 			So(er, ShouldBeNil)
-			So(result2, ShouldHaveLength, 2)
+			// Only bookmark namespace should be present
+			So(result2, ShouldHaveLength, 1)
 		})
 	})
 
@@ -150,6 +155,11 @@ func TestNSNewFields(t *testing.T) {
 		Convey("Create Meta Namespace with new fields", t, func() {
 			mockDAO, err0 := manager.Resolve[meta.NamespaceDAO](ctx)
 			So(err0, ShouldBeNil)
+
+			//count initial namespaces
+			initial, er := mockDAO.List(ctx)
+			So(er, ShouldBeNil)
+
 			tv := json_schema.LegacyTypeToLabel([]byte("{\"type\":\"string\"}"))
 			jsb, err1 := json_schema.GetJsonSchema(tv, "")
 			So(err1, ShouldBeNil)
@@ -172,7 +182,7 @@ func TestNSNewFields(t *testing.T) {
 			// Assert
 			result, err2 := mockDAO.List(ctx)
 			So(err2, ShouldBeNil)
-
+			So(result, ShouldHaveLength, len(initial)+1) // 2 because of the new namespace and the Bookmarks namespace
 			ns, ok := result["namespace-newfields"]
 			So(ok, ShouldBeTrue)
 


### PR DESCRIPTION
- Delete method was not matching the correct namespace because the From function returned Json Fields in a format not usable to match the db query
- Rely on the unique string column to match correct namespace
- fixe List namespace assertion in create namespace unit test
- count initial namespaces

Run locally with 
`CELLS_TEST_MYSQL_DSN="mysql://<user>:<passs>@tcp(<host>:3306)/testdb" go test -v -tags=storage ./idm/meta/dao/sql/...`
Failing test https://tc.pyd.io/buildConfiguration/CICD_TcUnitStorageMysql57/892619?logView=flowAware 