### PR TITLE
fix(s3): add path-style support to fix Ceph RGW S3 compatibility

### DIFF
--- a/common/config/datasources.go
+++ b/common/config/datasources.go
@@ -185,12 +185,18 @@ func FactorizeMinioServers(ctx context.Context, existingConfigs map[string]*obje
 			if !update {
 				newSource.ApiSecret = config.ApiSecret
 			} else {
-				// We may have to update signature version
+				// We may have to update signature version and path-style settings
+				if config.GatewayConfiguration == nil {
+					config.GatewayConfiguration = make(map[string]string)
+				}
 				if sv, o := newSource.StorageConfiguration[object.StorageKeySignatureVersion]; o {
-					if config.GatewayConfiguration == nil {
-						config.GatewayConfiguration = make(map[string]string, 1)
-					}
 					config.GatewayConfiguration[object.StorageKeySignatureVersion] = sv
+				}
+				if ps, o := newSource.StorageConfiguration[object.StorageKeyPathStyle]; o {
+					config.GatewayConfiguration[object.StorageKeyPathStyle] = ps
+				}
+				if fps, o := newSource.StorageConfiguration[object.StorageKeyForcePathStyle]; o {
+					config.GatewayConfiguration[object.StorageKeyForcePathStyle] = fps
 				}
 			}
 		} else if update {
@@ -199,11 +205,17 @@ func FactorizeMinioServers(ctx context.Context, existingConfigs map[string]*obje
 			config.ApiKey = newSource.ApiKey
 			config.ApiSecret = newSource.ApiSecret
 			config.EndpointUrl = newSource.StorageConfiguration[object.StorageKeyCustomEndpoint]
+			if config.GatewayConfiguration == nil {
+				config.GatewayConfiguration = make(map[string]string)
+			}
 			if sv, o := newSource.StorageConfiguration[object.StorageKeySignatureVersion]; o {
-				if config.GatewayConfiguration == nil {
-					config.GatewayConfiguration = make(map[string]string, 1)
-				}
 				config.GatewayConfiguration[object.StorageKeySignatureVersion] = sv
+			}
+			if ps, o := newSource.StorageConfiguration[object.StorageKeyPathStyle]; o {
+				config.GatewayConfiguration[object.StorageKeyPathStyle] = ps
+			}
+			if fps, o := newSource.StorageConfiguration[object.StorageKeyForcePathStyle]; o {
+				config.GatewayConfiguration[object.StorageKeyForcePathStyle] = fps
 			}
 		} else {
 			config = &object.MinioConfig{
@@ -214,10 +226,18 @@ func FactorizeMinioServers(ctx context.Context, existingConfigs map[string]*obje
 				RunningPort: createConfigPort(existingConfigs, newSource.ObjectsPort),
 				EndpointUrl: newSource.StorageConfiguration[object.StorageKeyCustomEndpoint],
 			}
+			gatewayConfig := make(map[string]string)
 			if sv, o := newSource.StorageConfiguration[object.StorageKeySignatureVersion]; o {
-				config.GatewayConfiguration = map[string]string{
-					object.StorageKeySignatureVersion: sv,
-				}
+				gatewayConfig[object.StorageKeySignatureVersion] = sv
+			}
+			if ps, o := newSource.StorageConfiguration[object.StorageKeyPathStyle]; o {
+				gatewayConfig[object.StorageKeyPathStyle] = ps
+			}
+			if fps, o := newSource.StorageConfiguration[object.StorageKeyForcePathStyle]; o {
+				gatewayConfig[object.StorageKeyForcePathStyle] = fps
+			}
+			if len(gatewayConfig) > 0 {
+				config.GatewayConfiguration = gatewayConfig
 			}
 		}
 	} else if newSource.StorageType == object.StorageType_AZURE {

--- a/common/config/datasources_pathstyle_test.go
+++ b/common/config/datasources_pathstyle_test.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2019-2021. Abstrium SAS <team (at) pydio.com>
+ * This file is part of Pydio Cells.
+ *
+ * Pydio Cells is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio Cells is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+package config
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/pydio/cells/v5/common/proto/object"
+)
+
+func TestFactorizeMinioServersPathStyle(t *testing.T) {
+
+	Convey("Testing FactorizeMinioServers path_style propagation", t, func() {
+
+		Convey("New S3 config with path_style should store it in GatewayConfiguration", func() {
+			newSource := &object.DataSource{
+				Name:        "test",
+				StorageType: object.StorageType_S3,
+				ApiKey:      "mykey",
+				ApiSecret:   "mysecret",
+				StorageConfiguration: map[string]string{
+					object.StorageKeyCustomEndpoint: "http://ceph.example.com:7480",
+					object.StorageKeyPathStyle:      "true",
+					object.StorageKeyForcePathStyle: "true",
+				},
+			}
+			cfg, err := FactorizeMinioServers(context.Background(), map[string]*object.MinioConfig{}, newSource, false)
+			So(err, ShouldBeNil)
+			So(cfg, ShouldNotBeNil)
+			So(cfg.GatewayConfiguration, ShouldNotBeNil)
+			So(cfg.GatewayConfiguration[object.StorageKeyPathStyle], ShouldEqual, "true")
+			So(cfg.GatewayConfiguration[object.StorageKeyForcePathStyle], ShouldEqual, "true")
+		})
+
+		Convey("New S3 config without path_style should not set GatewayConfiguration keys", func() {
+			newSource := &object.DataSource{
+				Name:        "test",
+				StorageType: object.StorageType_S3,
+				ApiKey:      "mykey",
+				ApiSecret:   "mysecret",
+				StorageConfiguration: map[string]string{
+					object.StorageKeyCustomEndpoint: "http://s3.amazonaws.com",
+				},
+			}
+			cfg, err := FactorizeMinioServers(context.Background(), map[string]*object.MinioConfig{}, newSource, false)
+			So(err, ShouldBeNil)
+			So(cfg, ShouldNotBeNil)
+			// GatewayConfiguration should be nil or not contain path_style keys
+			if cfg.GatewayConfiguration != nil {
+				_, hasPs := cfg.GatewayConfiguration[object.StorageKeyPathStyle]
+				_, hasFps := cfg.GatewayConfiguration[object.StorageKeyForcePathStyle]
+				So(hasPs, ShouldBeFalse)
+				So(hasFps, ShouldBeFalse)
+			}
+		})
+
+		Convey("Update S3 config with existing gateway should propagate path_style", func() {
+			existingName := "pydio-s3"
+			existing := map[string]*object.MinioConfig{
+				existingName: {
+					Name:        existingName,
+					StorageType: object.StorageType_S3,
+					ApiKey:      "mykey",
+					ApiSecret:   "mysecret",
+				},
+			}
+			newSource := &object.DataSource{
+				Name:                 "test",
+				ObjectsServiceName:   existingName,
+				StorageType:          object.StorageType_S3,
+				ApiKey:               "mykey",
+				ApiSecret:            "newsecret",
+				StorageConfiguration: map[string]string{
+					object.StorageKeyPathStyle:      "true",
+					object.StorageKeyForcePathStyle: "true",
+				},
+			}
+			cfg, err := FactorizeMinioServers(context.Background(), existing, newSource, true)
+			So(err, ShouldBeNil)
+			So(cfg, ShouldNotBeNil)
+			So(cfg.GatewayConfiguration, ShouldNotBeNil)
+			So(cfg.GatewayConfiguration[object.StorageKeyPathStyle], ShouldEqual, "true")
+			So(cfg.GatewayConfiguration[object.StorageKeyForcePathStyle], ShouldEqual, "true")
+		})
+
+		Convey("AZURE storage type should not receive path_style in GatewayConfiguration", func() {
+			newSource := &object.DataSource{
+				Name:        "test-azure",
+				StorageType: object.StorageType_AZURE,
+				ApiKey:      "azurekey",
+				ApiSecret:   "azuresecret",
+				StorageConfiguration: map[string]string{
+					object.StorageKeyPathStyle: "true",
+				},
+			}
+			cfg, err := FactorizeMinioServers(context.Background(), map[string]*object.MinioConfig{}, newSource, false)
+			So(err, ShouldBeNil)
+			So(cfg, ShouldNotBeNil)
+			// AZURE branch does not handle path_style
+			if cfg.GatewayConfiguration != nil {
+				_, hasPs := cfg.GatewayConfiguration[object.StorageKeyPathStyle]
+				So(hasPs, ShouldBeFalse)
+			}
+		})
+	})
+}

--- a/common/nodes/objects/mc/client.go
+++ b/common/nodes/objects/mc/client.go
@@ -104,6 +104,9 @@ func New(endpoint, accessKey, secretKey, signatureVersion string, secure bool, c
 	} else if r := s3utils.GetRegionFromURL(*u); r != "" {
 		options.Region = r
 	}
+	if other.Val("path_style").Bool() || other.Val("force_path_style").Bool() {
+		options.BucketLookup = minio.BucketLookupPath
+	}
 
 	c, err := minio.NewCore(endpoint, options)
 	if err != nil {

--- a/common/proto/object/datasource.go
+++ b/common/proto/object/datasource.go
@@ -51,6 +51,8 @@ const (
 	StorageKeyJsonCredentials  = "jsonCredentials"
 	StorageKeyStorageClass     = "storageClass"
 	StorageKeySignatureVersion = "signatureVersion"
+	StorageKeyPathStyle        = "path_style"
+	StorageKeyForcePathStyle   = "force_path_style"
 
 	StorageKeyCellsInternal    = "cellsInternal"
 	StorageKeyInitFromBucket   = "initFromBucket"
@@ -84,6 +86,12 @@ func (d *DataSource) ClientConfig(ctx context.Context, p SecretProvider) kv.Valu
 		}
 		if sv, o := d.StorageConfiguration[StorageKeySignatureVersion]; o && sv != "" {
 			_ = cfg.Val("signature").Set(sv)
+		}
+		if ps, o := d.StorageConfiguration[StorageKeyPathStyle]; o {
+			_ = cfg.Val(StorageKeyPathStyle).Set(ps == "true")
+		}
+		if fps, o := d.StorageConfiguration[StorageKeyForcePathStyle]; o {
+			_ = cfg.Val(StorageKeyForcePathStyle).Set(fps == "true")
 		}
 	}
 	return cfg
@@ -162,6 +170,12 @@ func (d *MinioConfig) ClientConfig(ctx context.Context, p SecretProvider, agentN
 		}
 		if sv, o := d.GatewayConfiguration[StorageKeySignatureVersion]; o && sv != "" {
 			_ = cfg.Val("signature").Set(sv)
+		}
+		if ps, o := d.GatewayConfiguration[StorageKeyPathStyle]; o {
+			_ = cfg.Val(StorageKeyPathStyle).Set(ps == "true")
+		}
+		if fps, o := d.GatewayConfiguration[StorageKeyForcePathStyle]; o {
+			_ = cfg.Val(StorageKeyForcePathStyle).Set(fps == "true")
 		}
 	}
 	return cfg

--- a/common/proto/object/datasource_test.go
+++ b/common/proto/object/datasource_test.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2019-2021. Abstrium SAS <team (at) pydio.com>
+ * This file is part of Pydio Cells.
+ *
+ * Pydio Cells is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio Cells is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+package object
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/pydio/cells/v5/common/utils/configx"
+	"github.com/pydio/cells/v5/common/utils/kv"
+)
+
+// noopSecretProvider returns an empty config for any secret lookup.
+var noopSecretProvider SecretProvider = func(_ context.Context, _ string) kv.Values {
+	return configx.New()
+}
+
+func TestDataSourceClientConfigPathStyle(t *testing.T) {
+
+	ctx := context.Background()
+
+	Convey("Testing DataSource.ClientConfig path_style propagation", t, func() {
+
+		Convey("path_style=true should set bool true in config", func() {
+			ds := &DataSource{
+				StorageType: StorageType_S3,
+				StorageConfiguration: map[string]string{
+					StorageKeyPathStyle: "true",
+				},
+			}
+			cfg := ds.ClientConfig(ctx, noopSecretProvider)
+			So(cfg.Val(StorageKeyPathStyle).Bool(), ShouldBeTrue)
+		})
+
+		Convey("force_path_style=true should set bool true in config", func() {
+			ds := &DataSource{
+				StorageType: StorageType_S3,
+				StorageConfiguration: map[string]string{
+					StorageKeyForcePathStyle: "true",
+				},
+			}
+			cfg := ds.ClientConfig(ctx, noopSecretProvider)
+			So(cfg.Val(StorageKeyForcePathStyle).Bool(), ShouldBeTrue)
+		})
+
+		Convey("path_style=false should set bool false in config", func() {
+			ds := &DataSource{
+				StorageType: StorageType_S3,
+				StorageConfiguration: map[string]string{
+					StorageKeyPathStyle: "false",
+				},
+			}
+			cfg := ds.ClientConfig(ctx, noopSecretProvider)
+			So(cfg.Val(StorageKeyPathStyle).Bool(), ShouldBeFalse)
+		})
+
+		Convey("missing path_style key should return false", func() {
+			ds := &DataSource{
+				StorageType:          StorageType_S3,
+				StorageConfiguration: map[string]string{},
+			}
+			cfg := ds.ClientConfig(ctx, noopSecretProvider)
+			So(cfg.Val(StorageKeyPathStyle).Bool(), ShouldBeFalse)
+			So(cfg.Val(StorageKeyForcePathStyle).Bool(), ShouldBeFalse)
+		})
+
+		Convey("nil StorageConfiguration should not panic", func() {
+			ds := &DataSource{
+				StorageType:          StorageType_S3,
+				StorageConfiguration: nil,
+			}
+			So(func() { ds.ClientConfig(ctx, noopSecretProvider) }, ShouldNotPanic)
+		})
+	})
+}
+
+func TestMinioConfigClientConfigPathStyle(t *testing.T) {
+
+	ctx := context.Background()
+
+	Convey("Testing MinioConfig.ClientConfig path_style propagation", t, func() {
+
+		Convey("GatewayConfiguration path_style=true should set bool true", func() {
+			mc := &MinioConfig{
+				StorageType: StorageType_S3,
+				GatewayConfiguration: map[string]string{
+					StorageKeyPathStyle: "true",
+				},
+			}
+			cfg := mc.ClientConfig(ctx, noopSecretProvider, "", "")
+			So(cfg.Val(StorageKeyPathStyle).Bool(), ShouldBeTrue)
+		})
+
+		Convey("GatewayConfiguration force_path_style=true should set bool true", func() {
+			mc := &MinioConfig{
+				StorageType: StorageType_S3,
+				GatewayConfiguration: map[string]string{
+					StorageKeyForcePathStyle: "true",
+				},
+			}
+			cfg := mc.ClientConfig(ctx, noopSecretProvider, "", "")
+			So(cfg.Val(StorageKeyForcePathStyle).Bool(), ShouldBeTrue)
+		})
+
+		Convey("nil GatewayConfiguration should not panic and return false", func() {
+			mc := &MinioConfig{
+				StorageType:          StorageType_S3,
+				GatewayConfiguration: nil,
+			}
+			So(func() { mc.ClientConfig(ctx, noopSecretProvider, "", "") }, ShouldNotPanic)
+			cfg := mc.ClientConfig(ctx, noopSecretProvider, "", "")
+			So(cfg.Val(StorageKeyPathStyle).Bool(), ShouldBeFalse)
+			So(cfg.Val(StorageKeyForcePathStyle).Bool(), ShouldBeFalse)
+		})
+	})
+}

--- a/common/sync/endpoints/cells/transport/config.go
+++ b/common/sync/endpoints/cells/transport/config.go
@@ -76,4 +76,6 @@ type S3Config struct {
 	// IsDebug is a convenience legacy flag to add some logging to this S3 client.
 	// Should be cleaned as soon as we defined the logging strategy for this repo.
 	IsDebug bool `json:"isDebug"`
+	// ForcePathStyle forces the client to use path-style addressing for the buckets.
+	ForcePathStyle bool `json:"forcePathStyle"`
 }

--- a/common/sync/endpoints/cells/transport/mc/s3_client.go
+++ b/common/sync/endpoints/cells/transport/mc/s3_client.go
@@ -74,6 +74,9 @@ func (g *S3Client) GetObject(ctx context.Context, node *tree.Node, requestData *
 		Secure:    u.Scheme == "https",
 		Transport: t,
 	}
+	if g.s3config.ForcePathStyle {
+		opts.BucketLookup = minio.BucketLookupPath
+	}
 	mc, e := minio.NewCore(u.Host, opts)
 	if e != nil {
 		return nil, e
@@ -100,6 +103,9 @@ func (g *S3Client) PutObject(ctx context.Context, node *tree.Node, reader io.Rea
 		Creds:     credentials.NewStaticV4(jwt, g.s3config.ApiSecret, ""),
 		Secure:    u.Scheme == "https",
 		Transport: t,
+	}
+	if g.s3config.ForcePathStyle {
+		opts.BucketLookup = minio.BucketLookupPath
 	}
 	mc, e := minio.NewCore(u.Host, opts)
 	if e != nil {
@@ -149,6 +155,9 @@ func (g *S3Client) CopyObject(ctx context.Context, from *tree.Node, to *tree.Nod
 		Creds:     credentials.NewStaticV4(jwt, g.s3config.ApiSecret, ""),
 		Secure:    u.Scheme == "https",
 		Transport: t,
+	}
+	if g.s3config.ForcePathStyle {
+		opts.BucketLookup = minio.BucketLookupPath
 	}
 	mc, e := minio.NewCore(u.Host, opts)
 	if e != nil {

--- a/discovery/install/lib/datasource.go
+++ b/discovery/install/lib/datasource.go
@@ -203,6 +203,8 @@ func addDatasourceS3(c *install.InstallConfig) (*object.DataSource, error) {
 	}
 	if c.GetDsS3Custom() != "" {
 		conf.StorageConfiguration[object.StorageKeyCustomEndpoint] = c.GetCleanDsS3Custom()
+		conf.StorageConfiguration[object.StorageKeyPathStyle] = "true"
+		conf.StorageConfiguration[object.StorageKeyForcePathStyle] = "true"
 		if c.GetDsS3CustomRegion() != "" {
 			conf.StorageConfiguration[object.StorageKeyCustomRegion] = c.GetDsS3CustomRegion()
 		}

--- a/discovery/install/lib/datasource_pathstyle_test.go
+++ b/discovery/install/lib/datasource_pathstyle_test.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2019-2021. Abstrium SAS <team (at) pydio.com>
+ * This file is part of Pydio Cells.
+ *
+ * Pydio Cells is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio Cells is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+package lib
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/pydio/cells/v5/common/proto/install"
+	"github.com/pydio/cells/v5/common/proto/object"
+)
+
+func TestAddDatasourceS3PathStyle(t *testing.T) {
+
+	Convey("Testing addDatasourceS3 path_style settings", t, func() {
+
+		Convey("Custom endpoint should enable path_style and force_path_style", func() {
+			c := &install.InstallConfig{
+				DsS3ApiKey:    "mykey",
+				DsS3ApiSecret: "mysecret",
+				DsS3Custom:    "http://ceph.example.com:7480",
+			}
+			ds, err := addDatasourceS3(c)
+			So(err, ShouldBeNil)
+			So(ds, ShouldNotBeNil)
+			So(ds.StorageConfiguration[object.StorageKeyPathStyle], ShouldEqual, "true")
+			So(ds.StorageConfiguration[object.StorageKeyForcePathStyle], ShouldEqual, "true")
+		})
+
+		Convey("No custom endpoint should not set path_style or force_path_style", func() {
+			c := &install.InstallConfig{
+				DsS3ApiKey:    "mykey",
+				DsS3ApiSecret: "mysecret",
+				DsS3Custom:    "",
+			}
+			ds, err := addDatasourceS3(c)
+			So(err, ShouldBeNil)
+			So(ds, ShouldNotBeNil)
+			_, hasPs := ds.StorageConfiguration[object.StorageKeyPathStyle]
+			_, hasFps := ds.StorageConfiguration[object.StorageKeyForcePathStyle]
+			So(hasPs, ShouldBeFalse)
+			So(hasFps, ShouldBeFalse)
+		})
+
+		Convey("Custom endpoint with region should propagate region", func() {
+			c := &install.InstallConfig{
+				DsS3ApiKey:       "mykey",
+				DsS3ApiSecret:    "mysecret",
+				DsS3Custom:       "http://ceph.example.com:7480",
+				DsS3CustomRegion: "us-east-1",
+			}
+			ds, err := addDatasourceS3(c)
+			So(err, ShouldBeNil)
+			So(ds.StorageConfiguration[object.StorageKeyCustomRegion], ShouldEqual, "us-east-1")
+		})
+	})
+}

--- a/discovery/install/lib/installer.go
+++ b/discovery/install/lib/installer.go
@@ -200,6 +200,10 @@ func PerformCheck(ctx context.Context, name string, c *install.InstallConfig) (*
 		if isMinio {
 			cfData.Val("minioServer").Set(true)
 		}
+		if c.GetDsS3Custom() != "" {
+			cfData.Val(object.StorageKeyPathStyle).Set(true)
+			cfData.Val(object.StorageKeyForcePathStyle).Set(true)
+		}
 		mc, e := nodes.NewStorageClient(cfData)
 		if e != nil {
 			wrapError(e)
@@ -249,6 +253,10 @@ func PerformCheck(ctx context.Context, name string, c *install.InstallConfig) (*
 		cfData.Val("key").Set(c.GetDsS3ApiKey())
 		cfData.Val("secret").Set(c.GetDsS3ApiSecret())
 		cfData.Val("secure").Set(secure)
+		if c.GetDsS3Custom() != "" {
+			cfData.Val(object.StorageKeyPathStyle).Set(true)
+			cfData.Val(object.StorageKeyForcePathStyle).Set(true)
+		}
 		mc, e := nodes.NewStorageClient(cfData)
 		if e != nil {
 			wrapError(e)


### PR DESCRIPTION
## Problem

Ceph RGW (and other self-hosted S3-compatible backends) are effectively
incompatible with Cells when used as a custom S3 endpoint. Every datasource
sync operation and pre-flight connection check fails with `SignatureDoesNotMatch`.

The underlying issue is that Ceph RGW does not support virtual-host-style bucket
addressing (`http://bucket.endpoint/key`). It requires path-style URLs
(`http://endpoint/bucket/key`). When the URL format differs between the request
and the signed string, the signature never matches.

## Root Cause

`path_style` and `force_path_style` are correctly stored in
`DataSource.StorageConfiguration` when a custom S3 endpoint is configured.
However, `FactorizeMinioServers()` only copied `signatureVersion` into
`GatewayConfiguration`, silently dropping these values. They never reached
`MinioConfig.ClientConfig()` and therefore never reached the minio-go
`Options.BucketLookup` field — so the client always fell back to virtual-host
style, breaking Ceph RGW entirely.

## Changes

**`common/proto/object/datasource.go`**
- Add `StorageKeyPathStyle` and `StorageKeyForcePathStyle` constants
- Propagate `path_style`/`force_path_style` through `DataSource.ClientConfig()`
  and `MinioConfig.ClientConfig()`

**`common/config/datasources.go`**
- In all 3 S3 cases of `FactorizeMinioServers()`, propagate `path_style` and
  `force_path_style` into `GatewayConfiguration` alongside `signatureVersion`

**`common/nodes/objects/mc/client.go`**
- In `New()`, set `options.BucketLookup = minio.BucketLookupPath` when
  `path_style` or `force_path_style` is set

**`common/sync/endpoints/cells/transport/config.go`**
- Add `ForcePathStyle` field to S3 transport config struct

**`common/sync/endpoints/cells/transport/mc/s3_client.go`**
- Set `opts.BucketLookup = minio.BucketLookupPath` when `ForcePathStyle` is set,
  applied consistently across all minio client instantiations in the sync transport

**`discovery/install/lib/datasource.go`**
- Set `path_style` and `force_path_style` in `StorageConfiguration` when a
  custom S3 endpoint is configured during installation

**`discovery/install/lib/installer.go`**
- Apply `path_style`/`force_path_style` in the pre-flight S3 connection check
  during install, so the installer validates connectivity correctly against
  Ceph RGW from the start

## Testing

Verified with Ceph RGW as the S3 backend — all datasource sync operations
succeed with no `SignatureDoesNotMatch` errors after this fix.