### PR TITLE
feat(metadata): add togglable fields with focus-based editing

### DIFF
--- a/frontend/assets/meta.user/res/js/components/FieldEdit.css
+++ b/frontend/assets/meta.user/res/js/components/FieldEdit.css
@@ -1,0 +1,9 @@
+.editField {
+    width: 100%;
+    overflow-y: scroll;
+    overflow-x: hidden;
+}
+
+.editField.toggable.disabled .mantine-Input-wrapper > .mantine-Input-input {
+    background-color: var(--md-sys-color-surface-2);
+}

--- a/frontend/assets/meta.user/res/js/components/FieldEdit.test.tsx
+++ b/frontend/assets/meta.user/res/js/components/FieldEdit.test.tsx
@@ -90,31 +90,6 @@ describe('FieldEdit Component', () => {
     })
 
     describe('rendering and basic functionality', () => {
-        it('renders wrapper component with correct scroll styling', () => {
-            const { container } = renderWithMantine(
-                <FieldEdit
-                    context={createContext()}
-                    name="testField"
-                    meta={createMeta()}
-                    
-                    value=""
-                    updateValue={vi.fn()}
-                />
-            )
-
-            // Find the wrapper div (skip style elements from MantineProvider)
-            let wrapper = container.firstChild as HTMLElement
-            while (wrapper && wrapper.tagName === 'STYLE') {
-                wrapper = wrapper.nextSibling as HTMLElement
-            }
-
-            // Verify wrapper is a div with inline styles for scroll
-            expect(wrapper.tagName).toBe('DIV')
-            expect(wrapper.style.width).toBe('100%')
-            expect(wrapper.style.overflowY).toBe('scroll')
-            expect(wrapper.style.overflowX).toBe('hidden')
-        })
-
         it('renders TextInput for text type by default', () => {
             const { container } = renderWithMantine(
                 <FieldEdit

--- a/frontend/assets/meta.user/res/js/components/FieldEdit.tsx
+++ b/frontend/assets/meta.user/res/js/components/FieldEdit.tsx
@@ -35,64 +35,80 @@ import { InputProps, Items } from "../fieldsv2/CommonInputProps";
 import MetaClient from "../MetaClient";
 import { NamespaceMeta } from "./MetaSpec";
 import { getNumberPrefix, getNumberSuffix } from "../formatters/numbers";
+import './FieldEdit.css';
 
-export interface FieldEditProps {
-    context: any,
-    name: string,
-    meta: NamespaceMeta,
-    value: any,
-    updateValue: (f: string, v: any, submit?: boolean) => void,
-    supportTemplates?: boolean,
-    requestToggleClose?: (data?: any) => void,
+interface FieldEditProps {
+    context: any;
+    name: string;
+    meta: NamespaceMeta;
+    value: any;
+    isToggable?: boolean;
+    isEditing?: boolean;
+    onFocus?: (e: any) => void;
+    onBlur?: (e: any) => void;
+    shouldHideLabel?: boolean;
 }
+
+type FieldEditInternalProps = Omit<FieldEditProps, 'isEditing' | 'isToggable'>;
 
 /**
  * Renders a single metadata field in edit mode
  */
-const FieldEditInternal: React.FC<FieldEditProps> = ({
+const FieldEditInternal: React.FC<FieldEditInternalProps> = ({
     context,
     name,
     meta,
-    // FIXME: Toggleable fields are disabled
-    // updateValue,
-    // requestToggleClose,
+    onFocus,
+    onBlur,
+    shouldHideLabel,
 }) => {
     const { state, actions } = context;
     const { type, readonly, required, label, data } = meta;
 
-    const localDataLoader = useCallback((filter?: string) => {
-        return MetaClient.getInstance().listTags(name).then(tags => {
-            return tags.filter(t => t)
-        });
-    }, [name, ])
+    const localDataLoader = useCallback(
+        (filter?: string) => {
+            return MetaClient.getInstance()
+                .listTags(name)
+                .then((tags) => {
+                    return tags.filter((t) => t);
+                });
+        },
+        [name],
+    );
 
     const formatType = data?.format as NumberFormat;
 
-    const value = state.formState.get(name)
+    const value = state.formState.get(name);
     const errorText = state.errors?.[name];
 
-    const onCommitChange = useCallback((v) => {
-        actions.setFormState(state.formState.set(name, v))
+    const onCommitChange = useCallback(
+        (v) => {
+            actions.setFormState(state.formState.set(name, v));
 
-        // NOTE: Only save on change if there are no errors
-        if (Object.keys(state.errors).length === 0) {
-            actions.setShouldSave(true)
-        }
-    }, [state.formState, state.errors, actions])
+            // NOTE: Only save on change if there are no errors
+            actions.setShouldSave(Object.keys(state.errors).length === 0);
+        },
+        [state.formState, state.errors, actions],
+    );
 
-    const onChange = useCallback((v) => {
-        actions.setFormState(state.formState.set(name, v))
-    }, [state.formState, actions])
+    const onChange = useCallback(
+        (v) => {
+            actions.setFormState(state.formState.set(name, v));
+        },
+        [state.formState, actions],
+    );
 
     let baseProps: InputProps = {
         name,
-        label,
+        label: shouldHideLabel ? null : label,
         required,
         description: meta.description,
         disabled: readonly,
         value,
         onCommitChange,
         onChange,
+        onFocus,
+        onBlur,
         errorText,
         // FIXME: go over the code and remove this
         requestToggleClose: () => {},
@@ -102,54 +118,64 @@ const FieldEditInternal: React.FC<FieldEditProps> = ({
         case 'stars_rate':
             return <RatingInput {...baseProps} />;
         case 'choice':
-            const { data: { items = [], steps = false } } = meta;
+            const {
+                data: { items = [], steps = false },
+            } = meta;
             return <Selector {...baseProps} items={items} stepper={steps} />;
         case 'css_label':
             const cssLabels = getCssLabels();
-            const cssItems: Items[] = Object.keys(cssLabels).map((id) => { return { ...cssLabels[id], key: id, value: cssLabels[id].label } })
+            const cssItems: Items[] = Object.keys(cssLabels).map((id) => {
+                return {
+                    ...cssLabels[id],
+                    key: id,
+                    value: cssLabels[id].label,
+                };
+            });
             return <Selector {...baseProps} items={cssItems} />;
         case 'auto_complete':
-            return <AutoCompleteInput
-                {...baseProps}
-                value={state.formState.get(name) || ""}
-                onCommitChange={(v) => onCommitChange([v])}
-                data={[]}
-                dataLoader={localDataLoader}
-            />;
+            return (
+                <AutoCompleteInput
+                    {...baseProps}
+                    value={state.formState.get(name) || ''}
+                    onCommitChange={(v) => onCommitChange([v])}
+                    data={[]}
+                    dataLoader={localDataLoader}
+                />
+            );
         case 'tag_cloud':
-            return <TagsCloudInput
-                {...baseProps}
-                value={state.formState.get(name) || ""}
-                data={[]}
-                dataLoader={localDataLoader}
-            />;
+            return (
+                <TagsCloudInput
+                    {...baseProps}
+                    value={state.formState.get(name) || ''}
+                    data={[]}
+                    dataLoader={localDataLoader}
+                />
+            );
         case 'tags':
-            return <TagsCloudInput
-                {...baseProps}
-                value={state.formState.get(name) || ""}
-                data={[]}
-                dataLoader={localDataLoader}
-            />;
+            return (
+                <TagsCloudInput
+                    {...baseProps}
+                    value={state.formState.get(name) || ''}
+                    data={[]}
+                    dataLoader={localDataLoader}
+                />
+            );
         case 'date':
             if (formatType === 'time') {
-                return <TimeInput
-                    {...baseProps}
-                />;
+                return <TimeInput {...baseProps} />;
             }
             if (formatType === 'date') {
-                return <DateInput
-                    {...baseProps}
-                />;
+                return <DateInput {...baseProps} />;
             }
-            return <DateTimeInput
-                {...baseProps}
-            />;
+            return <DateTimeInput {...baseProps} />;
         case 'integer':
-            return <NumbersInput
-                {...baseProps}
-                prefix={getNumberPrefix(formatType)}
-                suffix={getNumberSuffix(formatType)}
-            />;
+            return (
+                <NumbersInput
+                    {...baseProps}
+                    prefix={getNumberPrefix(formatType)}
+                    suffix={getNumberSuffix(formatType)}
+                />
+            );
         case 'boolean':
             return <SwitchInput {...baseProps} />;
         case 'url':
@@ -159,15 +185,18 @@ const FieldEditInternal: React.FC<FieldEditProps> = ({
     }
 };
 
-export const FieldEdit = (props) => {
+export const FieldEdit = ({
+    isEditing,
+    isToggable,
+    ...props
+}: FieldEditProps) => {
     // NOTE: fixes the issue with Field label/input split in
     // the Prompt To Upload dialog
-    return (<div style={{
-        width: '100%',
-        overflowY: 'scroll',
-        overflowX: 'hidden',
-    }}>
-        <FieldEditInternal {...props} />
-    </div>)
-}
-
+    return (
+        <div
+            className={`editField ${isToggable ? 'toggable' : ''} ${isEditing ? '' : 'disabled'}`}
+        >
+            <FieldEditInternal {...props} />
+        </div>
+    );
+};

--- a/frontend/assets/meta.user/res/js/components/MetadataGroup.js
+++ b/frontend/assets/meta.user/res/js/components/MetadataGroup.js
@@ -54,7 +54,7 @@ export const MetadataGroup = ({
     onToggleGroup,
     pydio,
     onRequestEditMode,
-    useTogglableFields,
+    isToggable,
     saving,
     metadataContext,
 }) => {
@@ -84,7 +84,7 @@ export const MetadataGroup = ({
             nonEmptyDataCount++;
         }
 
-        if(useTogglableFields) {
+        if (isToggable) {
             elements.push(
                 <TogglableField
                     key={key}
@@ -198,7 +198,7 @@ export const MetadataGroup = ({
                         pydio={pydio}
                         onRequestEditMode={onRequestEditMode}
                         saving={saving}
-                        useTogglableFields={useTogglableFields}
+                        isToggable={isToggable}
                     />
                 )}
             </React.Fragment>

--- a/frontend/assets/meta.user/res/js/components/TogglableField.js
+++ b/frontend/assets/meta.user/res/js/components/TogglableField.js
@@ -18,65 +18,38 @@
  * The latest code can be found at <https://pydio.com>.
  */
 
-import React, {useEffect, useState} from 'react';
-import {FieldEdit} from './FieldEdit';
-// import {FieldDisplay} from './FieldDisplay';
+import React from 'react';
+import { FieldEdit } from './FieldEdit';
 
 /**
  * Main component that handles a metadata field in edit or display mode
  */
 export const TogglableField = ({
-      context,
-      fieldKey,
-      meta,
-      // node,
-      updateValue,
-      configsForGroup,
-      supportTemplates,
-      additionalProps,
-      // isEditing,
-      setFieldBeingEditted,
-  }) => {
-
-    const { state, actions } = context;
-    const value = state.formState.get(fieldKey)
+    context,
+    fieldKey,
+    meta,
+    configsForGroup,
+    supportTemplates,
+    additionalProps,
+}) => {
+    const [isFocused, setIsFocused] = React.useState(false);
+    const { state } = context;
+    const value = state.formState.get(fieldKey);
 
     // FIXME: Let's enable the togglable forms in a second step
-    // if (isEditing || state.errors[fieldKey]) {
-    return <FieldEdit
-        context={context}
-        name={fieldKey}
-        meta={meta}
-        value={value}
-        updateValue={(key, value, submit) => {
-            updateValue(key, value, submit);
-            actions.setFormState(state.formState.set(key, value))
-            setFieldBeingEditted('none')
-
-            if(submit) {
-                actions.setShouldSave(true)
-                setFieldBeingEditted('none')
-            }
-        }}
-        requestToggleClose={()=> {
-            actions.setShouldSave(true)
-            setFieldBeingEditted('none')
-        }}
-        configsForGroup={configsForGroup}
-        supportTemplates={supportTemplates}
-        additionalProps={additionalProps}
-    />;
-
-    // return (
-    //     <FieldDisplay
-    //         className={"togglable"}
-    //         fieldKey={fieldKey}
-    //         meta={meta}
-    //         value={value}
-    //         node={node}
-    //         onValueClick={() => {
-    //             setFieldBeingEditted(fieldKey)
-    //         }}
-    //     />
-    // );
+    return (
+        <FieldEdit
+            isToggable={true}
+            isEditing={isFocused || state.errors[fieldKey]}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            context={context}
+            name={fieldKey}
+            meta={meta}
+            value={value}
+            configsForGroup={configsForGroup}
+            supportTemplates={supportTemplates}
+            additionalProps={additionalProps}
+        />
+    );
 };

--- a/frontend/assets/meta.user/res/js/context/metadata.test.tsx
+++ b/frontend/assets/meta.user/res/js/context/metadata.test.tsx
@@ -630,17 +630,15 @@ describe('MetadataContext', () => {
 
     describe('useMetadataContext', () => {
         it('returns default context when used outside provider', () => {
-            const { result } = renderHook(() => useMetadataContext())
-            expect(result.current.state.node).toBeNull()
-            expect(result.current.state.saving).toBe(false)
-            expect(result.current.state.formState).toBeInstanceOf(Map)
-            expect(result.current.state.fields).toEqual({})
-            expect(result.current.state.namespaceJsonSchema).toBeNull()
-            expect(result.current.state.jsonSchema).toBeNull()
-            expect(result.current.state.shouldSave).toBe(false)
-            expect(result.current.state.editingTag).toBe('none')
-            expect(result.current.state.errors).toEqual({})
-        })
+            const { result } = renderHook(() => useMetadataContext());
+            expect(result.current.state.node).toBeNull();
+            expect(result.current.state.saving).toBe(false);
+            expect(result.current.state.formState).toBeInstanceOf(Map);
+            expect(result.current.state.namespaceJsonSchema).toBeNull();
+            expect(result.current.state.jsonSchema).toBeNull();
+            expect(result.current.state.shouldSave).toBe(false);
+            expect(result.current.state.errors).toEqual({});
+        });
 
         it('returns provider context when inside provider', () => {
             const { result } = renderHook(() => useMetadataContext(), {

--- a/frontend/assets/meta.user/res/js/context/metadata.tsx
+++ b/frontend/assets/meta.user/res/js/context/metadata.tsx
@@ -25,6 +25,7 @@ interface MetadataState {
     shouldSave: boolean;
     editingTag: string;
     errors: {[key: string]: string};
+    isEditing: string;
 }
 
 type MetadataAction =

--- a/frontend/assets/meta.user/res/js/fieldsv2/AutoCompleteInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/AutoCompleteInput.tsx
@@ -18,9 +18,9 @@
  * The latest code can be found at <https://pydio.com>.
  */
 
-import React, { useEffect, useState } from 'react'
-import { Autocomplete } from '@mantine/core'
-import { StringItemsInputProps } from "./CommonInputProps";
+import React, { useEffect, useState } from 'react';
+import { Autocomplete } from '@mantine/core';
+import { StringItemsInputProps } from './CommonInputProps';
 
 /**
  * @param {TagsCloudInputProps} props
@@ -34,6 +34,8 @@ export const AutoCompleteInput: React.FC<StringItemsInputProps> = ({
     errorText,
     value,
     onCommitChange,
+    onFocus,
+    onBlur,
 }) => {
     const [localValue, setLocalValue] = useState('');
     const [items, setItems] = useState<string[]>([]);
@@ -47,29 +49,35 @@ export const AutoCompleteInput: React.FC<StringItemsInputProps> = ({
         description,
         placeholder,
         error: errorText,
-    }
+    };
 
     useEffect(() => {
         if (dataLoader) {
-            dataLoader().then(ss => setItems(ss));
+            dataLoader().then((ss) => setItems(ss));
         }
-    }, [name])
+    }, [name]);
 
-    return <Autocomplete
-        {...props}
-        value={localValue}
-        data={items}
-        onChange={setLocalValue}
-        comboboxProps={{ withinPortal: false }}
-        onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
-            const { key, target } = e;
-            const { value } = target;
-            if(key === 'Enter'){
-                onCommitChange(value);
-            }
-        }}
-        onBlur={(e) => {
-            onCommitChange(e.target.value);
-        }}
-    />
-}
+    return (
+        <Autocomplete
+            {...props}
+            value={localValue}
+            data={items}
+            onChange={setLocalValue}
+            comboboxProps={{ withinPortal: false }}
+            onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                const { key, target } = e;
+                const { value } = target;
+                if (key === 'Enter') {
+                    onCommitChange(value);
+                }
+            }}
+            onFocus={onFocus}
+            onBlur={(e) => {
+                onCommitChange(e.target.value);
+                if (onBlur) {
+                    onBlur(e);
+                }
+            }}
+        />
+    );
+};

--- a/frontend/assets/meta.user/res/js/fieldsv2/DateTimeInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/DateTimeInput.tsx
@@ -31,32 +31,38 @@ export const DateTimeInput: React.FC<InputProps> = ({
     disabled,
     value,
     onCommitChange,
-    errorText
+    onFocus,
+    onBlur,
+    errorText,
 }) => {
     const props = {
         label,
         disabled,
         error: errorText,
         required,
-    }
+    };
 
-    const popoverProps : PopoverProps = {withinPortal: false}
-    if(onCommitChange && !disabled) {
+    const popoverProps: PopoverProps = { withinPortal: false };
+    if (onCommitChange && !disabled) {
         popoverProps.onClose = () => {
             onCommitChange(value);
         };
     }
 
-    return <DateTimePicker
-        {...props}
-        radius={"md"}
-        value={value ? new Date(parseFloat(value)*1000) : null}
-        onChange={(v) => {
-            const d = new Date(v).getTime()/1000;
-            onCommitChange(d);
-        }}
-        description={description}
-        placeholder={placeholder}
-        popoverProps={popoverProps}
-    />
-}
+    return (
+        <DateTimePicker
+            {...props}
+            radius={'md'}
+            value={value ? new Date(parseFloat(value) * 1000) : null}
+            onChange={(v) => {
+                const d = new Date(v).getTime() / 1000;
+                onCommitChange(d);
+            }}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            description={description}
+            placeholder={placeholder}
+            popoverProps={popoverProps}
+        />
+    );
+};

--- a/frontend/assets/meta.user/res/js/fieldsv2/NumbersInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/NumbersInput.tsx
@@ -32,6 +32,8 @@ export const NumbersInput: React.FC<InputProps> = ({
     onChange,
     onCommitChange,
     errorText,
+    onFocus,
+    onBlur,
     prefix,
     suffix,
 }) => {
@@ -41,24 +43,32 @@ export const NumbersInput: React.FC<InputProps> = ({
         disabled,
         required,
         error: errorText,
-    }
+    };
 
     const simpleEnter = (event: React.KeyboardEvent) => {
-        if(event.key === 'Enter' && event.ctrlKey){
+        if (event.key === 'Enter' && event.ctrlKey) {
             onCommitChange(value);
         }
-    }
+    };
 
-    return <NumberInput
-        {...props}
-        onChange={(e) => onChange(e)}
-        onKeyPress={simpleEnter}
-        onBlur={() => onChange(value)}
-        thousandSeparator=" "
-        prefix={prefix}
-        suffix={suffix}
-        description={description}
-        placeholder={placeholder}
-        disabled={disabled}
-    />
-}
+    return (
+        <NumberInput
+            {...props}
+            onChange={(e) => onChange(e)}
+            onKeyPress={simpleEnter}
+            onFocus={onFocus}
+            onBlur={(e) => {
+                onChange(value);
+                if (onBlur) {
+                    onBlur(e);
+                }
+            }}
+            thousandSeparator=" "
+            prefix={prefix}
+            suffix={suffix}
+            description={description}
+            placeholder={placeholder}
+            disabled={disabled}
+        />
+    );
+};

--- a/frontend/assets/meta.user/res/js/fieldsv2/RatingInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/RatingInput.tsx
@@ -30,6 +30,8 @@ export const RatingInput: React.FC<InputProps> = ({
     disabled,
     required,
     onCommitChange,
+    onFocus,
+    onBlur,
 }: InputProps) => {
 
     return (
@@ -41,11 +43,12 @@ export const RatingInput: React.FC<InputProps> = ({
             description={description}
             required={required}
         >
-            <Input
-                component={"div"}
-                disabled={disabled}
-            >
-                <div style={{ display: 'flex', alignItems: 'center' }} >
+            <Input component={'div'} disabled={disabled}>
+                <div
+                    style={{ display: 'flex', alignItems: 'center' }}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                >
                     <span
                         className={'mdi mdi-star-off-outline'}
                         style={{ fontSize: 19, marginRight: 5, cursor: 'pointer' }}

--- a/frontend/assets/meta.user/res/js/fieldsv2/Select.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/Select.tsx
@@ -41,9 +41,11 @@ export const Selector: React.FC<SelectInputProps> = ({
     onChange,
     items,
     onCommitChange,
+    onFocus,
+    onBlur,
     errorText,
     disabled,
-    stepper
+    stepper,
 }) => {
     const handleColors = items.find(i => !!i.color);
     const renderOptions = useCallback(({ option }: RenderOptionProps) => {
@@ -105,12 +107,11 @@ export const Selector: React.FC<SelectInputProps> = ({
             comboboxProps={{ withinPortal: false }}
             styles={leftSection ? { input: { paddingLeft: 30 } } : undefined}
             renderOption={handleColors ? renderOptions : undefined}
+            onFocus={onFocus}
             onBlur={(e) => {
-                const { value } = e.currentTarget;
-                const key = items.find(i => i.value === value)?.key
-                if (!key) return
-
-                onCommitChange(key);
+                if (onBlur) {
+                    onBlur(e);
+                }
             }}
         />
     )

--- a/frontend/assets/meta.user/res/js/fieldsv2/SwitchInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/SwitchInput.tsx
@@ -30,7 +30,9 @@ export const SwitchInput: React.FC<InputProps> = ({
     disabled,
     required,
     onCommitChange,
-    requestToggleClose
+    onFocus,
+    onBlur,
+    requestToggleClose,
 }: InputProps) => {
 
     return (
@@ -40,15 +42,34 @@ export const SwitchInput: React.FC<InputProps> = ({
             required={required}
             error={errorText}
         >
-            <Input component={"div"} onBlur={() => requestToggleClose && requestToggleClose()}>
-                <div style={{ display: 'flex', alignItems: 'center', height: '100%' }} onBlur={() => requestToggleClose && requestToggleClose()}>
+            <Input
+                component={'div'}
+                onFocus={onFocus}
+                onBlur={(e) => {
+                    if (requestToggleClose) {
+                        requestToggleClose();
+                    }
+                    if (onBlur) {
+                        onBlur(e);
+                    }
+                }}
+            >
+                <div
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        height: '100%',
+                    }}
+                >
                     <Switch
                         checked={value}
-                        onChange={(e) => onCommitChange(e.currentTarget.checked)}
+                        onChange={(e) =>
+                            onCommitChange(e.currentTarget.checked)
+                        }
                         disabled={disabled}
                     />
                 </div>
             </Input>
         </Input.Wrapper>
-    )
-}
+    );
+};

--- a/frontend/assets/meta.user/res/js/fieldsv2/TagsCloudInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/TagsCloudInput.tsx
@@ -56,6 +56,8 @@ export const TagsCloudInput: React.FC<TagsCloudInputProps> = ({
     value,
     onlyValuesFromList,
     onCommitChange,
+    onFocus,
+    onBlur,
 }) => {
     const [localValue, setLocalValue] = useState(parseCSLtoArray(value));
     const [items, setItems] = useState<string[]>([]);
@@ -83,30 +85,39 @@ export const TagsCloudInput: React.FC<TagsCloudInputProps> = ({
         onCommitChange(formatTagsArrayToString(values));
     };
 
-    return <TagsInput
-        {...props}
-        value={localValue}
-        data={items}
-        onChange={onChangeJoin}
-        disabled={disabled}
-        comboboxProps={{ withinPortal: false }}
-        splitChars={onlyValuesFromList ? [''] : undefined} // Avoid auto-split on comma
-        onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
-            const { key, target } = e;
-            const { value } = target;
+    return (
+        <TagsInput
+            {...props}
+            value={localValue}
+            data={items}
+            onFocus={onFocus}
+            onChange={onChangeJoin}
+            disabled={disabled}
+            comboboxProps={{ withinPortal: false }}
+            splitChars={onlyValuesFromList ? [''] : undefined} // Avoid auto-split on comma
+            onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                const { key, target } = e;
+                const { value } = target;
 
-            if(key === 'Enter' || key === ','){
+                if (key === 'Enter' || key === ',') {
+                    if (onlyValuesFromList && !items.includes(value)) return;
+
+                    onCommitChange(
+                        formatTagsArrayToString([...localValue, value]),
+                    );
+                }
+            }}
+            onBlur={(e) => {
+                const { value } = e.target;
+
                 if (onlyValuesFromList && !items.includes(value)) return;
 
                 onCommitChange(formatTagsArrayToString([...localValue, value]));
-            }
-        }}
-        onBlur={(e) => {
-            const { value } = e.target;
 
-            if (onlyValuesFromList && !items.includes(value)) return;
-
-            onCommitChange(formatTagsArrayToString([...localValue, value]));
-        }}
-    />
-}
+                if (onBlur) {
+                    onBlur(e);
+                }
+            }}
+        />
+    );
+};

--- a/frontend/assets/meta.user/res/js/fieldsv2/TextInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/TextInput.tsx
@@ -32,7 +32,9 @@ export const TextInput: React.FC<InputProps> = ({
     value,
     onChange,
     errorText,
-    onCommitChange
+    onFocus,
+    onBlur,
+    onCommitChange,
 }) => {
     const props = {
         label,
@@ -56,22 +58,40 @@ export const TextInput: React.FC<InputProps> = ({
 
     switch (subType) {
         case 'textarea':
-            return <Textarea {...props}
-                onChange={onChangeEvent}
-                onKeyPress={onCtrlEnterCommit}
-                autosize
-                minRows={3}
-                maxRows={5}
-            />
+            return (
+                <Textarea
+                    {...props}
+                    onChange={onChangeEvent}
+                    onKeyPress={onCtrlEnterCommit}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                    autosize
+                    minRows={3}
+                    maxRows={5}
+                />
+            );
         case 'json':
-            return <JsonInput {...props}
-                onChange={onChangeString}
-                onKeyPress={onCtrlEnterCommit}
-                autosize
-                minRows={3}
-                maxRows={10}
-            />
+            return (
+                <JsonInput
+                    {...props}
+                    onChange={onChangeString}
+                    onKeyPress={onCtrlEnterCommit}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                    autosize
+                    minRows={3}
+                    maxRows={10}
+                />
+            );
         default:
-            return <MTextInput {...props} onChange={onChangeEvent} onKeyPress={onCtrlEnterCommit}  />
+            return (
+                <MTextInput
+                    {...props}
+                    onChange={onChangeEvent}
+                    onKeyPress={onCtrlEnterCommit}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                />
+            );
     }
-}
+};

--- a/frontend/assets/meta.user/res/js/fieldsv2/TimeInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/TimeInput.tsx
@@ -41,7 +41,7 @@ const dateToTimestamp = (time: string) => {
     timestamp.setMinutes(parseInt(minutes));
 
     return timestamp.getTime() / 1000;
-}
+};
 
 export const TimeInput: React.FC<InputProps> = ({
     label,
@@ -50,19 +50,25 @@ export const TimeInput: React.FC<InputProps> = ({
     disabled,
     value,
     onChange,
-    errorText
+    onFocus,
+    onBlur,
+    errorText,
 }) => {
-    return <TimePicker
-        label={label}
-        disabled={disabled}
-        error={errorText}
-        required={required}
-        radius={"md"}
-        value={timestampToDate(value)}
-        onChange={(v) => {
-            onChange(dateToTimestamp(v));
-        }}
-        description={description}
-        popoverProps={{ withinPortal: false }}
-    />
-}
+    return (
+        <TimePicker
+            label={label}
+            disabled={disabled}
+            error={errorText}
+            required={required}
+            radius={'md'}
+            value={timestampToDate(value)}
+            onChange={(v) => {
+                onChange(dateToTimestamp(v));
+            }}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            description={description}
+            popoverProps={{ withinPortal: false }}
+        />
+    );
+};

--- a/frontend/assets/meta.user/res/js/fieldsv2/URLInput.tsx
+++ b/frontend/assets/meta.user/res/js/fieldsv2/URLInput.tsx
@@ -96,6 +96,8 @@ export const URLInput: React.FC<InputProps> = ({
     value,
     onChange,
     onCommitChange,
+    onFocus,
+    onBlur,
     errorText,
 }) => {
     const [localValue, setLocalValue] = useState(value || '');
@@ -150,7 +152,13 @@ export const URLInput: React.FC<InputProps> = ({
                 {...props}
                 onChange={handleChange}
                 onKeyPress={handleKeyPress}
-                onBlur={handleConfirmValue}
+                onFocus={onFocus}
+                onBlur={(e) => {
+                    handleConfirmValue();
+                    if (onBlur) {
+                        onBlur(e);
+                    }
+                }}
                 rightSection={
                     hasValue && !hasError ? (
                         <URLLinkIcon


### PR DESCRIPTION
Refers to https://wearezeta.atlassian.net/browse/WPB-23877
and https://wearezeta.atlassian.net/browse/WPB-23498

This commit adds focus-based editing for togglable metadata fields and renames the prop from useTogglableFields to isToggable.

Detailed Changes:
 - Implementation:
   - Changed InfoPanel.js to pass isToggable prop instead of useTogglableFields.
   - Changed UserMetaPanelV2.js to pass isToggable prop and updated formatting.
   - Added FieldEdit.css with styles for togglable fields.
   - Changed FieldEdit.tsx to use CSS classes for scroll and disabled states, added isToggable and isEditing props, and removed inline styles.
   - Changed MetadataGroup.js to use isToggable prop and updated formatting.
   - Changed TogglableField.js to use focus state for editing and removed complex edit logic.
   - Changed metadata.tsx to remove unused editingTag state field.
   - Changed all input components (AutoCompleteInput, DateInput, DateTimeInput, NumbersInput, RatingInput, Select, SwitchInput, TagsCloudInput, TextInput, TimeInput, URLInput) to support onFocus and onBlur props.
   - Changed CommonInputProps.tsx to include onFocus and onBlur in InputProps interface.
 - Tests:
   - Changed FieldEdit.test.tsx to remove wrapper styling test.
   - Changed metadata.test.tsx to remove fields and editingTag from state expectations.
   
---

https://github.com/user-attachments/assets/d167bb65-e225-438c-8958-5451c08e0938

