### PR TITLE
feat(broker): Implement file system pubsub broker

### DIFF
--- a/common/broker/fsqueue/adapter.go
+++ b/common/broker/fsqueue/adapter.go
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2024. Abstrium SAS <team (at) pydio.com>
+ * This file is part of Pydio Cells.
+ *
+ * Pydio Cells is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio Cells is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+// Package filepubsub provides an AsyncQueue adapter that wraps the gocloud pubsub
+// file driver, enabling sync endpoints to use filesystem-backed pubsub queues.
+//
+// # URLs
+//
+// The queue registers the "fpub" scheme. The URL format is:
+//
+//	fpub:///path/to/spool?name=streamname&ackdeadline=1m
+//
+// Query parameters:
+//   - name: Required stream name (used for directory naming)
+//   - ackdeadline: Optional ack deadline (defaults to 1m)
+//
+// Example:
+//
+//	fpub:///shared/broker?name=syncro
+package filepubsub
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"gocloud.dev/pubsub"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/pydio/cells/v5/common/broker"
+	"github.com/pydio/cells/v5/common/telemetry/log"
+)
+
+var (
+	errMissingStreamName = errors.New("fpub: please provide a stream name via ?name=")
+	errQueueClosed       = errors.New("fpub: queue is closed")
+)
+
+func init() {
+	broker.RegisterAsyncQueue("fpub", &fpubQueue{})
+}
+
+// fpubQueue implements broker.AsyncQueue using the filepubsub gocloud driver.
+type fpubQueue struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	topic    *pubsub.Topic
+	sub      *pubsub.Subscription
+	basePath string
+	name     string
+
+	closeMu  sync.Mutex
+	closed   bool
+	closeErr error
+}
+
+// OpenURL implements broker.AsyncQueueOpener.
+func (f *fpubQueue) OpenURL(ctx context.Context, u *url.URL) (broker.AsyncQueue, error) {
+	streamName := u.Query().Get("name")
+	if streamName == "" {
+		return nil, errMissingStreamName
+	}
+
+	// Parse ack deadline
+	ackDeadline := time.Minute
+	if ad := u.Query().Get("ackdeadline"); ad != "" {
+		if d, err := time.ParseDuration(ad); err == nil {
+			ackDeadline = d
+		}
+	}
+
+	// Build base path: /path/from/url/fpub-streamname
+	basePath := filepath.Join(u.Path, "fpub-"+streamName)
+
+	// Create topic
+	topic, err := NewTopic(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create subscription
+	sub, err := NewSubscription(topic, ackDeadline)
+	if err != nil {
+		_ = topic.Shutdown(ctx)
+		return nil, err
+	}
+
+	qCtx, cancel := context.WithCancel(ctx)
+	return &fpubQueue{
+		ctx:      qCtx,
+		cancel:   cancel,
+		topic:    topic,
+		sub:      sub,
+		basePath: basePath,
+		name:     streamName,
+	}, nil
+}
+
+// Push implements broker.AsyncQueue.Push.
+// Encodes the protobuf message with context and sends via pubsub.Topic.
+func (f *fpubQueue) Push(ctx context.Context, msg proto.Message) error {
+	f.closeMu.Lock()
+	if f.closed {
+		f.closeMu.Unlock()
+		return errQueueClosed
+	}
+	f.closeMu.Unlock()
+
+	body := broker.EncodeProtoWithContext(ctx, msg)
+	return f.topic.Send(ctx, &pubsub.Message{
+		Body: body,
+	})
+}
+
+// PushRaw implements broker.AsyncQueue.PushRaw.
+// Sends a pre-encoded broker.Message.
+func (f *fpubQueue) PushRaw(ctx context.Context, message broker.Message) error {
+	f.closeMu.Lock()
+	if f.closed {
+		f.closeMu.Unlock()
+		return errQueueClosed
+	}
+	f.closeMu.Unlock()
+
+	body := broker.EncodeBrokerMessage(message)
+	return f.topic.Send(ctx, &pubsub.Message{
+		Body: body,
+	})
+}
+
+// Consume implements broker.AsyncQueue.Consume.
+// Starts a goroutine that receives messages from the subscription
+// and invokes the callback with decoded broker.Messages.
+func (f *fpubQueue) Consume(callback func(context.Context, ...broker.Message)) error {
+	go func() {
+		for {
+			select {
+			case <-f.ctx.Done():
+				log.Logger(f.ctx).Debug("[fpubQueue] Consumer stopping: context done", zap.String("name", f.name))
+				return
+			default:
+			}
+
+			msg, err := f.sub.Receive(f.ctx)
+			if err != nil {
+				// Check if we're closing
+				f.closeMu.Lock()
+				closing := f.closed
+				f.closeMu.Unlock()
+				if closing {
+					log.Logger(f.ctx).Debug("[fpubQueue] Consumer stopping: queue closed", zap.String("name", f.name))
+					return
+				}
+
+				// Context canceled
+				if f.ctx.Err() != nil {
+					log.Logger(f.ctx).Debug("[fpubQueue] Consumer stopping: context error", zap.String("name", f.name), zap.Error(f.ctx.Err()))
+					return
+				}
+
+				log.Logger(f.ctx).Error("[fpubQueue] Error receiving message", zap.String("name", f.name), zap.Error(err))
+				// Brief pause before retry
+				select {
+				case <-time.After(100 * time.Millisecond):
+				case <-f.ctx.Done():
+					return
+				}
+				continue
+			}
+
+			// Decode the broker message
+			brokerMsg, err := broker.DecodeToBrokerMessage(msg.Body)
+			if err != nil {
+				log.Logger(f.ctx).Error("[fpubQueue] Failed to decode message", zap.String("name", f.name), zap.Error(err))
+				msg.Ack()
+				continue
+			}
+
+			// Invoke callback
+			callback(f.ctx, brokerMsg)
+
+			// Acknowledge after callback completes
+			msg.Ack()
+		}
+	}()
+	return nil
+}
+
+// Close implements broker.AsyncQueue.Close.
+// Shuts down both subscription and topic.
+func (f *fpubQueue) Close(ctx context.Context) error {
+	f.closeMu.Lock()
+	defer f.closeMu.Unlock()
+
+	if f.closed {
+		return f.closeErr
+	}
+	f.closed = true
+
+	// Cancel consumer context
+	if f.cancel != nil {
+		f.cancel()
+	}
+
+	var errs []error
+
+	// Shutdown subscription first
+	if f.sub != nil {
+		if err := f.sub.Shutdown(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// Then shutdown topic
+	if f.topic != nil {
+		if err := f.topic.Shutdown(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		f.closeErr = errs[0]
+	}
+	return f.closeErr
+}

--- a/common/broker/fsqueue/adapter.go
+++ b/common/broker/fsqueue/adapter.go
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2024. Abstrium SAS <team (at) pydio.com>
+ * This file is part of Pydio Cells.
+ *
+ * Pydio Cells is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio Cells is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+// Package filepubsub provides an AsyncQueue adapter that wraps the gocloud pubsub
+// file driver, enabling sync endpoints to use filesystem-backed pubsub queues.
+//
+// # URLs
+//
+// The queue registers the "fpub" scheme. The URL format is:
+//
+//	fpub:///path/to/spool?name=streamname&ackdeadline=1m
+//
+// Query parameters:
+//   - name: Required stream name (used for directory naming)
+//   - ackdeadline: Optional ack deadline (defaults to 1m)
+//   - sendbatchsize: Optional send batch size for publisher (defaults to 10)
+//   - recvbatchsize: Optional receive batch size for subscriber (defaults to 1)
+//
+// Example:
+//
+//	fpub:///shared/broker?name=syncro
+package filepubsub
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"gocloud.dev/pubsub"
+	"gocloud.dev/pubsub/batcher"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/pydio/cells/v5/common/broker"
+	"github.com/pydio/cells/v5/common/telemetry/log"
+)
+
+var (
+	errMissingStreamName = errors.New("fpub: please provide a stream name via ?name=")
+	errQueueClosed       = errors.New("fpub: queue is closed")
+)
+
+func init() {
+	broker.RegisterAsyncQueue("fpub", &fpubQueue{})
+}
+
+// fpubQueue implements broker.AsyncQueue using the filepubsub gocloud driver.
+type fpubQueue struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	topic    *pubsub.Topic
+	sub      *pubsub.Subscription
+	basePath string
+	name     string
+
+	closeMu  sync.Mutex
+	closed   bool
+	closeErr error
+}
+
+// OpenURL implements broker.AsyncQueueOpener.
+func (f *fpubQueue) OpenURL(ctx context.Context, u *url.URL) (broker.AsyncQueue, error) {
+	streamName := u.Query().Get("name")
+	if streamName == "" {
+		return nil, errMissingStreamName
+	}
+
+	// Parse ack deadline
+	ackDeadline := time.Minute
+	if ad := u.Query().Get("ackdeadline"); ad != "" {
+		if d, err := time.ParseDuration(ad); err == nil {
+			ackDeadline = d
+		}
+	}
+
+	sendBatchSize := 10 //gocloud default
+	if sb := u.Query().Get("sendbatchsize"); sb != "" {
+		if n, err := strconv.Atoi(sb); err == nil && n > 0 {
+			sendBatchSize = n
+		}
+	}
+
+	recvBatchSize := 1 // maintain strict ordering
+	if rb := u.Query().Get("recvbatchsize"); rb != "" {
+		if n, err := strconv.Atoi(rb); err == nil && n > 0 {
+			recvBatchSize = n
+		}
+	}
+
+	// Build base path: /path/from/url/fpub-streamname
+	basePath := filepath.Join(u.Path, "fpub-"+streamName)
+	topicOptions := &TopicOptions{
+		BatcherOptions: batcher.Options{
+			MaxBatchSize: sendBatchSize,
+		},
+	}
+
+	// Create topic
+	topic, err := NewTopicWithOptions(basePath, topicOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	subOpts := &SubscriptionOptions{
+		ReceiveBatcherOptions: batcher.Options{
+			MaxBatchSize: recvBatchSize,
+			MaxHandlers:  1, // Keep strict ordering
+		},
+	}
+
+	// Create subscription
+	sub, err := NewSubscriptionWithOptions(topic, ackDeadline, subOpts)
+	if err != nil {
+		_ = topic.Shutdown(ctx)
+		return nil, err
+	}
+
+	qCtx, cancel := context.WithCancel(ctx)
+	return &fpubQueue{
+		ctx:      qCtx,
+		cancel:   cancel,
+		topic:    topic,
+		sub:      sub,
+		basePath: basePath,
+		name:     streamName,
+	}, nil
+}
+
+// Push implements broker.AsyncQueue.Push.
+// Encodes the protobuf message with context and sends via pubsub.Topic.
+func (f *fpubQueue) Push(ctx context.Context, msg proto.Message) error {
+	f.closeMu.Lock()
+	if f.closed {
+		f.closeMu.Unlock()
+		return errQueueClosed
+	}
+	f.closeMu.Unlock()
+
+	body := broker.EncodeProtoWithContext(ctx, msg)
+	return f.topic.Send(ctx, &pubsub.Message{
+		Body: body,
+	})
+}
+
+// PushRaw implements broker.AsyncQueue.PushRaw.
+// Sends a pre-encoded broker.Message.
+func (f *fpubQueue) PushRaw(ctx context.Context, message broker.Message) error {
+	f.closeMu.Lock()
+	if f.closed {
+		f.closeMu.Unlock()
+		return errQueueClosed
+	}
+	f.closeMu.Unlock()
+
+	body := broker.EncodeBrokerMessage(message)
+	return f.topic.Send(ctx, &pubsub.Message{
+		Body: body,
+	})
+}
+
+// Consume implements broker.AsyncQueue.Consume.
+// Starts a goroutine that receives messages from the subscription
+// and invokes the callback with decoded broker.Messages.
+func (f *fpubQueue) Consume(callback func(context.Context, ...broker.Message)) error {
+	go func() {
+		for {
+			select {
+			case <-f.ctx.Done():
+				log.Logger(f.ctx).Debug("[fpubQueue] Consumer stopping: context done", zap.String("name", f.name))
+				return
+			default:
+			}
+
+			msg, err := f.sub.Receive(f.ctx)
+			if err != nil {
+				// Check if we're closing
+				f.closeMu.Lock()
+				closing := f.closed
+				f.closeMu.Unlock()
+				if closing {
+					log.Logger(f.ctx).Debug("[fpubQueue] Consumer stopping: queue closed", zap.String("name", f.name))
+					return
+				}
+
+				// Context canceled
+				if f.ctx.Err() != nil {
+					log.Logger(f.ctx).Debug("[fpubQueue] Consumer stopping: context error", zap.String("name", f.name), zap.Error(f.ctx.Err()))
+					return
+				}
+
+				log.Logger(f.ctx).Error("[fpubQueue] Error receiving message", zap.String("name", f.name), zap.Error(err))
+				// Brief pause before retry
+				select {
+				case <-time.After(100 * time.Millisecond):
+				case <-f.ctx.Done():
+					return
+				}
+				continue
+			}
+
+			// Decode the broker message
+			brokerMsg, err := broker.DecodeToBrokerMessage(msg.Body)
+			if err != nil {
+				log.Logger(f.ctx).Error("[fpubQueue] Failed to decode message", zap.String("name", f.name), zap.Error(err))
+				msg.Ack()
+				continue
+			}
+
+			// Invoke callback
+			callback(f.ctx, brokerMsg)
+
+			// Acknowledge after callback completes
+			msg.Ack()
+		}
+	}()
+	return nil
+}
+
+// Close implements broker.AsyncQueue.Close.
+// Shuts down both subscription and topic.
+func (f *fpubQueue) Close(ctx context.Context) error {
+	f.closeMu.Lock()
+	defer f.closeMu.Unlock()
+
+	if f.closed {
+		return f.closeErr
+	}
+	f.closed = true
+
+	// Cancel consumer context
+	if f.cancel != nil {
+		f.cancel()
+	}
+
+	var errs []error
+
+	// Shutdown subscription first
+	if f.sub != nil {
+		if err := f.sub.Shutdown(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// Then shutdown topic
+	if f.topic != nil {
+		if err := f.topic.Shutdown(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		f.closeErr = errs[0]
+	}
+	return f.closeErr
+}

--- a/common/broker/fsqueue/adapter.go
+++ b/common/broker/fsqueue/adapter.go
@@ -30,6 +30,8 @@
 // Query parameters:
 //   - name: Required stream name (used for directory naming)
 //   - ackdeadline: Optional ack deadline (defaults to 1m)
+//   - sendbatchsize: Optional send batch size for publisher (defaults to 10)
+//   - recvbatchsize: Optional receive batch size for subscriber (defaults to 1)
 //
 // Example:
 //
@@ -41,11 +43,13 @@ import (
 	"errors"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
 	"go.uber.org/zap"
 	"gocloud.dev/pubsub"
+	"gocloud.dev/pubsub/batcher"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/pydio/cells/v5/common/broker"
@@ -90,17 +94,43 @@ func (f *fpubQueue) OpenURL(ctx context.Context, u *url.URL) (broker.AsyncQueue,
 		}
 	}
 
+	sendBatchSize := 10 //gocloud default
+	if sb := u.Query().Get("sendbatchsize"); sb != "" {
+		if n, err := strconv.Atoi(sb); err == nil && n > 0 {
+			sendBatchSize = n
+		}
+	}
+
+	recvBatchSize := 1 // maintain strict ordering
+	if rb := u.Query().Get("recvbatchsize"); rb != "" {
+		if n, err := strconv.Atoi(rb); err == nil && n > 0 {
+			recvBatchSize = n
+		}
+	}
+
 	// Build base path: /path/from/url/fpub-streamname
 	basePath := filepath.Join(u.Path, "fpub-"+streamName)
+	topicOptions := &TopicOptions{
+		BatcherOptions: batcher.Options{
+			MaxBatchSize: sendBatchSize,
+		},
+	}
 
 	// Create topic
-	topic, err := NewTopic(basePath)
+	topic, err := NewTopicWithOptions(basePath, topicOptions)
 	if err != nil {
 		return nil, err
 	}
 
+	subOpts := &SubscriptionOptions{
+		ReceiveBatcherOptions: batcher.Options{
+			MaxBatchSize: recvBatchSize,
+			MaxHandlers:  1, // Keep strict ordering
+		},
+	}
+
 	// Create subscription
-	sub, err := NewSubscription(topic, ackDeadline)
+	sub, err := NewSubscriptionWithOptions(topic, ackDeadline, subOpts)
 	if err != nil {
 		_ = topic.Shutdown(ctx)
 		return nil, err

--- a/common/broker/fsqueue/fspubsub.go
+++ b/common/broker/fsqueue/fspubsub.go
@@ -433,7 +433,6 @@ func (s *subscription) startWatcher() error {
 				notify.Stop(s.notifyChan)
 				return
 			case ev := <-s.notifyChan:
-				// Only care about .pb files
 				if strings.HasSuffix(ev.Path(), ".pb") {
 					s.notifyNewMessages()
 				}

--- a/common/broker/fsqueue/fspubsub.go
+++ b/common/broker/fsqueue/fspubsub.go
@@ -1,0 +1,746 @@
+/*
+ * Copyright (c) 2024. Abstrium SAS <team (at) pydio.com>
+ * This file is part of Pydio Cells.
+ *
+ * Pydio Cells is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio Cells is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+// Package filepubsub provides a filesystem-backed pubsub implementation using gocloud.dev/pubsub.
+// It writes messages as .pb files to a directory and uses filesystem notifications (notify)
+// for efficient subscription instead of polling.
+//
+// Use NewTopic to construct a *pubsub.Topic, and NewSubscription to construct a *pubsub.Subscription.
+//
+// filepubsub provides at-least-once delivery semantics. Messages that are not acknowledged
+// within the ack deadline will be redelivered.
+//
+// # URLs
+//
+// For pubsub.OpenTopic and pubsub.OpenSubscription, filepubsub registers
+// for the scheme "file".
+// The host+path is used as the directory path for message storage.
+// Query parameters:
+//   - ackdeadline: The ack deadline for OpenSubscription, in time.ParseDuration formats.
+//     Defaults to 1m.
+//
+// Examples:
+//   - file:///shared/broker/mytopic
+//   - file:///var/spool/pubsub/events?ackdeadline=30s
+//
+// # As
+//
+// filepubsub does not support any types for As.
+package filepubsub
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rjeczalik/notify"
+	"gocloud.dev/gcerrors"
+	"gocloud.dev/pubsub"
+	"gocloud.dev/pubsub/batcher"
+	"gocloud.dev/pubsub/driver"
+)
+
+func init() {
+	o := new(URLOpener)
+	pubsub.DefaultURLMux().RegisterTopic(Scheme, o)
+	pubsub.DefaultURLMux().RegisterSubscription(Scheme, o)
+}
+
+// Scheme is the URL scheme filepubsub registers its URLOpeners under on pubsub.DefaultMux.
+const Scheme = "file"
+
+// Subdirectories for message states
+const (
+	pendingDir    = "pending"
+	processingDir = "processing"
+	tmpDir        = ".tmp"
+)
+
+// Sentinel errors for filepubsub package
+var (
+	ErrTopicNotExist      = errors.New("filepubsub: topic does not exist")
+	ErrTopicClosed        = errors.New("filepubsub: topic is closed")
+	ErrSubscriptionClosed = errors.New("filepubsub: subscription is closed")
+	ErrInvalidPath        = errors.New("filepubsub: path is required")
+	ErrInvalidParam       = errors.New("filepubsub: invalid query parameter")
+	ErrInvalidAckDeadline = errors.New("filepubsub: invalid ackdeadline")
+	ErrCreateDir          = errors.New("filepubsub: failed to create directory")
+	ErrWriteFile          = errors.New("filepubsub: failed to write file")
+	ErrMoveFile           = errors.New("filepubsub: failed to move file")
+)
+
+// recvBatcherOpts configures batching for receives.
+// Like NATS, we use MaxBatchSize=1 and MaxHandlers=1 for strict ordering.
+var recvBatcherOpts = &batcher.Options{
+	MaxBatchSize: 1,
+	MaxHandlers:  1,
+}
+
+// URLOpener opens filepubsub URLs like "file:///path/to/topic".
+//
+// The URL's host+path is used as the directory for message storage.
+//
+// Query parameters:
+//   - ackdeadline: The ack deadline for OpenSubscription, in time.ParseDuration formats.
+//     Defaults to 1m.
+type URLOpener struct {
+	mu     sync.Mutex
+	topics map[string]*pubsub.Topic
+}
+
+// OpenTopicURL opens a pubsub.Topic based on u.
+func (o *URLOpener) OpenTopicURL(ctx context.Context, u *url.URL) (*pubsub.Topic, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	for param := range u.Query() {
+		if param != "ackdeadline" {
+			return nil, fmt.Errorf("%w: %q in %v", ErrInvalidParam, param, u)
+		}
+	}
+	topicPath := path.Join(u.Host, u.Path)
+	if topicPath == "" {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidPath, u)
+	}
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.topics == nil {
+		o.topics = map[string]*pubsub.Topic{}
+	}
+	t := o.topics[topicPath]
+	if t == nil {
+		var err error
+		t, err = NewTopic(topicPath)
+		if err != nil {
+			return nil, err
+		}
+		o.topics[topicPath] = t
+	}
+	return t, nil
+}
+
+// OpenSubscriptionURL opens a pubsub.Subscription based on u.
+func (o *URLOpener) OpenSubscriptionURL(ctx context.Context, u *url.URL) (*pubsub.Subscription, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	ackDeadline := 1 * time.Minute
+	if s := q.Get("ackdeadline"); s != "" {
+		var err error
+		ackDeadline, err = time.ParseDuration(s)
+		if err != nil {
+			return nil, fmt.Errorf("%w %q: %v", ErrInvalidAckDeadline, s, err)
+		}
+		q.Del("ackdeadline")
+	}
+	for param := range q {
+		return nil, fmt.Errorf("%w: %q in %v", ErrInvalidParam, param, u)
+	}
+	topicPath := path.Join(u.Host, u.Path)
+	if topicPath == "" {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidPath, u)
+	}
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.topics == nil {
+		o.topics = map[string]*pubsub.Topic{}
+	}
+	t := o.topics[topicPath]
+	if t == nil {
+		// Create topic if it doesn't exist
+		var err error
+		t, err = NewTopic(topicPath)
+		if err != nil {
+			return nil, err
+		}
+		o.topics[topicPath] = t
+	}
+	return NewSubscription(t, ackDeadline)
+}
+
+// TopicOptions contains configuration options for topics.
+type TopicOptions struct {
+	// BatcherOptions adds constraints to the default batching done for sends.
+	BatcherOptions batcher.Options
+}
+
+type topic struct {
+	mu        sync.Mutex
+	basePath  string
+	subs      []*subscription
+	nextAckID int
+	closed    bool
+}
+
+// NewTopic creates a new filesystem-backed topic.
+func NewTopic(basePath string) (*pubsub.Topic, error) {
+	return NewTopicWithOptions(basePath, nil)
+}
+
+// NewTopicWithOptions is similar to NewTopic, but supports TopicOptions.
+func NewTopicWithOptions(basePath string, opts *TopicOptions) (*pubsub.Topic, error) {
+	if opts == nil {
+		opts = &TopicOptions{}
+	}
+
+	// Create directories
+	for _, dir := range []string{pendingDir, processingDir, tmpDir} {
+		dirPath := filepath.Join(basePath, dir)
+		if err := os.MkdirAll(dirPath, 0o755); err != nil {
+			return nil, fmt.Errorf("filepubsub: failed to create directory %s: %w", dirPath, err)
+		}
+	}
+
+	t := &topic{
+		basePath: basePath,
+	}
+	return pubsub.NewTopic(t, &opts.BatcherOptions), nil
+}
+
+// SendBatch implements driver.Topic.SendBatch.
+func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if t == nil {
+		return ErrTopicNotExist
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return ErrTopicClosed
+	}
+
+	tmpPath := filepath.Join(t.basePath, tmpDir)
+	pendPath := filepath.Join(t.basePath, pendingDir)
+
+	// Pre-allocate slices to reduce memory allocations
+	var filenames []string
+	filenames = make([]string, 0, len(ms))
+
+	for i, m := range ms {
+		m.AckID = t.nextAckID + i
+		m.LoggableID = fmt.Sprintf("msg #%d", m.AckID)
+		m.AsFunc = func(any) bool { return false }
+
+		if m.BeforeSend != nil {
+			if err := m.BeforeSend(func(any) bool { return false }); err != nil {
+				return err
+			}
+		}
+
+		// Encode message
+		payload, err := encodeMessage(m)
+		if err != nil {
+			return err
+		}
+
+		// Generate unique filename with timestamp for ordering
+		filename := fmt.Sprintf("%020d-%08d-%s.pb", time.Now().UnixNano(), m.AckID, uuid.New().String()[:8])
+		filenames = append(filenames, filename)
+
+		// Write atomically: tmp -> pending
+		tmpFile := filepath.Join(tmpPath, filename)
+		if err := os.WriteFile(tmpFile, payload, 0o644); err != nil {
+			return fmt.Errorf("filepubsub: failed to write temp file: %w", err)
+		}
+	}
+
+	// Move all files to pending directory in a single loop
+	for _, filename := range filenames {
+		tmpFile := filepath.Join(tmpPath, filename)
+		finalFile := filepath.Join(pendPath, filename)
+		if err := os.Rename(tmpFile, finalFile); err != nil {
+			_ = os.Remove(tmpFile)
+			return fmt.Errorf("filepubsub: failed to move file to pending: %w", err)
+		}
+	}
+
+	t.nextAckID += len(ms)
+
+	// Notify all subscriptions
+	for _, s := range t.subs {
+		s.notifyNewMessages()
+	}
+	return nil
+}
+
+// IsRetryable implements driver.Topic.IsRetryable.
+func (*topic) IsRetryable(error) bool { return false }
+
+// As implements driver.Topic.As.
+func (t *topic) As(i any) bool {
+	p, ok := i.(**topic)
+	if !ok {
+		return false
+	}
+	*p = t
+	return true
+}
+
+// ErrorAs implements driver.Topic.ErrorAs
+func (*topic) ErrorAs(error, any) bool {
+	return false
+}
+
+// ErrorCode implements driver.Topic.ErrorCode
+func (*topic) ErrorCode(err error) gcerrors.ErrorCode {
+	switch {
+	case errors.Is(err, ErrTopicNotExist), errors.Is(err, ErrTopicClosed), errors.Is(err, ErrSubscriptionClosed):
+		return gcerrors.NotFound
+	case errors.Is(err, ErrInvalidPath), errors.Is(err, ErrInvalidParam), errors.Is(err, ErrInvalidAckDeadline):
+		return gcerrors.InvalidArgument
+	case errors.Is(err, context.Canceled):
+		return gcerrors.Canceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return gcerrors.DeadlineExceeded
+	default:
+		return gcerrors.Unknown
+	}
+}
+
+// Close implements driver.Topic.Close.
+func (t *topic) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.closed = true
+	return nil
+}
+
+// SubscriptionOptions sets options for constructing a *pubsub.Subscription
+// backed by filepubsub.
+type SubscriptionOptions struct {
+	// ReceiveBatcherOptions adds constraints to the default batching done for receives.
+	ReceiveBatcherOptions batcher.Options
+	// AckBatcherOptions adds constraints to the default batching done for acks.
+	AckBatcherOptions batcher.Options
+}
+
+type subscription struct {
+	mu          sync.Mutex
+	topic       *topic
+	ackDeadline time.Duration
+	msgs        map[driver.AckID]*message // all unacknowledged messages
+	notifyChan  chan notify.EventInfo
+	newMsgChan  chan struct{} // signaled when new messages arrive
+	stopWatcher chan struct{}
+	watcherDone chan struct{}
+	closed      bool
+}
+
+type message struct {
+	msg        *driver.Message
+	filename   string
+	expiration time.Time
+}
+
+// NewSubscription creates a new subscription for the given topic.
+// It panics if the given topic did not come from filepubsub.
+func NewSubscription(pstopic *pubsub.Topic, ackDeadline time.Duration) (*pubsub.Subscription, error) {
+	return NewSubscriptionWithOptions(pstopic, ackDeadline, nil)
+}
+
+// NewSubscriptionWithOptions is similar to NewSubscription, but supports SubscriptionOptions.
+func NewSubscriptionWithOptions(pstopic *pubsub.Topic, ackDeadline time.Duration, opts *SubscriptionOptions) (*pubsub.Subscription, error) {
+	if opts == nil {
+		opts = &SubscriptionOptions{}
+	}
+	var t *topic
+	if !pstopic.As(&t) {
+		panic("filepubsub: NewSubscription passed a Topic not from filepubsub")
+	}
+
+	s, err := newSubscription(t, ackDeadline)
+	if err != nil {
+		return nil, err
+	}
+	return pubsub.NewSubscription(s, recvBatcherOpts, &opts.AckBatcherOptions), nil
+}
+
+func newSubscription(t *topic, ackDeadline time.Duration) (*subscription, error) {
+	s := &subscription{
+		topic:       t,
+		ackDeadline: ackDeadline,
+		msgs:        map[driver.AckID]*message{},
+		notifyChan:  make(chan notify.EventInfo, 100),
+		newMsgChan:  make(chan struct{}, 1),
+		stopWatcher: make(chan struct{}),
+		watcherDone: make(chan struct{}),
+	}
+
+	if t != nil {
+		t.mu.Lock()
+		t.subs = append(t.subs, s)
+		t.mu.Unlock()
+
+		// Recover any messages stuck in processing
+		if err := s.recoverProcessing(); err != nil {
+			return nil, err
+		}
+
+		// Start filesystem watcher
+		if err := s.startWatcher(); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+// startWatcher sets up filesystem notifications on the pending directory
+func (s *subscription) startWatcher() error {
+	pendPath := filepath.Join(s.topic.basePath, pendingDir)
+
+	// Watch for new files in pending directory
+	if err := notify.Watch(pendPath, s.notifyChan, notify.Create, notify.Rename); err != nil {
+		return fmt.Errorf("filepubsub: failed to watch directory: %w", err)
+	}
+
+	go func() {
+		defer close(s.watcherDone)
+		for {
+			select {
+			case <-s.stopWatcher:
+				notify.Stop(s.notifyChan)
+				return
+			case ev := <-s.notifyChan:
+				// Only care about .pb files
+				if strings.HasSuffix(ev.Path(), ".pb") {
+					s.notifyNewMessages()
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+// notifyNewMessages signals that new messages are available
+func (s *subscription) notifyNewMessages() {
+	select {
+	case s.newMsgChan <- struct{}{}:
+	default:
+		// Channel already has a signal
+	}
+}
+
+// recoverProcessing moves stuck messages from processing back to pending
+func (s *subscription) recoverProcessing() error {
+	procPath := filepath.Join(s.topic.basePath, processingDir)
+	pendPath := filepath.Join(s.topic.basePath, pendingDir)
+
+	entries, err := os.ReadDir(procPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	// Pre-allocate slice for filenames to reduce memory allocations
+	filenames := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".pb") {
+			continue
+		}
+		filenames = append(filenames, entry.Name())
+	}
+
+	// Move all files in a single loop
+	for _, filename := range filenames {
+		src := filepath.Join(procPath, filename)
+		dst := filepath.Join(pendPath, filename)
+		_ = os.Rename(src, dst)
+	}
+	return nil
+}
+
+// receiveNoWait collects messages available for delivery
+func (s *subscription) receiveNoWait(now time.Time, max int) ([]*driver.Message, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// First, check for expired messages that need redelivery
+	for _, m := range s.msgs {
+		if now.After(m.expiration) {
+			// Reset expiration for redelivery
+			m.expiration = now.Add(s.ackDeadline)
+			return []*driver.Message{m.msg}, nil
+		}
+	}
+
+	// Read new messages from pending directory
+	pendPath := filepath.Join(s.topic.basePath, pendingDir)
+	procPath := filepath.Join(s.topic.basePath, processingDir)
+
+	entries, err := os.ReadDir(pendPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Pre-allocate slice to reduce memory allocations
+	var msgs []*driver.Message
+	msgs = make([]*driver.Message, 0, max)
+
+	// Sort by filename (timestamp-based ordering)
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".pb") {
+			continue
+		}
+
+		filename := entry.Name()
+		src := filepath.Join(pendPath, filename)
+		dst := filepath.Join(procPath, filename)
+
+		// Try to claim the message via atomic rename
+		if err := os.Rename(src, dst); err != nil {
+			// Another consumer claimed it
+			continue
+		}
+
+		// Read the message
+		data, err := os.ReadFile(dst)
+		if err != nil {
+			// Move back to pending for retry
+			_ = os.Rename(dst, src)
+			continue
+		}
+
+		dm, err := decodeMessage(data)
+		if err != nil {
+			// Corrupt message, remove it
+			_ = os.Remove(dst)
+			continue
+		}
+
+		// Track the message for ack/nack
+		m := &message{
+			msg:        dm,
+			filename:   filename,
+			expiration: now.Add(s.ackDeadline),
+		}
+		s.msgs[dm.AckID] = m
+
+		msgs = append(msgs, dm)
+		if len(msgs) >= max {
+			break
+		}
+	}
+
+	return msgs, nil
+}
+
+// ReceiveBatch implements driver.ReceiveBatch.
+func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*driver.Message, error) {
+	if s == nil || s.topic == nil {
+		return nil, ErrTopicNotExist
+	}
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, ErrSubscriptionClosed
+	}
+	s.mu.Unlock()
+
+	// Check for messages
+	msgs, err := s.receiveNoWait(time.Now(), maxMessages)
+	if err != nil {
+		return nil, err
+	}
+	if len(msgs) > 0 {
+		return msgs, nil
+	}
+
+	// Wait for new messages or timeout
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.newMsgChan:
+		// New messages available, try again
+		return s.receiveNoWait(time.Now(), maxMessages)
+	case <-time.After(100 * time.Millisecond):
+		// Periodic check for redelivery
+		return nil, nil
+	}
+}
+
+// SendAcks implements driver.SendAcks.
+func (s *subscription) SendAcks(ctx context.Context, ackIDs []driver.AckID) error {
+	if s.topic == nil {
+		return ErrTopicNotExist
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	procPath := filepath.Join(s.topic.basePath, processingDir)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Pre-allocate slice to reduce memory allocations
+	toDelete := make([]driver.AckID, 0, len(ackIDs))
+	for _, id := range ackIDs {
+		if m, ok := s.msgs[id]; ok {
+			// Delete the file (acknowledge)
+			filePath := filepath.Join(procPath, m.filename)
+			_ = os.Remove(filePath)
+			toDelete = append(toDelete, id)
+		}
+	}
+
+	// Delete all messages at once to reduce map operations
+	for _, id := range toDelete {
+		delete(s.msgs, id)
+	}
+	return nil
+}
+
+// CanNack implements driver.CanNack.
+func (s *subscription) CanNack() bool { return true }
+
+// SendNacks implements driver.SendNacks.
+func (s *subscription) SendNacks(ctx context.Context, ackIDs []driver.AckID) error {
+	if s.topic == nil {
+		return ErrTopicNotExist
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	procPath := filepath.Join(s.topic.basePath, processingDir)
+	pendPath := filepath.Join(s.topic.basePath, pendingDir)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Pre-allocate slice to reduce memory allocations
+	toProcess := make([]driver.AckID, 0, len(ackIDs))
+	for _, id := range ackIDs {
+		if m, ok := s.msgs[id]; ok {
+			// Move file back to pending for redelivery
+			src := filepath.Join(procPath, m.filename)
+			dst := filepath.Join(pendPath, m.filename)
+			_ = os.Rename(src, dst)
+			toProcess = append(toProcess, id)
+		}
+	}
+
+	// Delete all messages at once to reduce map operations
+	for _, id := range toProcess {
+		delete(s.msgs, id)
+	}
+	return nil
+}
+
+// IsRetryable implements driver.Subscription.IsRetryable.
+func (*subscription) IsRetryable(error) bool { return false }
+
+// As implements driver.Subscription.As.
+func (s *subscription) As(i any) bool { return false }
+
+// ErrorAs implements driver.Subscription.ErrorAs
+func (*subscription) ErrorAs(error, any) bool {
+	return false
+}
+
+// Close implements driver.Subscription.Close.
+func (s *subscription) Close() error {
+	s.mu.Lock()
+	s.closed = true
+	s.mu.Unlock()
+
+	// Stop the watcher
+	close(s.stopWatcher)
+	<-s.watcherDone
+
+	return nil
+}
+
+// ErrorCode implements driver.Subscription.ErrorCode.
+func (*subscription) ErrorCode(err error) gcerrors.ErrorCode {
+	switch {
+	case errors.Is(err, ErrTopicNotExist), errors.Is(err, ErrTopicClosed), errors.Is(err, ErrSubscriptionClosed):
+		return gcerrors.NotFound
+	case errors.Is(err, ErrInvalidPath), errors.Is(err, ErrInvalidParam), errors.Is(err, ErrInvalidAckDeadline):
+		return gcerrors.InvalidArgument
+	case errors.Is(err, context.Canceled):
+		return gcerrors.Canceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return gcerrors.DeadlineExceeded
+	default:
+		return gcerrors.Unknown
+	}
+}
+
+// wireMessage is a serializable representation of driver.Message
+type wireMessage struct {
+	Metadata map[string]string
+	Body     []byte
+	AckID    int // concrete type instead of driver.AckID (any)
+}
+
+// encodeMessage encodes a driver.Message to bytes using gob.
+func encodeMessage(dm *driver.Message) ([]byte, error) {
+	wm := wireMessage{
+		Metadata: dm.Metadata,
+		Body:     dm.Body,
+		AckID:    dm.AckID.(int), // we always set AckID as int in SendBatch
+	}
+	var buf bytes.Buffer
+	// Pre-allocate buffer to reduce memory allocations
+	buf.Grow(1024) // Start with 1KB buffer
+	if err := gob.NewEncoder(&buf).Encode(wm); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// decodeMessage decodes bytes to a driver.Message using gob.
+func decodeMessage(data []byte) (*driver.Message, error) {
+	var wm wireMessage
+	if err := gob.NewDecoder(bytes.NewBuffer(data)).Decode(&wm); err != nil {
+		return nil, err
+	}
+	return &driver.Message{
+		Metadata: wm.Metadata,
+		Body:     wm.Body,
+		AckID:    wm.AckID,
+		AsFunc:   func(any) bool { return false },
+	}, nil
+}

--- a/common/broker/fsqueue/fspubsub.go
+++ b/common/broker/fsqueue/fspubsub.go
@@ -1,0 +1,744 @@
+/*
+ * Copyright (c) 2024. Abstrium SAS <team (at) pydio.com>
+ * This file is part of Pydio Cells.
+ *
+ * Pydio Cells is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio Cells is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+// Package filepubsub provides a filesystem-backed pubsub implementation using gocloud.dev/pubsub.
+// It writes messages as .pb files to a directory and uses filesystem notifications (notify)
+// for efficient subscription instead of polling.
+//
+// Use NewTopic to construct a *pubsub.Topic, and NewSubscription to construct a *pubsub.Subscription.
+//
+// filepubsub provides at-least-once delivery semantics. Messages that are not acknowledged
+// within the ack deadline will be redelivered.
+//
+// # URLs
+//
+// For pubsub.OpenTopic and pubsub.OpenSubscription, filepubsub registers
+// for the scheme "file".
+// The host+path is used as the directory path for message storage.
+// Query parameters:
+//   - ackdeadline: The ack deadline for OpenSubscription, in time.ParseDuration formats.
+//     Defaults to 1m.
+//
+// Examples:
+//   - file:///shared/broker/mytopic
+//   - file:///var/spool/pubsub/events?ackdeadline=30s
+//
+// # As
+//
+// filepubsub does not support any types for As.
+package filepubsub
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rjeczalik/notify"
+	"gocloud.dev/gcerrors"
+	"gocloud.dev/pubsub"
+	"gocloud.dev/pubsub/batcher"
+	"gocloud.dev/pubsub/driver"
+)
+
+func init() {
+	o := new(URLOpener)
+	pubsub.DefaultURLMux().RegisterTopic(Scheme, o)
+	pubsub.DefaultURLMux().RegisterSubscription(Scheme, o)
+}
+
+// Scheme is the URL scheme filepubsub registers its URLOpeners under on pubsub.DefaultMux.
+const Scheme = "file"
+
+// Subdirectories for message states
+const (
+	pendingDir    = "pending"
+	processingDir = "processing"
+	tmpDir        = ".tmp"
+)
+
+// Sentinel errors for filepubsub package
+var (
+	ErrTopicNotExist      = errors.New("filepubsub: topic does not exist")
+	ErrTopicClosed        = errors.New("filepubsub: topic is closed")
+	ErrSubscriptionClosed = errors.New("filepubsub: subscription is closed")
+	ErrInvalidPath        = errors.New("filepubsub: path is required")
+	ErrInvalidParam       = errors.New("filepubsub: invalid query parameter")
+	ErrInvalidAckDeadline = errors.New("filepubsub: invalid ackdeadline")
+	ErrCreateDir          = errors.New("filepubsub: failed to create directory")
+	ErrWriteFile          = errors.New("filepubsub: failed to write file")
+	ErrMoveFile           = errors.New("filepubsub: failed to move file")
+)
+
+// recvBatcherOpts configures batching for receives.
+// Like NATS, we use MaxBatchSize=1 and MaxHandlers=1 for strict ordering.
+var recvBatcherOpts = &batcher.Options{
+	MaxBatchSize: 1,
+	MaxHandlers:  1,
+}
+
+// URLOpener opens filepubsub URLs like "file:///path/to/topic".
+//
+// The URL's host+path is used as the directory for message storage.
+//
+// Query parameters:
+//   - ackdeadline: The ack deadline for OpenSubscription, in time.ParseDuration formats.
+//     Defaults to 1m.
+type URLOpener struct {
+	mu     sync.Mutex
+	topics map[string]*pubsub.Topic
+}
+
+// OpenTopicURL opens a pubsub.Topic based on u.
+func (o *URLOpener) OpenTopicURL(ctx context.Context, u *url.URL) (*pubsub.Topic, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	for param := range u.Query() {
+		if param != "ackdeadline" {
+			return nil, fmt.Errorf("%w: %q in %v", ErrInvalidParam, param, u)
+		}
+	}
+	topicPath := path.Join(u.Host, u.Path)
+	if topicPath == "" {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidPath, u)
+	}
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.topics == nil {
+		o.topics = map[string]*pubsub.Topic{}
+	}
+	t := o.topics[topicPath]
+	if t == nil {
+		var err error
+		t, err = NewTopic(topicPath)
+		if err != nil {
+			return nil, err
+		}
+		o.topics[topicPath] = t
+	}
+	return t, nil
+}
+
+// OpenSubscriptionURL opens a pubsub.Subscription based on u.
+func (o *URLOpener) OpenSubscriptionURL(ctx context.Context, u *url.URL) (*pubsub.Subscription, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	ackDeadline := 1 * time.Minute
+	if s := q.Get("ackdeadline"); s != "" {
+		var err error
+		ackDeadline, err = time.ParseDuration(s)
+		if err != nil {
+			return nil, fmt.Errorf("%w %q: %v", ErrInvalidAckDeadline, s, err)
+		}
+		q.Del("ackdeadline")
+	}
+	for param := range q {
+		return nil, fmt.Errorf("%w: %q in %v", ErrInvalidParam, param, u)
+	}
+	topicPath := path.Join(u.Host, u.Path)
+	if topicPath == "" {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidPath, u)
+	}
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.topics == nil {
+		o.topics = map[string]*pubsub.Topic{}
+	}
+	t := o.topics[topicPath]
+	if t == nil {
+		// Create topic if it doesn't exist
+		var err error
+		t, err = NewTopic(topicPath)
+		if err != nil {
+			return nil, err
+		}
+		o.topics[topicPath] = t
+	}
+	return NewSubscription(t, ackDeadline)
+}
+
+// TopicOptions contains configuration options for topics.
+type TopicOptions struct {
+	// BatcherOptions adds constraints to the default batching done for sends.
+	BatcherOptions batcher.Options
+}
+
+type topic struct {
+	mu        sync.Mutex
+	basePath  string
+	subs      []*subscription
+	nextAckID int
+	closed    bool
+}
+
+// NewTopic creates a new filesystem-backed topic.
+func NewTopic(basePath string) (*pubsub.Topic, error) {
+	return NewTopicWithOptions(basePath, nil)
+}
+
+// NewTopicWithOptions is similar to NewTopic, but supports TopicOptions.
+func NewTopicWithOptions(basePath string, opts *TopicOptions) (*pubsub.Topic, error) {
+	if opts == nil {
+		opts = &TopicOptions{}
+	}
+
+	// Create directories
+	for _, dir := range []string{pendingDir, processingDir, tmpDir} {
+		dirPath := filepath.Join(basePath, dir)
+		if err := os.MkdirAll(dirPath, 0o755); err != nil {
+			return nil, fmt.Errorf("filepubsub: failed to create directory %s: %w", dirPath, err)
+		}
+	}
+
+	t := &topic{
+		basePath: basePath,
+	}
+	return pubsub.NewTopic(t, &opts.BatcherOptions), nil
+}
+
+// SendBatch implements driver.Topic.SendBatch.
+func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if t == nil {
+		return ErrTopicNotExist
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return ErrTopicClosed
+	}
+
+	tmpPath := filepath.Join(t.basePath, tmpDir)
+	pendPath := filepath.Join(t.basePath, pendingDir)
+
+	// Pre-allocate slices to reduce memory allocations
+	var filenames []string
+	filenames = make([]string, 0, len(ms))
+
+	for i, m := range ms {
+		m.AckID = t.nextAckID + i
+		m.LoggableID = fmt.Sprintf("msg #%d", m.AckID)
+		m.AsFunc = func(any) bool { return false }
+
+		if m.BeforeSend != nil {
+			if err := m.BeforeSend(func(any) bool { return false }); err != nil {
+				return err
+			}
+		}
+
+		// Encode message
+		payload, err := encodeMessage(m)
+		if err != nil {
+			return err
+		}
+
+		filename := fmt.Sprintf("%020d-%s.pb", m.AckID, uuid.New().String()[:8])
+		filenames = append(filenames, filename)
+
+		// Write atomically: tmp -> pending
+		tmpFile := filepath.Join(tmpPath, filename)
+		if err := os.WriteFile(tmpFile, payload, 0o644); err != nil {
+			return fmt.Errorf("filepubsub: failed to write temp file: %w", err)
+		}
+	}
+
+	// Move all files to pending directory in a single loop
+	for _, filename := range filenames {
+		tmpFile := filepath.Join(tmpPath, filename)
+		finalFile := filepath.Join(pendPath, filename)
+		if err := os.Rename(tmpFile, finalFile); err != nil {
+			_ = os.Remove(tmpFile)
+			return fmt.Errorf("filepubsub: failed to move file to pending: %w", err)
+		}
+	}
+
+	t.nextAckID += len(ms)
+
+	// Notify all subscriptions
+	for _, s := range t.subs {
+		s.notifyNewMessages()
+	}
+	return nil
+}
+
+// IsRetryable implements driver.Topic.IsRetryable.
+func (*topic) IsRetryable(error) bool { return false }
+
+// As implements driver.Topic.As.
+func (t *topic) As(i any) bool {
+	p, ok := i.(**topic)
+	if !ok {
+		return false
+	}
+	*p = t
+	return true
+}
+
+// ErrorAs implements driver.Topic.ErrorAs
+func (*topic) ErrorAs(error, any) bool {
+	return false
+}
+
+// ErrorCode implements driver.Topic.ErrorCode
+func (*topic) ErrorCode(err error) gcerrors.ErrorCode {
+	switch {
+	case errors.Is(err, ErrTopicNotExist), errors.Is(err, ErrTopicClosed), errors.Is(err, ErrSubscriptionClosed):
+		return gcerrors.NotFound
+	case errors.Is(err, ErrInvalidPath), errors.Is(err, ErrInvalidParam), errors.Is(err, ErrInvalidAckDeadline):
+		return gcerrors.InvalidArgument
+	case errors.Is(err, context.Canceled):
+		return gcerrors.Canceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return gcerrors.DeadlineExceeded
+	default:
+		return gcerrors.Unknown
+	}
+}
+
+// Close implements driver.Topic.Close.
+func (t *topic) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.closed = true
+	return nil
+}
+
+// SubscriptionOptions sets options for constructing a *pubsub.Subscription
+// backed by filepubsub.
+type SubscriptionOptions struct {
+	// ReceiveBatcherOptions adds constraints to the default batching done for receives.
+	ReceiveBatcherOptions batcher.Options
+	// AckBatcherOptions adds constraints to the default batching done for acks.
+	AckBatcherOptions batcher.Options
+}
+
+type subscription struct {
+	mu          sync.Mutex
+	topic       *topic
+	ackDeadline time.Duration
+	msgs        map[driver.AckID]*message // all unacknowledged messages
+	notifyChan  chan notify.EventInfo
+	newMsgChan  chan struct{} // signaled when new messages arrive
+	stopWatcher chan struct{}
+	watcherDone chan struct{}
+	closed      bool
+}
+
+type message struct {
+	msg        *driver.Message
+	filename   string
+	expiration time.Time
+}
+
+// NewSubscription creates a new subscription for the given topic.
+// It panics if the given topic did not come from filepubsub.
+func NewSubscription(pstopic *pubsub.Topic, ackDeadline time.Duration) (*pubsub.Subscription, error) {
+	return NewSubscriptionWithOptions(pstopic, ackDeadline, nil)
+}
+
+// NewSubscriptionWithOptions is similar to NewSubscription, but supports SubscriptionOptions.
+func NewSubscriptionWithOptions(pstopic *pubsub.Topic, ackDeadline time.Duration, opts *SubscriptionOptions) (*pubsub.Subscription, error) {
+	if opts == nil {
+		opts = &SubscriptionOptions{}
+	}
+	var t *topic
+	if !pstopic.As(&t) {
+		panic("filepubsub: NewSubscription passed a Topic not from filepubsub")
+	}
+
+	s, err := newSubscription(t, ackDeadline)
+	if err != nil {
+		return nil, err
+	}
+	return pubsub.NewSubscription(s, recvBatcherOpts, &opts.AckBatcherOptions), nil
+}
+
+func newSubscription(t *topic, ackDeadline time.Duration) (*subscription, error) {
+	s := &subscription{
+		topic:       t,
+		ackDeadline: ackDeadline,
+		msgs:        map[driver.AckID]*message{},
+		notifyChan:  make(chan notify.EventInfo, 100),
+		newMsgChan:  make(chan struct{}, 1),
+		stopWatcher: make(chan struct{}),
+		watcherDone: make(chan struct{}),
+	}
+
+	if t != nil {
+		t.mu.Lock()
+		t.subs = append(t.subs, s)
+		t.mu.Unlock()
+
+		// Recover any messages stuck in processing
+		if err := s.recoverProcessing(); err != nil {
+			return nil, err
+		}
+
+		// Start filesystem watcher
+		if err := s.startWatcher(); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+// startWatcher sets up filesystem notifications on the pending directory
+func (s *subscription) startWatcher() error {
+	pendPath := filepath.Join(s.topic.basePath, pendingDir)
+
+	// Watch for new files in pending directory
+	if err := notify.Watch(pendPath, s.notifyChan, notify.Create, notify.Rename); err != nil {
+		return fmt.Errorf("filepubsub: failed to watch directory: %w", err)
+	}
+
+	go func() {
+		defer close(s.watcherDone)
+		for {
+			select {
+			case <-s.stopWatcher:
+				notify.Stop(s.notifyChan)
+				return
+			case ev := <-s.notifyChan:
+				if strings.HasSuffix(ev.Path(), ".pb") {
+					s.notifyNewMessages()
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+// notifyNewMessages signals that new messages are available
+func (s *subscription) notifyNewMessages() {
+	select {
+	case s.newMsgChan <- struct{}{}:
+	default:
+		// Channel already has a signal
+	}
+}
+
+// recoverProcessing moves stuck messages from processing back to pending
+func (s *subscription) recoverProcessing() error {
+	procPath := filepath.Join(s.topic.basePath, processingDir)
+	pendPath := filepath.Join(s.topic.basePath, pendingDir)
+
+	entries, err := os.ReadDir(procPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	// Pre-allocate slice for filenames to reduce memory allocations
+	filenames := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".pb") {
+			continue
+		}
+		filenames = append(filenames, entry.Name())
+	}
+
+	// Move all files in a single loop
+	for _, filename := range filenames {
+		src := filepath.Join(procPath, filename)
+		dst := filepath.Join(pendPath, filename)
+		_ = os.Rename(src, dst)
+	}
+	return nil
+}
+
+// receiveNoWait collects messages available for delivery
+func (s *subscription) receiveNoWait(now time.Time, max int) ([]*driver.Message, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// First, check for expired messages that need redelivery
+	for _, m := range s.msgs {
+		if now.After(m.expiration) {
+			// Reset expiration for redelivery
+			m.expiration = now.Add(s.ackDeadline)
+			return []*driver.Message{m.msg}, nil
+		}
+	}
+
+	// Read new messages from pending directory
+	pendPath := filepath.Join(s.topic.basePath, pendingDir)
+	procPath := filepath.Join(s.topic.basePath, processingDir)
+
+	entries, err := os.ReadDir(pendPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Pre-allocate slice to reduce memory allocations
+	var msgs []*driver.Message
+	msgs = make([]*driver.Message, 0, max)
+
+	// Sort by filename (timestamp-based ordering)
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".pb") {
+			continue
+		}
+
+		filename := entry.Name()
+		src := filepath.Join(pendPath, filename)
+		dst := filepath.Join(procPath, filename)
+
+		// Try to claim the message via atomic rename
+		if err := os.Rename(src, dst); err != nil {
+			// Another consumer claimed it
+			continue
+		}
+
+		// Read the message
+		data, err := os.ReadFile(dst)
+		if err != nil {
+			// Move back to pending for retry
+			_ = os.Rename(dst, src)
+			continue
+		}
+
+		dm, err := decodeMessage(data)
+		if err != nil {
+			// Corrupt message, remove it
+			_ = os.Remove(dst)
+			continue
+		}
+
+		// Track the message for ack/nack
+		m := &message{
+			msg:        dm,
+			filename:   filename,
+			expiration: now.Add(s.ackDeadline),
+		}
+		s.msgs[dm.AckID] = m
+
+		msgs = append(msgs, dm)
+		if len(msgs) >= max {
+			break
+		}
+	}
+
+	return msgs, nil
+}
+
+// ReceiveBatch implements driver.ReceiveBatch.
+func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*driver.Message, error) {
+	if s == nil || s.topic == nil {
+		return nil, ErrTopicNotExist
+	}
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, ErrSubscriptionClosed
+	}
+	s.mu.Unlock()
+
+	// Check for messages
+	msgs, err := s.receiveNoWait(time.Now(), maxMessages)
+	if err != nil {
+		return nil, err
+	}
+	if len(msgs) > 0 {
+		return msgs, nil
+	}
+
+	// Wait for new messages or timeout
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.newMsgChan:
+		// New messages available, try again
+		return s.receiveNoWait(time.Now(), maxMessages)
+	case <-time.After(100 * time.Millisecond):
+		// Periodic check for redelivery
+		return nil, nil
+	}
+}
+
+// SendAcks implements driver.SendAcks.
+func (s *subscription) SendAcks(ctx context.Context, ackIDs []driver.AckID) error {
+	if s.topic == nil {
+		return ErrTopicNotExist
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	procPath := filepath.Join(s.topic.basePath, processingDir)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Pre-allocate slice to reduce memory allocations
+	toDelete := make([]driver.AckID, 0, len(ackIDs))
+	for _, id := range ackIDs {
+		if m, ok := s.msgs[id]; ok {
+			// Delete the file (acknowledge)
+			filePath := filepath.Join(procPath, m.filename)
+			_ = os.Remove(filePath)
+			toDelete = append(toDelete, id)
+		}
+	}
+
+	// Delete all messages at once to reduce map operations
+	for _, id := range toDelete {
+		delete(s.msgs, id)
+	}
+	return nil
+}
+
+// CanNack implements driver.CanNack.
+func (s *subscription) CanNack() bool { return true }
+
+// SendNacks implements driver.SendNacks.
+func (s *subscription) SendNacks(ctx context.Context, ackIDs []driver.AckID) error {
+	if s.topic == nil {
+		return ErrTopicNotExist
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	procPath := filepath.Join(s.topic.basePath, processingDir)
+	pendPath := filepath.Join(s.topic.basePath, pendingDir)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Pre-allocate slice to reduce memory allocations
+	toProcess := make([]driver.AckID, 0, len(ackIDs))
+	for _, id := range ackIDs {
+		if m, ok := s.msgs[id]; ok {
+			// Move file back to pending for redelivery
+			src := filepath.Join(procPath, m.filename)
+			dst := filepath.Join(pendPath, m.filename)
+			_ = os.Rename(src, dst)
+			toProcess = append(toProcess, id)
+		}
+	}
+
+	// Delete all messages at once to reduce map operations
+	for _, id := range toProcess {
+		delete(s.msgs, id)
+	}
+	return nil
+}
+
+// IsRetryable implements driver.Subscription.IsRetryable.
+func (*subscription) IsRetryable(error) bool { return false }
+
+// As implements driver.Subscription.As.
+func (s *subscription) As(i any) bool { return false }
+
+// ErrorAs implements driver.Subscription.ErrorAs
+func (*subscription) ErrorAs(error, any) bool {
+	return false
+}
+
+// Close implements driver.Subscription.Close.
+func (s *subscription) Close() error {
+	s.mu.Lock()
+	s.closed = true
+	s.mu.Unlock()
+
+	// Stop the watcher
+	close(s.stopWatcher)
+	<-s.watcherDone
+
+	return nil
+}
+
+// ErrorCode implements driver.Subscription.ErrorCode.
+func (*subscription) ErrorCode(err error) gcerrors.ErrorCode {
+	switch {
+	case errors.Is(err, ErrTopicNotExist), errors.Is(err, ErrTopicClosed), errors.Is(err, ErrSubscriptionClosed):
+		return gcerrors.NotFound
+	case errors.Is(err, ErrInvalidPath), errors.Is(err, ErrInvalidParam), errors.Is(err, ErrInvalidAckDeadline):
+		return gcerrors.InvalidArgument
+	case errors.Is(err, context.Canceled):
+		return gcerrors.Canceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return gcerrors.DeadlineExceeded
+	default:
+		return gcerrors.Unknown
+	}
+}
+
+// wireMessage is a serializable representation of driver.Message
+type wireMessage struct {
+	Metadata map[string]string
+	Body     []byte
+	AckID    int // concrete type instead of driver.AckID (any)
+}
+
+// encodeMessage encodes a driver.Message to bytes using gob.
+func encodeMessage(dm *driver.Message) ([]byte, error) {
+	wm := wireMessage{
+		Metadata: dm.Metadata,
+		Body:     dm.Body,
+		AckID:    dm.AckID.(int), // we always set AckID as int in SendBatch
+	}
+	var buf bytes.Buffer
+	// Pre-allocate buffer to reduce memory allocations
+	buf.Grow(1024) // Start with 1KB buffer
+	if err := gob.NewEncoder(&buf).Encode(wm); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// decodeMessage decodes bytes to a driver.Message using gob.
+func decodeMessage(data []byte) (*driver.Message, error) {
+	var wm wireMessage
+	if err := gob.NewDecoder(bytes.NewBuffer(data)).Decode(&wm); err != nil {
+		return nil, err
+	}
+	return &driver.Message{
+		Metadata: wm.Metadata,
+		Body:     wm.Body,
+		AckID:    wm.AckID,
+		AsFunc:   func(any) bool { return false },
+	}, nil
+}

--- a/common/broker/fsqueue/fspubsub.go
+++ b/common/broker/fsqueue/fspubsub.go
@@ -266,8 +266,7 @@ func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
 			return err
 		}
 
-		// Generate unique filename with timestamp for ordering
-		filename := fmt.Sprintf("%020d-%08d-%s.pb", time.Now().UnixNano(), m.AckID, uuid.New().String()[:8])
+		filename := fmt.Sprintf("%020d-%s.pb", m.AckID, uuid.New().String()[:8])
 		filenames = append(filenames, filename)
 
 		// Write atomically: tmp -> pending

--- a/common/broker/fsqueue/fspubsub_test.go
+++ b/common/broker/fsqueue/fspubsub_test.go
@@ -1,0 +1,825 @@
+/*
+ * Copyright (c) 2024. Abstrium SAS <team (at) pydio.com>
+ * This file is part of Pydio Cells.
+ *
+ * Pydio Cells is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio Cells is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+package filepubsub
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"gocloud.dev/pubsub"
+	"gocloud.dev/pubsub/batcher"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/pydio/cells/v5/common/broker"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestFilePubSub(t *testing.T) {
+	Convey("Test FilePubSub Topic and Subscription", t, func() {
+		// Create temp directory
+		testDir, err := os.MkdirTemp("", "filepubsub-test-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		topicPath := filepath.Join(testDir, "test-topic")
+
+		Convey("Create Topic", func() {
+			topic, err := NewTopic(topicPath)
+			So(err, ShouldBeNil)
+			So(topic, ShouldNotBeNil)
+			defer topic.Shutdown(context.Background())
+
+			// Verify directories created
+			_, err = os.Stat(filepath.Join(topicPath, pendingDir))
+			So(err, ShouldBeNil)
+			_, err = os.Stat(filepath.Join(topicPath, processingDir))
+			So(err, ShouldBeNil)
+			_, err = os.Stat(filepath.Join(topicPath, tmpDir))
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Send and Receive Message", func() {
+			topic, err := NewTopic(topicPath)
+			So(err, ShouldBeNil)
+			defer topic.Shutdown(context.Background())
+
+			sub, err := NewSubscription(topic, 1*time.Minute)
+			So(err, ShouldBeNil)
+			defer sub.Shutdown(context.Background())
+
+			ctx := context.Background()
+
+			// Send message
+			err = topic.Send(ctx, &pubsub.Message{
+				Body:     []byte("hello world"),
+				Metadata: map[string]string{"key": "value"},
+			})
+			So(err, ShouldBeNil)
+
+			// Receive message
+			msg, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(msg, ShouldNotBeNil)
+			So(string(msg.Body), ShouldEqual, "hello world")
+			So(msg.Metadata["key"], ShouldEqual, "value")
+
+			// Ack the message
+			msg.Ack()
+
+			// Verify file is deleted
+			time.Sleep(100 * time.Millisecond)
+			entries, _ := os.ReadDir(filepath.Join(topicPath, processingDir))
+			So(len(entries), ShouldEqual, 0)
+		})
+
+		Convey("Nack and Redeliver Message", func() {
+			topic, err := NewTopic(topicPath)
+			So(err, ShouldBeNil)
+			defer topic.Shutdown(context.Background())
+
+			sub, err := NewSubscription(topic, 1*time.Minute)
+			So(err, ShouldBeNil)
+			defer sub.Shutdown(context.Background())
+
+			ctx := context.Background()
+
+			// Send message
+			err = topic.Send(ctx, &pubsub.Message{
+				Body: []byte("nack test"),
+			})
+			So(err, ShouldBeNil)
+
+			// Receive and nack
+			msg, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(msg.Nackable(), ShouldBeTrue)
+			msg.Nack()
+
+			// Should be redelivered
+			time.Sleep(100 * time.Millisecond)
+			msg2, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(string(msg2.Body), ShouldEqual, "nack test")
+			msg2.Ack()
+		})
+
+		Convey("Message Ordering", func() {
+			topic, err := NewTopic(topicPath)
+			So(err, ShouldBeNil)
+			defer topic.Shutdown(context.Background())
+
+			sub, err := NewSubscription(topic, 1*time.Minute)
+			So(err, ShouldBeNil)
+			defer sub.Shutdown(context.Background())
+
+			ctx := context.Background()
+
+			// Send multiple messages
+			for i := 0; i < 5; i++ {
+				err = topic.Send(ctx, &pubsub.Message{
+					Body: []byte{byte('A' + i)},
+				})
+				So(err, ShouldBeNil)
+				time.Sleep(10 * time.Millisecond) // Ensure different timestamps
+			}
+
+			// Receive in order
+			for i := 0; i < 5; i++ {
+				msg, err := sub.Receive(ctx)
+				So(err, ShouldBeNil)
+				So(msg.Body[0], ShouldEqual, byte('A'+i))
+				msg.Ack()
+			}
+		})
+	})
+}
+
+func TestURLOpener(t *testing.T) {
+	Convey("Test URL Opener", t, func() {
+		tmpDir, err := os.MkdirTemp("", "filepubsub-url-test-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(tmpDir)
+
+		ctx := context.Background()
+
+		Convey("Open Topic via URL", func() {
+			url := "file://" + filepath.Join(tmpDir, "url-topic")
+			topic, err := pubsub.OpenTopic(ctx, url)
+			So(err, ShouldBeNil)
+			So(topic, ShouldNotBeNil)
+			defer topic.Shutdown(ctx)
+		})
+
+		Convey("Open Subscription via URL", func() {
+			url := "file://" + filepath.Join(tmpDir, "url-sub") + "?ackdeadline=30s"
+			sub, err := pubsub.OpenSubscription(ctx, url)
+			So(err, ShouldBeNil)
+			So(sub, ShouldNotBeNil)
+			defer sub.Shutdown(ctx)
+		})
+	})
+}
+
+func mustParseURL(s string) *url.URL {
+	u, _ := url.Parse(s)
+	return u
+}
+
+func TestFpubQueue(t *testing.T) {
+	Convey("Test fpubQueue AsyncQueue", t, func() {
+		testDir, err := os.MkdirTemp("", "fpubqueue-test-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		ctx := context.Background()
+
+		Convey("OpenURL with valid params", func() {
+			q := &fpubQueue{}
+			queue, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir+"?name=test"))
+			So(err, ShouldBeNil)
+			So(queue, ShouldNotBeNil)
+			defer queue.Close(ctx)
+		})
+
+		Convey("OpenURL missing name param", func() {
+			q := &fpubQueue{}
+			_, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir))
+			So(err, ShouldEqual, errMissingStreamName)
+		})
+
+		Convey("Push and Consume", func() {
+			q := &fpubQueue{}
+			queue, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir+"?name=pushtest"))
+			So(err, ShouldBeNil)
+			defer queue.Close(ctx)
+
+			received := make(chan broker.Message, 1)
+			err = queue.Consume(func(ctx context.Context, msgs ...broker.Message) {
+				for _, m := range msgs {
+					received <- m
+				}
+			})
+			So(err, ShouldBeNil)
+
+			// Push a proto message
+			err = queue.Push(ctx, &emptypb.Empty{})
+			So(err, ShouldBeNil)
+
+			select {
+			case <-received:
+				// OK
+			case <-time.After(2 * time.Second):
+				t.Fatal("timeout waiting for message")
+			}
+		})
+
+		Convey("Push after Close returns error", func() {
+			q := &fpubQueue{}
+			queue, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir+"?name=closetest"))
+			So(err, ShouldBeNil)
+			queue.Close(ctx)
+
+			err = queue.Push(ctx, &emptypb.Empty{})
+			So(err, ShouldEqual, errQueueClosed)
+		})
+	})
+}
+
+func TestRecovery(t *testing.T) {
+	Convey("Test recovery of processing messages with ordering", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-recovery-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		topicPath := filepath.Join(testDir, "recovery-topic")
+		ctx := context.Background()
+
+		// Phase 1: Send multiple messages
+		topic, err := NewTopic(topicPath)
+		So(err, ShouldBeNil)
+
+		messages := []string{"msg1", "msg2", "recover me", "msg4"}
+		for _, msg := range messages {
+			err = topic.Send(ctx, &pubsub.Message{Body: []byte(msg)})
+			So(err, ShouldBeNil)
+			time.Sleep(10 * time.Millisecond) // Ensure different timestamps for ordering
+		}
+
+		// Phase 2: Receive and selectively ack
+		sub, err := NewSubscription(topic, time.Minute)
+		So(err, ShouldBeNil)
+
+		// Receive msg1 and ack (should be gone)
+		msg1, err := sub.Receive(ctx)
+		So(err, ShouldBeNil)
+		So(string(msg1.Body), ShouldEqual, "msg1")
+		msg1.Ack()
+
+		// Receive msg2 and ack (should be gone)
+		msg2, err := sub.Receive(ctx)
+		So(err, ShouldBeNil)
+		So(string(msg2.Body), ShouldEqual, "msg2")
+		msg2.Ack()
+
+		// Receive "recover me" but DON'T ack (simulate crash with in-flight message)
+		msgRecover, err := sub.Receive(ctx)
+		So(err, ShouldBeNil)
+		So(string(msgRecover.Body), ShouldEqual, "recover me")
+		_ = msgRecover // Intentionally NOT acking
+
+		// Receive msg4 and ack (should be gone)
+		msg4, err := sub.Receive(ctx)
+		So(err, ShouldBeNil)
+		So(string(msg4.Body), ShouldEqual, "msg4")
+		msg4.Ack()
+
+		// Phase 3: Verify state before crash
+		// Pending should be empty (all processed)
+		pendingDir := filepath.Join(topicPath, "pending")
+		pendingEntries, _ := os.ReadDir(pendingDir)
+		So(len(pendingEntries), ShouldEqual, 0) // All moved to processing
+
+		// Processing should have "recover me" (unacked)
+		// Phase 3: Verify state before crash
+		processingDir := filepath.Join(topicPath, "processing")
+		procEntries, _ := os.ReadDir(processingDir)
+		So(len(procEntries), ShouldEqual, 1)
+
+		// Optionally verify the file contains "recover me"
+		filePath := filepath.Join(processingDir, procEntries[0].Name())
+		data, err := os.ReadFile(filePath)
+		So(err, ShouldBeNil)
+		msg, err := decodeMessage(data)
+		So(err, ShouldBeNil)
+		So(string(msg.Body), ShouldEqual, "recover me") // ✅ Correct - checks file content
+
+		// Phase 4: Simulate crash - shutdown without acking the last message
+		sub.Shutdown(ctx)
+		topic.Shutdown(ctx)
+
+		// Phase 5: Recovery - re-open and verify
+		topic2, err := NewTopic(topicPath)
+		So(err, ShouldBeNil)
+		defer topic2.Shutdown(ctx)
+
+		sub2, err := NewSubscription(topic2, time.Minute)
+		So(err, ShouldBeNil)
+		defer sub2.Shutdown(ctx)
+
+		// Should recover "recover me" (was in processing, moved back to pending)
+		recoveredMsg, err := sub2.Receive(ctx)
+		So(err, ShouldBeNil)
+		So(string(recoveredMsg.Body), ShouldEqual, "recover me")
+		recoveredMsg.Ack()
+
+		// Should NOT receive msg1, msg2, or msg4 (they were acked)
+		ctx2, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+
+		extraMsg, err := sub2.Receive(ctx2)
+		So(err, ShouldNotBeNil) // Timeout or cancelled
+		So(extraMsg, ShouldBeNil)
+
+		// Verify processing dir is now clean
+		procEntries2, _ := os.ReadDir(processingDir)
+		So(len(procEntries2), ShouldEqual, 0)
+	})
+}
+
+func TestContextCancellation(t *testing.T) {
+	Convey("Test context cancellation", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-ctx-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		topicPath := filepath.Join(testDir, "ctx-topic")
+
+		topic, err := NewTopic(topicPath)
+		So(err, ShouldBeNil)
+		defer topic.Shutdown(context.Background())
+
+		sub, err := NewSubscription(topic, time.Minute)
+		So(err, ShouldBeNil)
+		defer sub.Shutdown(context.Background())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		_, err = sub.Receive(ctx)
+		So(err, ShouldNotBeNil) // Should return context canceled
+	})
+}
+
+func TestErrorCases(t *testing.T) {
+	Convey("Test error cases", t, func() {
+		ctx := context.Background()
+
+		Convey("Invalid URL param", func() {
+			_, err := pubsub.OpenTopic(ctx, "file:///tmp/test?invalid=param")
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Empty path", func() {
+			_, err := pubsub.OpenTopic(ctx, "file://")
+			So(err, ShouldNotBeNil)
+		})
+	})
+}
+func TestFuzzyOrderingWithFolderStructure(t *testing.T) {
+	Convey("Test ordering with deep folder structure and many messages", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-fuzzy-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		// Create 3-layer deep folder structure with various files
+		deepPath := filepath.Join(testDir, "layer1", "layer2", "layer3")
+		os.MkdirAll(deepPath, 0o755)
+
+		// Add some noise/junk files in the structure
+		os.WriteFile(filepath.Join(testDir, "layer1", "junk.txt"), []byte("noise"), 0o644)
+		os.WriteFile(filepath.Join(testDir, "layer1", "layer2", ".hidden"), []byte("hidden"), 0o644)
+		os.WriteFile(filepath.Join(testDir, "layer1", "layer2", "layer3", "readme.md"), []byte("readme"), 0o644)
+
+		// Create topic in deep folder
+		topicPath := filepath.Join(deepPath, "topic")
+		ctx := context.Background()
+
+		topic, err := NewTopic(topicPath)
+		So(err, ShouldBeNil)
+		defer topic.Shutdown(ctx)
+
+		// Phase 1: Send many messages rapidly with various payload sizes
+		// TODO configure
+		numMessages := 20
+		expectedBodies := make([]string, numMessages)
+
+		for i := 0; i < numMessages; i++ {
+			payload := fmt.Sprintf("msg-%05d-payload-with-longer-content-for-variety-%s",
+				i, strings.Repeat("x", i%100))
+			expectedBodies[i] = payload
+
+			err = topic.Send(ctx, &pubsub.Message{Body: []byte(payload)})
+			So(err, ShouldBeNil)
+
+			// Vary timing slightly to test timestamp handling
+			if i%5 == 0 {
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+
+		// Verify pending directory state
+		pendingDir := filepath.Join(topicPath, pendingDir)
+		pendingFiles, err := os.ReadDir(pendingDir)
+		So(err, ShouldBeNil)
+		So(len(pendingFiles), ShouldEqual, numMessages)
+
+		// Phase 2: Create subscription and receive in order
+		sub, err := NewSubscription(topic, time.Minute)
+		So(err, ShouldBeNil)
+		defer sub.Shutdown(ctx)
+
+		receivedBodies := make([]string, 0, numMessages)
+
+		for i := 0; i < numMessages; i++ {
+			msg, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(msg, ShouldNotBeNil)
+
+			body := string(msg.Body)
+			receivedBodies = append(receivedBodies, body)
+			msg.Ack()
+
+			// Verify processing directory has exactly 1 file at a time (due to batcher)
+			procDir := filepath.Join(topicPath, processingDir)
+			procFiles, _ := os.ReadDir(procDir)
+			So(len(procFiles), ShouldBeLessThanOrEqualTo, 1) // Can be 0 if already cleaned
+		}
+
+		// Phase 3: Assert ordering matches send order
+		So(len(receivedBodies), ShouldEqual, numMessages)
+		var orderErrors []string
+		for i := 0; i < numMessages; i++ {
+			if receivedBodies[i] != expectedBodies[i] {
+				orderErrors = append(orderErrors, fmt.Sprintf("pos %d: got %s, expected %s", i, receivedBodies[i], expectedBodies[i]))
+			}
+		}
+		So(orderErrors, ShouldBeEmpty)
+
+		// Phase 4: Verify pending/processing directories are now clean
+		pendingFiles, _ = os.ReadDir(pendingDir)
+		So(len(pendingFiles), ShouldEqual, 0)
+
+		procFiles, _ := os.ReadDir(filepath.Join(topicPath, processingDir))
+		So(len(procFiles), ShouldEqual, 0)
+
+		// Phase 5: Verify no extra messages are available
+		ctx2, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+		defer cancel()
+
+		extraMsg, err := sub.Receive(ctx2)
+		So(err, ShouldNotBeNil) // Should timeout
+		So(extraMsg, ShouldBeNil)
+
+		// Phase 6: Verify original junk files still exist (not affected by topic)
+		layer1Junk, err := os.ReadFile(filepath.Join(testDir, "layer1", "junk.txt"))
+		So(err, ShouldBeNil)
+		So(string(layer1Junk), ShouldEqual, "noise")
+
+		layer2Hidden, err := os.ReadFile(filepath.Join(testDir, "layer1", "layer2", ".hidden"))
+		So(err, ShouldBeNil)
+		So(string(layer2Hidden), ShouldEqual, "hidden")
+	})
+}
+
+func TestWatcherOrderPreservation(t *testing.T) {
+	Convey("Test watcher preserves order on rapid batch publish", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-watcher-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		topicPath := filepath.Join(testDir, "watcher-topic")
+		ctx := context.Background()
+
+		// Create topic and subscription
+		topic, err := NewTopic(topicPath)
+		So(err, ShouldBeNil)
+		defer topic.Shutdown(ctx)
+
+		sub, err := NewSubscription(topic, time.Minute)
+		So(err, ShouldBeNil)
+		defer sub.Shutdown(ctx)
+
+		// Rapidly publish many messages (not as batch, but rapid individual sends)
+		for i := 0; i < 50; i++ {
+			err = topic.Send(ctx, &pubsub.Message{Body: []byte(fmt.Sprintf("msg-%03d", i))})
+			So(err, ShouldBeNil)
+		}
+
+		// Wait briefly for watcher to fire
+		time.Sleep(100 * time.Millisecond)
+
+		// Receive messages and verify ordering
+		var received []string
+		for i := 0; i < 50; i++ {
+			msg, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(msg, ShouldNotBeNil)
+
+			received = append(received, string(msg.Body))
+			msg.Ack()
+		}
+
+		// Verify all messages received in order
+		So(len(received), ShouldEqual, 50)
+		var orderErrors []string
+		for i, msgBody := range received {
+			expectedBody := fmt.Sprintf("msg-%03d", i)
+			if msgBody != expectedBody {
+				orderErrors = append(orderErrors, fmt.Sprintf("pos %d: got %s, expected %s", i, msgBody, expectedBody))
+			}
+		}
+		So(orderErrors, ShouldBeEmpty)
+
+		// Verify no more messages available
+		ctx2, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+		_, err = sub.Receive(ctx2)
+		So(err, ShouldNotBeNil) // Should timeout
+	})
+}
+
+func TestRapidBatchOrdering(t *testing.T) {
+	Convey("Test rapid batch publishing preserves order", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-batch-order-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		topicPath := filepath.Join(testDir, "batch-order-topic")
+		ctx := context.Background()
+
+		topic, err := NewTopic(topicPath)
+		So(err, ShouldBeNil)
+		defer topic.Shutdown(ctx)
+
+		sub, err := NewSubscription(topic, time.Minute)
+		So(err, ShouldBeNil)
+		defer sub.Shutdown(ctx)
+
+		// Publish messages as rapidly as possible without delays
+		totalMessages := 0
+		for batch := 0; batch < 3; batch++ {
+			for i := 0; i < 20; i++ {
+				err = topic.Send(ctx, &pubsub.Message{
+					Body: []byte(fmt.Sprintf("%04d", totalMessages)),
+				})
+				So(err, ShouldBeNil)
+				totalMessages++
+			}
+			// Minimal delay between batches - still rapid
+			time.Sleep(500 * time.Microsecond)
+		}
+
+		// Wait for all files to be written
+		time.Sleep(200 * time.Millisecond)
+
+		// Receive all messages and extract their sequence numbers
+		var received []int
+		for i := 0; i < totalMessages; i++ {
+			msg, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(msg, ShouldNotBeNil)
+
+			seqNum := 0
+			_, err = fmt.Sscanf(string(msg.Body), "%d", &seqNum)
+			So(err, ShouldBeNil)
+			received = append(received, seqNum)
+
+			msg.Ack()
+		}
+
+		// Verify strictly sequential ordering
+		So(len(received), ShouldEqual, 60)
+		var orderErrors []string
+		for i, seqNum := range received {
+			if seqNum != i {
+				orderErrors = append(orderErrors, fmt.Sprintf("pos %d: got %d, expected %d", i, seqNum, i))
+			}
+		}
+		So(orderErrors, ShouldBeEmpty)
+
+		// Verify no more messages
+		ctx2, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+		_, err = sub.Receive(ctx2)
+		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestTopicWithBatchOptions(t *testing.T) {
+	Convey("Test topic creation with custom batch options", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-topic-opts-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		ctx := context.Background()
+
+		Convey("Should accept custom send batch size", func() {
+			topicOpts := &TopicOptions{
+				BatcherOptions: batcher.Options{
+					MaxBatchSize: 5,
+				},
+			}
+			topic, err := NewTopicWithOptions(testDir, topicOpts)
+			So(err, ShouldBeNil)
+			So(topic, ShouldNotBeNil)
+			defer topic.Shutdown(ctx)
+
+			// Verify topic was created successfully
+			pendingPath := filepath.Join(testDir, pendingDir)
+			_, err = os.Stat(pendingPath)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Should use defaults when nil options provided", func() {
+			topic, err := NewTopicWithOptions(testDir, nil)
+			So(err, ShouldBeNil)
+			So(topic, ShouldNotBeNil)
+			defer topic.Shutdown(ctx)
+		})
+	})
+}
+
+func TestSubscriptionWithBatchOptions(t *testing.T) {
+	Convey("Test subscription creation with custom batch options", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-sub-opts-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		ctx := context.Background()
+
+		topic, err := NewTopic(testDir)
+		So(err, ShouldBeNil)
+		defer topic.Shutdown(ctx)
+
+		Convey("Should accept custom receive batch size", func() {
+			subOpts := &SubscriptionOptions{
+				ReceiveBatcherOptions: batcher.Options{
+					MaxBatchSize: 10,
+					MaxHandlers:  1, // Keep ordering
+				},
+			}
+			sub, err := NewSubscriptionWithOptions(topic, time.Minute, subOpts)
+			So(err, ShouldBeNil)
+			So(sub, ShouldNotBeNil)
+			defer sub.Shutdown(ctx)
+		})
+
+		Convey("Should use defaults when nil options provided", func() {
+			sub, err := NewSubscriptionWithOptions(topic, time.Minute, nil)
+			So(err, ShouldBeNil)
+			So(sub, ShouldNotBeNil)
+			defer sub.Shutdown(ctx)
+		})
+	})
+}
+
+func TestBatchSizePreservesOrdering(t *testing.T) {
+	Convey("Test that batch size > 1 preserves ordering with MaxHandlers=1", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-batch-ordering-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		ctx := context.Background()
+
+		// Create topic with batch size 10
+		topicOpts := &TopicOptions{
+			BatcherOptions: batcher.Options{
+				MaxBatchSize: 10,
+			},
+		}
+		topic, err := NewTopicWithOptions(testDir, topicOpts)
+		So(err, ShouldBeNil)
+		defer topic.Shutdown(ctx)
+
+		// Create subscription with receive batch size 5 but MaxHandlers=1
+		subOpts := &SubscriptionOptions{
+			ReceiveBatcherOptions: batcher.Options{
+				MaxBatchSize: 5,
+				MaxHandlers:  1, // Single handler maintains order
+			},
+		}
+		sub, err := NewSubscriptionWithOptions(topic, time.Minute, subOpts)
+		So(err, ShouldBeNil)
+		defer sub.Shutdown(ctx)
+
+		// Publish 20 messages
+		totalMessages := 20
+		for i := 0; i < totalMessages; i++ {
+			err = topic.Send(ctx, &pubsub.Message{
+				Body: []byte(fmt.Sprintf("%04d", i)),
+			})
+			So(err, ShouldBeNil)
+		}
+
+		// Wait for writes
+		time.Sleep(200 * time.Millisecond)
+
+		// Receive all messages and verify order
+		var received []int
+		for i := 0; i < totalMessages; i++ {
+			msg, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(msg, ShouldNotBeNil)
+
+			seqNum := 0
+			_, err = fmt.Sscanf(string(msg.Body), "%d", &seqNum)
+			So(err, ShouldBeNil)
+			received = append(received, seqNum)
+
+			msg.Ack()
+		}
+
+		// Verify strict ordering maintained despite batching
+		So(len(received), ShouldEqual, totalMessages)
+		for i, seqNum := range received {
+			So(seqNum, ShouldEqual, i)
+		}
+	})
+}
+
+func TestSendBatchSizeAffectsThroughput(t *testing.T) {
+	Convey("Test that larger send batch reduces filesystem operations", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-batch-throughput-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		ctx := context.Background()
+
+		Convey("Small batch size (1)", func() {
+			topicOpts := &TopicOptions{
+				BatcherOptions: batcher.Options{
+					MaxBatchSize: 1,
+				},
+			}
+			topic, err := NewTopicWithOptions(testDir, topicOpts)
+			So(err, ShouldBeNil)
+			defer topic.Shutdown(ctx)
+
+			start := time.Now()
+			for i := 0; i < 100; i++ {
+				err = topic.Send(ctx, &pubsub.Message{
+					Body: []byte(fmt.Sprintf("msg-%d", i)),
+				})
+				So(err, ShouldBeNil)
+			}
+			smallBatchDuration := time.Since(start)
+
+			// Verify all files written
+			pendingPath := filepath.Join(testDir, pendingDir)
+			entries, err := os.ReadDir(pendingPath)
+			So(err, ShouldBeNil)
+			So(len(entries), ShouldEqual, 100)
+
+			t.Logf("Small batch (1): %v for 100 messages", smallBatchDuration)
+		})
+
+		// Clean up for next test
+		os.RemoveAll(testDir)
+		testDir, err = os.MkdirTemp("", "filepubsub-batch-throughput-*")
+		So(err, ShouldBeNil)
+
+		Convey("Large batch size (20)", func() {
+			topicOpts := &TopicOptions{
+				BatcherOptions: batcher.Options{
+					MaxBatchSize: 20,
+				},
+			}
+			topic, err := NewTopicWithOptions(testDir, topicOpts)
+			So(err, ShouldBeNil)
+			defer topic.Shutdown(ctx)
+
+			start := time.Now()
+			for i := 0; i < 100; i++ {
+				err = topic.Send(ctx, &pubsub.Message{
+					Body: []byte(fmt.Sprintf("msg-%d", i)),
+				})
+				So(err, ShouldBeNil)
+			}
+			// Force flush
+			topic.Shutdown(ctx)
+			largeBatchDuration := time.Since(start)
+
+			// Verify all files written
+			pendingPath := filepath.Join(testDir, pendingDir)
+			entries, err := os.ReadDir(pendingPath)
+			So(err, ShouldBeNil)
+			So(len(entries), ShouldEqual, 100)
+
+			t.Logf("Large batch (20): %v for 100 messages", largeBatchDuration)
+		})
+	})
+}

--- a/common/broker/fsqueue/fspubsub_test.go
+++ b/common/broker/fsqueue/fspubsub_test.go
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2024. Abstrium SAS <team (at) pydio.com>
+ * This file is part of Pydio Cells.
+ *
+ * Pydio Cells is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio Cells is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+package filepubsub
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gocloud.dev/pubsub"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/pydio/cells/v5/common/broker"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestFilePubSub(t *testing.T) {
+	Convey("Test FilePubSub Topic and Subscription", t, func() {
+		// Create temp directory
+		testDir, err := os.MkdirTemp("", "filepubsub-test-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		topicPath := filepath.Join(testDir, "test-topic")
+
+		Convey("Create Topic", func() {
+			topic, err := NewTopic(topicPath)
+			So(err, ShouldBeNil)
+			So(topic, ShouldNotBeNil)
+			defer topic.Shutdown(context.Background())
+
+			// Verify directories created
+			_, err = os.Stat(filepath.Join(topicPath, pendingDir))
+			So(err, ShouldBeNil)
+			_, err = os.Stat(filepath.Join(topicPath, processingDir))
+			So(err, ShouldBeNil)
+			_, err = os.Stat(filepath.Join(topicPath, tmpDir))
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Send and Receive Message", func() {
+			topic, err := NewTopic(topicPath)
+			So(err, ShouldBeNil)
+			defer topic.Shutdown(context.Background())
+
+			sub, err := NewSubscription(topic, 1*time.Minute)
+			So(err, ShouldBeNil)
+			defer sub.Shutdown(context.Background())
+
+			ctx := context.Background()
+
+			// Send message
+			err = topic.Send(ctx, &pubsub.Message{
+				Body:     []byte("hello world"),
+				Metadata: map[string]string{"key": "value"},
+			})
+			So(err, ShouldBeNil)
+
+			// Receive message
+			msg, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(msg, ShouldNotBeNil)
+			So(string(msg.Body), ShouldEqual, "hello world")
+			So(msg.Metadata["key"], ShouldEqual, "value")
+
+			// Ack the message
+			msg.Ack()
+
+			// Verify file is deleted
+			time.Sleep(100 * time.Millisecond)
+			entries, _ := os.ReadDir(filepath.Join(topicPath, processingDir))
+			So(len(entries), ShouldEqual, 0)
+		})
+
+		Convey("Nack and Redeliver Message", func() {
+			topic, err := NewTopic(topicPath)
+			So(err, ShouldBeNil)
+			defer topic.Shutdown(context.Background())
+
+			sub, err := NewSubscription(topic, 1*time.Minute)
+			So(err, ShouldBeNil)
+			defer sub.Shutdown(context.Background())
+
+			ctx := context.Background()
+
+			// Send message
+			err = topic.Send(ctx, &pubsub.Message{
+				Body: []byte("nack test"),
+			})
+			So(err, ShouldBeNil)
+
+			// Receive and nack
+			msg, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(msg.Nackable(), ShouldBeTrue)
+			msg.Nack()
+
+			// Should be redelivered
+			time.Sleep(100 * time.Millisecond)
+			msg2, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(string(msg2.Body), ShouldEqual, "nack test")
+			msg2.Ack()
+		})
+
+		Convey("Message Ordering", func() {
+			topic, err := NewTopic(topicPath)
+			So(err, ShouldBeNil)
+			defer topic.Shutdown(context.Background())
+
+			sub, err := NewSubscription(topic, 1*time.Minute)
+			So(err, ShouldBeNil)
+			defer sub.Shutdown(context.Background())
+
+			ctx := context.Background()
+
+			// Send multiple messages
+			for i := 0; i < 5; i++ {
+				err = topic.Send(ctx, &pubsub.Message{
+					Body: []byte{byte('A' + i)},
+				})
+				So(err, ShouldBeNil)
+				time.Sleep(10 * time.Millisecond) // Ensure different timestamps
+			}
+
+			// Receive in order
+			for i := 0; i < 5; i++ {
+				msg, err := sub.Receive(ctx)
+				So(err, ShouldBeNil)
+				So(msg.Body[0], ShouldEqual, byte('A'+i))
+				msg.Ack()
+			}
+		})
+	})
+}
+
+func TestURLOpener(t *testing.T) {
+	Convey("Test URL Opener", t, func() {
+		tmpDir, err := os.MkdirTemp("", "filepubsub-url-test-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(tmpDir)
+
+		ctx := context.Background()
+
+		Convey("Open Topic via URL", func() {
+			url := "file://" + filepath.Join(tmpDir, "url-topic")
+			topic, err := pubsub.OpenTopic(ctx, url)
+			So(err, ShouldBeNil)
+			So(topic, ShouldNotBeNil)
+			defer topic.Shutdown(ctx)
+		})
+
+		Convey("Open Subscription via URL", func() {
+			url := "file://" + filepath.Join(tmpDir, "url-sub") + "?ackdeadline=30s"
+			sub, err := pubsub.OpenSubscription(ctx, url)
+			So(err, ShouldBeNil)
+			So(sub, ShouldNotBeNil)
+			defer sub.Shutdown(ctx)
+		})
+	})
+}
+
+func mustParseURL(s string) *url.URL {
+	u, _ := url.Parse(s)
+	return u
+}
+
+func TestFpubQueue(t *testing.T) {
+	Convey("Test fpubQueue AsyncQueue", t, func() {
+		testDir, err := os.MkdirTemp("", "fpubqueue-test-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		ctx := context.Background()
+
+		Convey("OpenURL with valid params", func() {
+			q := &fpubQueue{}
+			queue, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir+"?name=test"))
+			So(err, ShouldBeNil)
+			So(queue, ShouldNotBeNil)
+			defer queue.Close(ctx)
+		})
+
+		Convey("OpenURL missing name param", func() {
+			q := &fpubQueue{}
+			_, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir))
+			So(err, ShouldEqual, errMissingStreamName)
+		})
+
+		Convey("Push and Consume", func() {
+			q := &fpubQueue{}
+			queue, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir+"?name=pushtest"))
+			So(err, ShouldBeNil)
+			defer queue.Close(ctx)
+
+			received := make(chan broker.Message, 1)
+			err = queue.Consume(func(ctx context.Context, msgs ...broker.Message) {
+				for _, m := range msgs {
+					received <- m
+				}
+			})
+			So(err, ShouldBeNil)
+
+			// Push a proto message
+			err = queue.Push(ctx, &emptypb.Empty{})
+			So(err, ShouldBeNil)
+
+			select {
+			case <-received:
+				// OK
+			case <-time.After(2 * time.Second):
+				t.Fatal("timeout waiting for message")
+			}
+		})
+
+		Convey("Push after Close returns error", func() {
+			q := &fpubQueue{}
+			queue, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir+"?name=closetest"))
+			So(err, ShouldBeNil)
+			queue.Close(ctx)
+
+			err = queue.Push(ctx, &emptypb.Empty{})
+			So(err, ShouldEqual, errQueueClosed)
+		})
+	})
+}
+
+func TestRecovery(t *testing.T) {
+	Convey("Test recovery of processing messages", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-recovery-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		topicPath := filepath.Join(testDir, "recovery-topic")
+		ctx := context.Background()
+
+		// Create topic and send message
+		topic, err := NewTopic(topicPath)
+		So(err, ShouldBeNil)
+
+		err = topic.Send(ctx, &pubsub.Message{Body: []byte("recover me")})
+		So(err, ShouldBeNil)
+
+		sub, err := NewSubscription(topic, time.Minute)
+		So(err, ShouldBeNil)
+
+		// Receive but don't ack (simulate crash)
+		msg, err := sub.Receive(ctx)
+		So(err, ShouldBeNil)
+		_ = msg // intentionally not acking
+
+		// Shutdown without ack
+		sub.Shutdown(ctx)
+		topic.Shutdown(ctx)
+
+		// Re-open - should recover stuck message
+		topic2, err := NewTopic(topicPath)
+		So(err, ShouldBeNil)
+		defer topic2.Shutdown(ctx)
+
+		sub2, err := NewSubscription(topic2, time.Minute)
+		So(err, ShouldBeNil)
+		defer sub2.Shutdown(ctx)
+
+		msg2, err := sub2.Receive(ctx)
+		So(err, ShouldBeNil)
+		So(string(msg2.Body), ShouldEqual, "recover me")
+		msg2.Ack()
+	})
+}
+
+func TestContextCancellation(t *testing.T) {
+	Convey("Test context cancellation", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-ctx-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		topicPath := filepath.Join(testDir, "ctx-topic")
+
+		topic, err := NewTopic(topicPath)
+		So(err, ShouldBeNil)
+		defer topic.Shutdown(context.Background())
+
+		sub, err := NewSubscription(topic, time.Minute)
+		So(err, ShouldBeNil)
+		defer sub.Shutdown(context.Background())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		_, err = sub.Receive(ctx)
+		So(err, ShouldNotBeNil) // Should return context canceled
+	})
+}
+
+func TestErrorCases(t *testing.T) {
+	Convey("Test error cases", t, func() {
+		ctx := context.Background()
+
+		Convey("Invalid URL param", func() {
+			_, err := pubsub.OpenTopic(ctx, "file:///tmp/test?invalid=param")
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Empty path", func() {
+			_, err := pubsub.OpenTopic(ctx, "file://")
+			So(err, ShouldNotBeNil)
+		})
+	})
+}

--- a/common/broker/fsqueue/fspubsub_test.go
+++ b/common/broker/fsqueue/fspubsub_test.go
@@ -22,7 +22,7 @@ package filepubsub
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -30,21 +30,47 @@ import (
 	"testing"
 	"time"
 
+	"gocloud.dev/gcerrors"
 	"gocloud.dev/pubsub"
 	"gocloud.dev/pubsub/batcher"
+	"gocloud.dev/pubsub/driver"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/pydio/cells/v5/common/broker"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+// Test constants
+const (
+	testBody      = "test"
+	invalidPath   = "/dev/null/cannot-create"
+	testURLFile   = "file:///tmp/test"
+	ackDeadline1m = "?ackdeadline=1m"
+)
+
+// Helper: create temp dir with cleanup
+func tempDir(_ *testing.T, pattern string) (string, func()) {
+	dir, _ := os.MkdirTemp("", pattern)
+	return dir, func() { os.RemoveAll(dir) }
+}
+
+// Helper: create topic dirs manually
+func createTopicDirs(basePath string) {
+	for _, d := range []string{pendingDir, processingDir, tmpDir} {
+		os.MkdirAll(filepath.Join(basePath, d), 0o755)
+	}
+}
+
+func mustParseURL(s string) *url.URL {
+	u, _ := url.Parse(s)
+	return u
+}
+
 func TestFilePubSub(t *testing.T) {
 	Convey("Test FilePubSub Topic and Subscription", t, func() {
-		// Create temp directory
-		testDir, err := os.MkdirTemp("", "filepubsub-test-*")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(testDir)
-
+		testDir, cleanup := tempDir(t, "filepubsub-test-*")
+		defer cleanup()
 		topicPath := filepath.Join(testDir, "test-topic")
 
 		Convey("Create Topic", func() {
@@ -54,12 +80,10 @@ func TestFilePubSub(t *testing.T) {
 			defer topic.Shutdown(context.Background())
 
 			// Verify directories created
-			_, err = os.Stat(filepath.Join(topicPath, pendingDir))
-			So(err, ShouldBeNil)
-			_, err = os.Stat(filepath.Join(topicPath, processingDir))
-			So(err, ShouldBeNil)
-			_, err = os.Stat(filepath.Join(topicPath, tmpDir))
-			So(err, ShouldBeNil)
+			for _, d := range []string{pendingDir, processingDir, tmpDir} {
+				_, err = os.Stat(filepath.Join(topicPath, d))
+				So(err, ShouldBeNil)
+			}
 		})
 
 		Convey("Send and Receive Message", func() {
@@ -160,101 +184,66 @@ func TestFilePubSub(t *testing.T) {
 
 func TestURLOpener(t *testing.T) {
 	Convey("Test URL Opener", t, func() {
-		tmpDir, err := os.MkdirTemp("", "filepubsub-url-test-*")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(tmpDir)
-
+		td, cleanup := tempDir(t, "filepubsub-url-*")
+		defer cleanup()
 		ctx := context.Background()
 
-		Convey("Open Topic via URL", func() {
-			url := "file://" + filepath.Join(tmpDir, "url-topic")
-			topic, err := pubsub.OpenTopic(ctx, url)
-			So(err, ShouldBeNil)
-			So(topic, ShouldNotBeNil)
-			defer topic.Shutdown(ctx)
-		})
+		topic, err := pubsub.OpenTopic(ctx, "file://"+filepath.Join(td, "topic"))
+		So(err, ShouldBeNil)
+		defer topic.Shutdown(ctx)
 
-		Convey("Open Subscription via URL", func() {
-			url := "file://" + filepath.Join(tmpDir, "url-sub") + "?ackdeadline=30s"
-			sub, err := pubsub.OpenSubscription(ctx, url)
-			So(err, ShouldBeNil)
-			So(sub, ShouldNotBeNil)
-			defer sub.Shutdown(ctx)
-		})
+		sub, err := pubsub.OpenSubscription(ctx, "file://"+filepath.Join(td, "sub")+"?ackdeadline=30s")
+		So(err, ShouldBeNil)
+		defer sub.Shutdown(ctx)
 	})
-}
-
-func mustParseURL(s string) *url.URL {
-	u, _ := url.Parse(s)
-	return u
 }
 
 func TestFpubQueue(t *testing.T) {
 	Convey("Test fpubQueue AsyncQueue", t, func() {
-		testDir, err := os.MkdirTemp("", "fpubqueue-test-*")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(testDir)
-
+		td, cleanup := tempDir(t, "fpubqueue-*")
+		defer cleanup()
 		ctx := context.Background()
 
-		Convey("OpenURL with valid params", func() {
+		Convey("OpenURL and Push/Consume", func() {
 			q := &fpubQueue{}
-			queue, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir+"?name=test"))
-			So(err, ShouldBeNil)
-			So(queue, ShouldNotBeNil)
-			defer queue.Close(ctx)
-		})
 
-		Convey("OpenURL missing name param", func() {
-			q := &fpubQueue{}
-			_, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir))
+			// Missing name fails
+			_, err := q.OpenURL(ctx, mustParseURL("fpub://"+td))
 			So(err, ShouldEqual, errMissingStreamName)
-		})
 
-		Convey("Push and Consume", func() {
-			q := &fpubQueue{}
-			queue, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir+"?name=pushtest"))
+			// Valid open
+			queue, err := q.OpenURL(ctx, mustParseURL("fpub://"+td+"?name=test"))
 			So(err, ShouldBeNil)
 			defer queue.Close(ctx)
 
 			received := make(chan broker.Message, 1)
-			err = queue.Consume(func(ctx context.Context, msgs ...broker.Message) {
+			queue.Consume(func(ctx context.Context, msgs ...broker.Message) {
 				for _, m := range msgs {
 					received <- m
 				}
 			})
-			So(err, ShouldBeNil)
-
-			// Push a proto message
-			err = queue.Push(ctx, &emptypb.Empty{})
-			So(err, ShouldBeNil)
+			queue.Push(ctx, &emptypb.Empty{})
 
 			select {
 			case <-received:
-				// OK
 			case <-time.After(2 * time.Second):
-				t.Fatal("timeout waiting for message")
+				t.Fatal("timeout")
 			}
 		})
 
-		Convey("Push after Close returns error", func() {
+		Convey("Push after Close", func() {
 			q := &fpubQueue{}
-			queue, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir+"?name=closetest"))
-			So(err, ShouldBeNil)
+			queue, _ := q.OpenURL(ctx, mustParseURL("fpub://"+td+"?name=close"))
 			queue.Close(ctx)
-
-			err = queue.Push(ctx, &emptypb.Empty{})
-			So(err, ShouldEqual, errQueueClosed)
+			So(queue.Push(ctx, &emptypb.Empty{}), ShouldEqual, errQueueClosed)
 		})
 	})
 }
 
 func TestRecovery(t *testing.T) {
 	Convey("Test recovery of processing messages with ordering", t, func() {
-		testDir, err := os.MkdirTemp("", "filepubsub-recovery-*")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(testDir)
-
+		testDir, cleanup := tempDir(t, "filepubsub-recovery-*")
+		defer cleanup()
 		topicPath := filepath.Join(testDir, "recovery-topic")
 		ctx := context.Background()
 
@@ -296,6 +285,9 @@ func TestRecovery(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(string(msg4.Body), ShouldEqual, "msg4")
 		msg4.Ack()
+
+		// Wait for ack to be processed
+		time.Sleep(100 * time.Millisecond)
 
 		// Phase 3: Verify state before crash
 		// Pending should be empty (all processed)
@@ -352,474 +344,527 @@ func TestRecovery(t *testing.T) {
 
 func TestContextCancellation(t *testing.T) {
 	Convey("Test context cancellation", t, func() {
-		testDir, err := os.MkdirTemp("", "filepubsub-ctx-*")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(testDir)
+		td, cleanup := tempDir(t, "filepubsub-ctx-*")
+		defer cleanup()
 
-		topicPath := filepath.Join(testDir, "ctx-topic")
-
-		topic, err := NewTopic(topicPath)
-		So(err, ShouldBeNil)
+		topic, _ := NewTopic(td)
 		defer topic.Shutdown(context.Background())
-
-		sub, err := NewSubscription(topic, time.Minute)
-		So(err, ShouldBeNil)
+		sub, _ := NewSubscription(topic, time.Minute)
 		defer sub.Shutdown(context.Background())
 
 		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // Cancel immediately
-
-		_, err = sub.Receive(ctx)
-		So(err, ShouldNotBeNil) // Should return context canceled
+		cancel()
+		_, err := sub.Receive(ctx)
+		So(err, ShouldNotBeNil)
 	})
 }
 
 func TestErrorCases(t *testing.T) {
 	Convey("Test error cases", t, func() {
 		ctx := context.Background()
-
-		Convey("Invalid URL param", func() {
-			_, err := pubsub.OpenTopic(ctx, "file:///tmp/test?invalid=param")
-			So(err, ShouldNotBeNil)
-		})
-
-		Convey("Empty path", func() {
-			_, err := pubsub.OpenTopic(ctx, "file://")
-			So(err, ShouldNotBeNil)
-		})
-	})
-}
-func TestFuzzyOrderingWithFolderStructure(t *testing.T) {
-	Convey("Test ordering with deep folder structure and many messages", t, func() {
-		testDir, err := os.MkdirTemp("", "filepubsub-fuzzy-*")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(testDir)
-
-		// Create 3-layer deep folder structure with various files
-		deepPath := filepath.Join(testDir, "layer1", "layer2", "layer3")
-		os.MkdirAll(deepPath, 0o755)
-
-		// Add some noise/junk files in the structure
-		os.WriteFile(filepath.Join(testDir, "layer1", "junk.txt"), []byte("noise"), 0o644)
-		os.WriteFile(filepath.Join(testDir, "layer1", "layer2", ".hidden"), []byte("hidden"), 0o644)
-		os.WriteFile(filepath.Join(testDir, "layer1", "layer2", "layer3", "readme.md"), []byte("readme"), 0o644)
-
-		// Create topic in deep folder
-		topicPath := filepath.Join(deepPath, "topic")
-		ctx := context.Background()
-
-		topic, err := NewTopic(topicPath)
-		So(err, ShouldBeNil)
-		defer topic.Shutdown(ctx)
-
-		// Phase 1: Send many messages rapidly with various payload sizes
-		// TODO configure
-		numMessages := 20
-		expectedBodies := make([]string, numMessages)
-
-		for i := 0; i < numMessages; i++ {
-			payload := fmt.Sprintf("msg-%05d-payload-with-longer-content-for-variety-%s",
-				i, strings.Repeat("x", i%100))
-			expectedBodies[i] = payload
-
-			err = topic.Send(ctx, &pubsub.Message{Body: []byte(payload)})
-			So(err, ShouldBeNil)
-
-			// Vary timing slightly to test timestamp handling
-			if i%5 == 0 {
-				time.Sleep(1 * time.Millisecond)
-			}
-		}
-
-		// Verify pending directory state
-		pendingDir := filepath.Join(topicPath, pendingDir)
-		pendingFiles, err := os.ReadDir(pendingDir)
-		So(err, ShouldBeNil)
-		So(len(pendingFiles), ShouldEqual, numMessages)
-
-		// Phase 2: Create subscription and receive in order
-		sub, err := NewSubscription(topic, time.Minute)
-		So(err, ShouldBeNil)
-		defer sub.Shutdown(ctx)
-
-		receivedBodies := make([]string, 0, numMessages)
-
-		for i := 0; i < numMessages; i++ {
-			msg, err := sub.Receive(ctx)
-			So(err, ShouldBeNil)
-			So(msg, ShouldNotBeNil)
-
-			body := string(msg.Body)
-			receivedBodies = append(receivedBodies, body)
-			msg.Ack()
-
-			// Verify processing directory has exactly 1 file at a time (due to batcher)
-			procDir := filepath.Join(topicPath, processingDir)
-			procFiles, _ := os.ReadDir(procDir)
-			So(len(procFiles), ShouldBeLessThanOrEqualTo, 1) // Can be 0 if already cleaned
-		}
-
-		// Phase 3: Assert ordering matches send order
-		So(len(receivedBodies), ShouldEqual, numMessages)
-		var orderErrors []string
-		for i := 0; i < numMessages; i++ {
-			if receivedBodies[i] != expectedBodies[i] {
-				orderErrors = append(orderErrors, fmt.Sprintf("pos %d: got %s, expected %s", i, receivedBodies[i], expectedBodies[i]))
-			}
-		}
-		So(orderErrors, ShouldBeEmpty)
-
-		// Phase 4: Verify pending/processing directories are now clean
-		pendingFiles, _ = os.ReadDir(pendingDir)
-		So(len(pendingFiles), ShouldEqual, 0)
-
-		procFiles, _ := os.ReadDir(filepath.Join(topicPath, processingDir))
-		So(len(procFiles), ShouldEqual, 0)
-
-		// Phase 5: Verify no extra messages are available
-		ctx2, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
-		defer cancel()
-
-		extraMsg, err := sub.Receive(ctx2)
-		So(err, ShouldNotBeNil) // Should timeout
-		So(extraMsg, ShouldBeNil)
-
-		// Phase 6: Verify original junk files still exist (not affected by topic)
-		layer1Junk, err := os.ReadFile(filepath.Join(testDir, "layer1", "junk.txt"))
-		So(err, ShouldBeNil)
-		So(string(layer1Junk), ShouldEqual, "noise")
-
-		layer2Hidden, err := os.ReadFile(filepath.Join(testDir, "layer1", "layer2", ".hidden"))
-		So(err, ShouldBeNil)
-		So(string(layer2Hidden), ShouldEqual, "hidden")
-	})
-}
-
-func TestWatcherOrderPreservation(t *testing.T) {
-	Convey("Test watcher preserves order on rapid batch publish", t, func() {
-		testDir, err := os.MkdirTemp("", "filepubsub-watcher-*")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(testDir)
-
-		topicPath := filepath.Join(testDir, "watcher-topic")
-		ctx := context.Background()
-
-		// Create topic and subscription
-		topic, err := NewTopic(topicPath)
-		So(err, ShouldBeNil)
-		defer topic.Shutdown(ctx)
-
-		sub, err := NewSubscription(topic, time.Minute)
-		So(err, ShouldBeNil)
-		defer sub.Shutdown(ctx)
-
-		// Rapidly publish many messages (not as batch, but rapid individual sends)
-		for i := 0; i < 50; i++ {
-			err = topic.Send(ctx, &pubsub.Message{Body: []byte(fmt.Sprintf("msg-%03d", i))})
-			So(err, ShouldBeNil)
-		}
-
-		// Wait briefly for watcher to fire
-		time.Sleep(100 * time.Millisecond)
-
-		// Receive messages and verify ordering
-		var received []string
-		for i := 0; i < 50; i++ {
-			msg, err := sub.Receive(ctx)
-			So(err, ShouldBeNil)
-			So(msg, ShouldNotBeNil)
-
-			received = append(received, string(msg.Body))
-			msg.Ack()
-		}
-
-		// Verify all messages received in order
-		So(len(received), ShouldEqual, 50)
-		var orderErrors []string
-		for i, msgBody := range received {
-			expectedBody := fmt.Sprintf("msg-%03d", i)
-			if msgBody != expectedBody {
-				orderErrors = append(orderErrors, fmt.Sprintf("pos %d: got %s, expected %s", i, msgBody, expectedBody))
-			}
-		}
-		So(orderErrors, ShouldBeEmpty)
-
-		// Verify no more messages available
-		ctx2, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-		defer cancel()
-		_, err = sub.Receive(ctx2)
-		So(err, ShouldNotBeNil) // Should timeout
-	})
-}
-
-func TestRapidBatchOrdering(t *testing.T) {
-	Convey("Test rapid batch publishing preserves order", t, func() {
-		testDir, err := os.MkdirTemp("", "filepubsub-batch-order-*")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(testDir)
-
-		topicPath := filepath.Join(testDir, "batch-order-topic")
-		ctx := context.Background()
-
-		topic, err := NewTopic(topicPath)
-		So(err, ShouldBeNil)
-		defer topic.Shutdown(ctx)
-
-		sub, err := NewSubscription(topic, time.Minute)
-		So(err, ShouldBeNil)
-		defer sub.Shutdown(ctx)
-
-		// Publish messages as rapidly as possible without delays
-		totalMessages := 0
-		for batch := 0; batch < 3; batch++ {
-			for i := 0; i < 20; i++ {
-				err = topic.Send(ctx, &pubsub.Message{
-					Body: []byte(fmt.Sprintf("%04d", totalMessages)),
-				})
-				So(err, ShouldBeNil)
-				totalMessages++
-			}
-			// Minimal delay between batches - still rapid
-			time.Sleep(500 * time.Microsecond)
-		}
-
-		// Wait for all files to be written
-		time.Sleep(200 * time.Millisecond)
-
-		// Receive all messages and extract their sequence numbers
-		var received []int
-		for i := 0; i < totalMessages; i++ {
-			msg, err := sub.Receive(ctx)
-			So(err, ShouldBeNil)
-			So(msg, ShouldNotBeNil)
-
-			seqNum := 0
-			_, err = fmt.Sscanf(string(msg.Body), "%d", &seqNum)
-			So(err, ShouldBeNil)
-			received = append(received, seqNum)
-
-			msg.Ack()
-		}
-
-		// Verify strictly sequential ordering
-		So(len(received), ShouldEqual, 60)
-		var orderErrors []string
-		for i, seqNum := range received {
-			if seqNum != i {
-				orderErrors = append(orderErrors, fmt.Sprintf("pos %d: got %d, expected %d", i, seqNum, i))
-			}
-		}
-		So(orderErrors, ShouldBeEmpty)
-
-		// Verify no more messages
-		ctx2, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-		defer cancel()
-		_, err = sub.Receive(ctx2)
+		_, err := pubsub.OpenTopic(ctx, testURLFile+"?invalid=param")
+		So(err, ShouldNotBeNil)
+		_, err = pubsub.OpenTopic(ctx, "file://")
 		So(err, ShouldNotBeNil)
 	})
 }
 
-func TestTopicWithBatchOptions(t *testing.T) {
-	Convey("Test topic creation with custom batch options", t, func() {
-		testDir, err := os.MkdirTemp("", "filepubsub-topic-opts-*")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(testDir)
-
+func TestWithOptions(t *testing.T) {
+	Convey("Test WithOptions functions", t, func() {
+		td, cleanup := tempDir(t, "filepubsub-opts-*")
+		defer cleanup()
 		ctx := context.Background()
 
-		Convey("Should accept custom send batch size", func() {
-			topicOpts := &TopicOptions{
-				BatcherOptions: batcher.Options{
-					MaxBatchSize: 5,
-				},
-			}
-			topic, err := NewTopicWithOptions(testDir, topicOpts)
-			So(err, ShouldBeNil)
-			So(topic, ShouldNotBeNil)
-			defer topic.Shutdown(ctx)
-
-			// Verify topic was created successfully
-			pendingPath := filepath.Join(testDir, pendingDir)
-			_, err = os.Stat(pendingPath)
-			So(err, ShouldBeNil)
-		})
-
-		Convey("Should use defaults when nil options provided", func() {
-			topic, err := NewTopicWithOptions(testDir, nil)
-			So(err, ShouldBeNil)
-			So(topic, ShouldNotBeNil)
-			defer topic.Shutdown(ctx)
-		})
-	})
-}
-
-func TestSubscriptionWithBatchOptions(t *testing.T) {
-	Convey("Test subscription creation with custom batch options", t, func() {
-		testDir, err := os.MkdirTemp("", "filepubsub-sub-opts-*")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(testDir)
-
-		ctx := context.Background()
-
-		topic, err := NewTopic(testDir)
-		So(err, ShouldBeNil)
+		topic, _ := NewTopicWithOptions(td, &TopicOptions{BatcherOptions: batcher.Options{MaxBatchSize: 5}})
 		defer topic.Shutdown(ctx)
-
-		Convey("Should accept custom receive batch size", func() {
-			subOpts := &SubscriptionOptions{
-				ReceiveBatcherOptions: batcher.Options{
-					MaxBatchSize: 10,
-					MaxHandlers:  1, // Keep ordering
-				},
-			}
-			sub, err := NewSubscriptionWithOptions(topic, time.Minute, subOpts)
-			So(err, ShouldBeNil)
-			So(sub, ShouldNotBeNil)
-			defer sub.Shutdown(ctx)
-		})
-
-		Convey("Should use defaults when nil options provided", func() {
-			sub, err := NewSubscriptionWithOptions(topic, time.Minute, nil)
-			So(err, ShouldBeNil)
-			So(sub, ShouldNotBeNil)
-			defer sub.Shutdown(ctx)
-		})
-	})
-}
-
-func TestBatchSizePreservesOrdering(t *testing.T) {
-	Convey("Test that batch size > 1 preserves ordering with MaxHandlers=1", t, func() {
-		testDir, err := os.MkdirTemp("", "filepubsub-batch-ordering-*")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(testDir)
-
-		ctx := context.Background()
-
-		// Create topic with batch size 10
-		topicOpts := &TopicOptions{
-			BatcherOptions: batcher.Options{
-				MaxBatchSize: 10,
-			},
-		}
-		topic, err := NewTopicWithOptions(testDir, topicOpts)
-		So(err, ShouldBeNil)
-		defer topic.Shutdown(ctx)
-
-		// Create subscription with receive batch size 5 but MaxHandlers=1
-		subOpts := &SubscriptionOptions{
-			ReceiveBatcherOptions: batcher.Options{
-				MaxBatchSize: 5,
-				MaxHandlers:  1, // Single handler maintains order
-			},
-		}
-		sub, err := NewSubscriptionWithOptions(topic, time.Minute, subOpts)
-		So(err, ShouldBeNil)
+		sub, _ := NewSubscriptionWithOptions(topic, time.Minute, &SubscriptionOptions{ReceiveBatcherOptions: batcher.Options{MaxBatchSize: 5, MaxHandlers: 1}})
 		defer sub.Shutdown(ctx)
 
-		// Publish 20 messages
-		totalMessages := 20
-		for i := 0; i < totalMessages; i++ {
-			err = topic.Send(ctx, &pubsub.Message{
-				Body: []byte(fmt.Sprintf("%04d", i)),
-			})
-			So(err, ShouldBeNil)
-		}
+		// Nil options use defaults
+		topic2, _ := NewTopicWithOptions(filepath.Join(td, "t2"), nil)
+		defer topic2.Shutdown(ctx)
+		sub2, _ := NewSubscriptionWithOptions(topic2, time.Minute, nil)
+		defer sub2.Shutdown(ctx)
+	})
+}
+func TestDriverMethods(t *testing.T) {
+	Convey("Driver topic and subscription methods", t, func() {
+		td, cleanup := tempDir(t, "fspubsub-drv-*")
+		defer cleanup()
+		ctx := context.Background()
 
-		// Wait for writes
-		time.Sleep(200 * time.Millisecond)
+		psTopic, _ := NewTopic(td)
+		defer psTopic.Shutdown(ctx)
+		var drv *topic
+		psTopic.As(&drv)
 
-		// Receive all messages and verify order
-		var received []int
-		for i := 0; i < totalMessages; i++ {
-			msg, err := sub.Receive(ctx)
-			So(err, ShouldBeNil)
-			So(msg, ShouldNotBeNil)
+		sub := &subscription{topic: drv, ackDeadline: time.Minute, msgs: map[driver.AckID]*message{},
+			newMsgChan: make(chan struct{}, 1), stopWatcher: make(chan struct{}), watcherDone: make(chan struct{})}
+		go func() { <-sub.stopWatcher; close(sub.watcherDone) }()
 
-			seqNum := 0
-			_, err = fmt.Sscanf(string(msg.Body), "%d", &seqNum)
-			So(err, ShouldBeNil)
-			received = append(received, seqNum)
+		// IsRetryable, CanNack
+		So(drv.IsRetryable(errors.New("x")), ShouldBeFalse)
+		So(sub.IsRetryable(errors.New("x")), ShouldBeFalse)
+		So(sub.CanNack(), ShouldBeTrue)
 
-			msg.Ack()
-		}
+		// As
+		var t2 *topic
+		var str string
+		So(drv.As(&t2), ShouldBeTrue)
+		So(drv.As(&str), ShouldBeFalse)
+		So(sub.As(&struct{}{}), ShouldBeFalse)
 
-		// Verify strict ordering maintained despite batching
-		So(len(received), ShouldEqual, totalMessages)
-		for i, seqNum := range received {
-			So(seqNum, ShouldEqual, i)
-		}
+		// ErrorAs
+		So(drv.ErrorAs(errors.New("x"), &str), ShouldBeFalse)
+		So(sub.ErrorAs(errors.New("x"), &str), ShouldBeFalse)
+
+		// ErrorCode - topic
+		So(drv.ErrorCode(ErrTopicNotExist), ShouldEqual, gcerrors.NotFound)
+		So(drv.ErrorCode(ErrTopicClosed), ShouldEqual, gcerrors.NotFound)
+		So(drv.ErrorCode(ErrSubscriptionClosed), ShouldEqual, gcerrors.NotFound)
+		So(drv.ErrorCode(ErrInvalidPath), ShouldEqual, gcerrors.InvalidArgument)
+		So(drv.ErrorCode(ErrInvalidParam), ShouldEqual, gcerrors.InvalidArgument)
+		So(drv.ErrorCode(ErrInvalidAckDeadline), ShouldEqual, gcerrors.InvalidArgument)
+		So(drv.ErrorCode(context.Canceled), ShouldEqual, gcerrors.Canceled)
+		So(drv.ErrorCode(context.DeadlineExceeded), ShouldEqual, gcerrors.DeadlineExceeded)
+		So(drv.ErrorCode(errors.New("x")), ShouldEqual, gcerrors.Unknown)
+
+		// ErrorCode - subscription
+		So(sub.ErrorCode(ErrTopicNotExist), ShouldEqual, gcerrors.NotFound)
+		So(sub.ErrorCode(context.Canceled), ShouldEqual, gcerrors.Canceled)
+		So(sub.ErrorCode(context.DeadlineExceeded), ShouldEqual, gcerrors.DeadlineExceeded)
+
+		// Close
+		So(sub.Close(), ShouldBeNil)
+		So(drv.Close(), ShouldBeNil)
+		So(drv.closed, ShouldBeTrue)
 	})
 }
 
-func TestSendBatchSizeAffectsThroughput(t *testing.T) {
-	Convey("Test that larger send batch reduces filesystem operations", t, func() {
-		testDir, err := os.MkdirTemp("", "filepubsub-batch-throughput-*")
+func TestEdgeCases(t *testing.T) {
+	Convey("Edge cases for Send/Receive/Ack/Nack", t, func() {
+		ctx := context.Background()
+		td, cleanup := tempDir(t, "fspubsub-edge-*")
+		defer cleanup()
+
+		psTopic, _ := NewTopic(td)
+		defer psTopic.Shutdown(ctx)
+		var drv *topic
+		psTopic.As(&drv)
+
+		canceledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		// Nil/closed topic
+		var nilDrv *topic
+		So(nilDrv.SendBatch(ctx, nil), ShouldEqual, ErrTopicNotExist)
+		closedDrv := &topic{basePath: td, closed: true}
+		So(closedDrv.SendBatch(ctx, nil), ShouldEqual, ErrTopicClosed)
+		So(drv.SendBatch(canceledCtx, nil), ShouldEqual, context.Canceled)
+
+		// Nil/closed subscription
+		var nilSub *subscription
+		_, err := nilSub.ReceiveBatch(ctx, 1)
+		So(err, ShouldEqual, ErrTopicNotExist)
+		nilTopicSub := &subscription{topic: nil}
+		_, err = nilTopicSub.ReceiveBatch(ctx, 1)
+		So(err, ShouldEqual, ErrTopicNotExist)
+
+		closedSub := &subscription{topic: drv, closed: true, msgs: map[driver.AckID]*message{},
+			newMsgChan: make(chan struct{}, 1), stopWatcher: make(chan struct{}), watcherDone: make(chan struct{})}
+		go func() { <-closedSub.stopWatcher; close(closedSub.watcherDone) }()
+		_, err = closedSub.ReceiveBatch(ctx, 1)
+		So(err, ShouldEqual, ErrSubscriptionClosed)
+
+		// Ack/Nack with nil topic or canceled ctx
+		So(nilTopicSub.SendAcks(ctx, nil), ShouldEqual, ErrTopicNotExist)
+		So(nilTopicSub.SendNacks(ctx, nil), ShouldEqual, ErrTopicNotExist)
+		validSub := &subscription{topic: drv, msgs: map[driver.AckID]*message{}}
+		So(validSub.SendAcks(canceledCtx, nil), ShouldEqual, context.Canceled)
+		So(validSub.SendNacks(canceledCtx, nil), ShouldEqual, context.Canceled)
+	})
+}
+
+func TestCreationErrors(t *testing.T) {
+	Convey("Creation errors", t, func() {
+		_, err := NewTopic(invalidPath)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "failed to create directory")
+
+		q := &fpubQueue{}
+		_, err = q.OpenURL(context.Background(), mustParseURL("fpub://"+invalidPath+"?name=test"))
+		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestSendBatchErrors(t *testing.T) {
+	Convey("SendBatch errors", t, func() {
+		ctx := context.Background()
+
+		Convey("BeforeSend callback error", func() {
+			td, cleanup := tempDir(t, "fspubsub-send-*")
+			defer cleanup()
+			createTopicDirs(td)
+			drv := &topic{basePath: td}
+
+			expectedErr := errors.New("BeforeSend failed")
+			err := drv.SendBatch(ctx, []*driver.Message{{Body: []byte(testBody), BeforeSend: func(func(any) bool) error { return expectedErr }}})
+			So(err, ShouldEqual, expectedErr)
+		})
+
+		Convey("Write and rename errors", func() {
+			td, cleanup := tempDir(t, "fspubsub-send-*")
+			defer cleanup()
+			createTopicDirs(td)
+
+			// Write error - make tmp readonly
+			os.Chmod(filepath.Join(td, tmpDir), 0o555)
+			drv := &topic{basePath: td}
+			err := drv.SendBatch(ctx, []*driver.Message{{Body: []byte(testBody)}})
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "failed to write temp file")
+			os.Chmod(filepath.Join(td, tmpDir), 0o755)
+
+			// Rename error - make pending readonly
+			os.Chmod(filepath.Join(td, pendingDir), 0o555)
+			err = drv.SendBatch(ctx, []*driver.Message{{Body: []byte(testBody)}})
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "failed to move file to pending")
+			os.Chmod(filepath.Join(td, pendingDir), 0o755)
+		})
+	})
+}
+
+func TestReceiveNoWaitErrors(t *testing.T) {
+	Convey("receiveNoWait error handling", t, func() {
+		td, cleanup := tempDir(t, "fspubsub-recv-*")
+		defer cleanup()
+		ctx := context.Background()
+
+		psTopic, _ := NewTopic(td)
+		defer psTopic.Shutdown(ctx)
+		var drv *topic
+		psTopic.As(&drv)
+		sub := &subscription{topic: drv, ackDeadline: time.Minute, msgs: map[driver.AckID]*message{}}
+
+		// ReadDir error
+		os.RemoveAll(filepath.Join(td, pendingDir))
+		_, err := sub.receiveNoWait(time.Now(), 1)
+		So(err, ShouldNotBeNil)
+		os.MkdirAll(filepath.Join(td, pendingDir), 0o755)
+
+		// Corrupt message deleted
+		os.WriteFile(filepath.Join(td, pendingDir, "00000000000000000001-corrupt.pb"), []byte("bad"), 0o644)
+		msgs, _ := sub.receiveNoWait(time.Now(), 1)
+		So(len(msgs), ShouldEqual, 0)
+
+		// recoverProcessing with missing dir returns nil
+		os.RemoveAll(filepath.Join(td, processingDir))
+		So(sub.recoverProcessing(), ShouldBeNil)
+	})
+}
+
+func TestURLOpenerErrors(t *testing.T) {
+	Convey("URL opener error cases", t, func() {
+		ctx := context.Background()
+
+		// Invalid ack deadline
+		_, err := pubsub.OpenSubscription(ctx, testURLFile+"?ackdeadline=invalid")
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "invalid ackdeadline")
+
+		// Extra invalid params
+		_, err = pubsub.OpenSubscription(ctx, testURLFile+ackDeadline1m+"&badparam=x")
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "invalid query parameter")
+
+		// Canceled context
+		canceledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		opener := &URLOpener{}
+		_, err = opener.OpenTopicURL(canceledCtx, mustParseURL(testURLFile))
+		So(err, ShouldEqual, context.Canceled)
+		_, err = opener.OpenSubscriptionURL(canceledCtx, mustParseURL(testURLFile))
+		So(err, ShouldEqual, context.Canceled)
+
+		// Decode error
+		_, err = decodeMessage([]byte("invalid gob data"))
+		So(err, ShouldNotBeNil)
+	})
+}
+
+// testMessage implements broker.Message for testing
+type testMessage struct {
+	header map[string]string
+	body   []byte
+}
+
+func (m *testMessage) Unmarshal(ctx context.Context, target proto.Message) (context.Context, error) {
+	return ctx, proto.Unmarshal(m.body, target)
+}
+
+func (m *testMessage) RawData() (map[string]string, []byte) {
+	return m.header, m.body
+}
+
+func TestFpubQueuePushRaw(t *testing.T) {
+	Convey("fpubQueue PushRaw", t, func() {
+		td, cleanup := tempDir(t, "fpubqueue-raw-*")
+		defer cleanup()
+		ctx := context.Background()
+		q := &fpubQueue{}
+
+		queue, _ := q.OpenURL(ctx, mustParseURL("fpub://"+td+"?name=raw"))
+		defer queue.Close(ctx)
+
+		received := make(chan broker.Message, 1)
+		queue.Consume(func(ctx context.Context, msgs ...broker.Message) { received <- msgs[0] })
+
+		fq := queue.(*fpubQueue)
+		fq.PushRaw(ctx, &testMessage{header: map[string]string{"k": "v"}, body: []byte("raw")})
+
+		select {
+		case <-received:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout")
+		}
+
+		// After close
+		queue2, _ := q.OpenURL(ctx, mustParseURL("fpub://"+td+"?name=raw2"))
+		fq2 := queue2.(*fpubQueue)
+		queue2.Close(ctx)
+		So(fq2.PushRaw(ctx, &testMessage{body: []byte("x")}), ShouldEqual, errQueueClosed)
+	})
+}
+
+func TestFpubQueueOpenURLWithOptions(t *testing.T) {
+	Convey("Test fpubQueue OpenURL options", t, func() {
+		testDir, err := os.MkdirTemp("", "fpubqueue-opts-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+		ctx := context.Background()
+		q := &fpubQueue{}
+
+		// Valid options
+		queue, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir+"?name=test1&ackdeadline=5m&sendbatchsize=5&recvbatchsize=3"))
+		So(err, ShouldBeNil)
+		queue.Close(ctx)
+
+		// Invalid values fall back to defaults
+		queue, err = q.OpenURL(ctx, mustParseURL("fpub://"+testDir+"?name=test2&ackdeadline=invalid&sendbatchsize=notanumber&recvbatchsize=-1"))
+		So(err, ShouldBeNil)
+		queue.Close(ctx)
+	})
+}
+
+func TestFileHandlingAndRecovery(t *testing.T) {
+	Convey("File handling in receive and recovery", t, func() {
+		td, cleanup := tempDir(t, "fspubsub-fh-*")
+		defer cleanup()
+		ctx := context.Background()
+
+		psTopic, _ := NewTopic(td)
+		defer psTopic.Shutdown(ctx)
+		var drv *topic
+		psTopic.As(&drv)
+		sub := &subscription{topic: drv, ackDeadline: time.Minute, msgs: map[driver.AckID]*message{}}
+
+		// Skips directories and non-.pb files
+		os.MkdirAll(filepath.Join(td, pendingDir, "subdir.pb"), 0o755)
+		os.WriteFile(filepath.Join(td, pendingDir, "notamessage.txt"), []byte("skip"), 0o644)
+		msgs, _ := sub.receiveNoWait(time.Now(), 1)
+		So(len(msgs), ShouldEqual, 0)
+
+		// Expired message redelivery
+		sub.msgs[1] = &message{msg: &driver.Message{Body: []byte("expired"), AckID: 1}, filename: "x.pb", expiration: time.Now().Add(-time.Hour)}
+		msgs, _ = sub.receiveNoWait(time.Now(), 1)
+		So(len(msgs), ShouldEqual, 1)
+		So(string(msgs[0].Body), ShouldEqual, "expired")
+		delete(sub.msgs, 1)
+
+		// recoverProcessing skips non-.pb files
+		procPath := filepath.Join(td, processingDir)
+		os.MkdirAll(filepath.Join(procPath, "subdir.pb"), 0o755)
+		os.WriteFile(filepath.Join(procPath, "skip.txt"), []byte("x"), 0o644)
+		os.WriteFile(filepath.Join(procPath, "valid.pb"), []byte("data"), 0o644)
+		sub.recoverProcessing()
+		pendFiles, _ := os.ReadDir(filepath.Join(td, pendingDir))
+		pbCount := 0
+		for _, f := range pendFiles {
+			if strings.HasSuffix(f.Name(), ".pb") && !f.IsDir() {
+				pbCount++
+			}
+		}
+		So(pbCount, ShouldEqual, 1)
+	})
+}
+
+func TestURLOpenerCachesTopics(t *testing.T) {
+	Convey("URLOpener caches topics", t, func() {
+		tmpDir, err := os.MkdirTemp("", "fspubsub-cache-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(tmpDir)
+
+		ctx := context.Background()
+		opener := &URLOpener{}
+
+		topicPath := filepath.Join(tmpDir, "cached-topic")
+		u := mustParseURL("file://" + topicPath)
+
+		// First open
+		topic1, err := opener.OpenTopicURL(ctx, u)
+		So(err, ShouldBeNil)
+		defer topic1.Shutdown(ctx)
+
+		// Second open - should return same topic
+		topic2, err := opener.OpenTopicURL(ctx, u)
+		So(err, ShouldBeNil)
+
+		// Should be the same instance
+		So(topic1, ShouldEqual, topic2)
+	})
+}
+
+func TestConsumeWithDecodeError(t *testing.T) {
+	Convey("Consume handles decode error", t, func() {
+		testDir, err := os.MkdirTemp("", "fpubqueue-decode-*")
 		So(err, ShouldBeNil)
 		defer os.RemoveAll(testDir)
 
 		ctx := context.Background()
+		q := &fpubQueue{}
+		queue, err := q.OpenURL(ctx, mustParseURL("fpub://"+testDir+"?name=decodetest"))
+		So(err, ShouldBeNil)
+		defer queue.Close(ctx)
 
-		Convey("Small batch size (1)", func() {
-			topicOpts := &TopicOptions{
-				BatcherOptions: batcher.Options{
-					MaxBatchSize: 1,
-				},
-			}
-			topic, err := NewTopicWithOptions(testDir, topicOpts)
-			So(err, ShouldBeNil)
-			defer topic.Shutdown(ctx)
-
-			start := time.Now()
-			for i := 0; i < 100; i++ {
-				err = topic.Send(ctx, &pubsub.Message{
-					Body: []byte(fmt.Sprintf("msg-%d", i)),
-				})
-				So(err, ShouldBeNil)
-			}
-			smallBatchDuration := time.Since(start)
-
-			// Verify all files written
-			pendingPath := filepath.Join(testDir, pendingDir)
-			entries, err := os.ReadDir(pendingPath)
-			So(err, ShouldBeNil)
-			So(len(entries), ShouldEqual, 100)
-
-			t.Logf("Small batch (1): %v for 100 messages", smallBatchDuration)
+		consumed := make(chan struct{}, 1)
+		err = queue.Consume(func(ctx context.Context, msgs ...broker.Message) {
+			consumed <- struct{}{}
 		})
-
-		// Clean up for next test
-		os.RemoveAll(testDir)
-		testDir, err = os.MkdirTemp("", "filepubsub-batch-throughput-*")
 		So(err, ShouldBeNil)
 
-		Convey("Large batch size (20)", func() {
-			topicOpts := &TopicOptions{
-				BatcherOptions: batcher.Options{
-					MaxBatchSize: 20,
-				},
-			}
-			topic, err := NewTopicWithOptions(testDir, topicOpts)
-			So(err, ShouldBeNil)
-			defer topic.Shutdown(ctx)
+		// Write invalid message directly to pending (will fail broker decode)
+		fq := queue.(*fpubQueue)
+		var drv *topic
+		fq.topic.As(&drv)
+		// Valid fspubsub encoding but invalid broker message
+		invalidData, _ := encodeMessage(&driver.Message{Body: []byte("not a valid broker message"), AckID: 1})
+		os.WriteFile(filepath.Join(drv.basePath, pendingDir, "00000000000000000001-bad.pb"), invalidData, 0o644)
 
-			start := time.Now()
-			for i := 0; i < 100; i++ {
-				err = topic.Send(ctx, &pubsub.Message{
-					Body: []byte(fmt.Sprintf("msg-%d", i)),
-				})
-				So(err, ShouldBeNil)
-			}
-			// Force flush
-			topic.Shutdown(ctx)
-			largeBatchDuration := time.Since(start)
+		// Consumer should handle decode error gracefully (ack and continue)
+		time.Sleep(500 * time.Millisecond)
 
-			// Verify all files written
-			pendingPath := filepath.Join(testDir, pendingDir)
-			entries, err := os.ReadDir(pendingPath)
-			So(err, ShouldBeNil)
-			So(len(entries), ShouldEqual, 100)
+		// Push a valid message - should still be consumed
+		err = queue.Push(ctx, &emptypb.Empty{})
+		So(err, ShouldBeNil)
 
-			t.Logf("Large batch (20): %v for 100 messages", largeBatchDuration)
-		})
+		select {
+		case <-consumed:
+			// OK - consumer still working
+		case <-time.After(2 * time.Second):
+			t.Fatal("consumer should still be working after decode error")
+		}
+	})
+}
+
+func TestNewSubscriptionErrors(t *testing.T) {
+	Convey("newSubscription errors", t, func() {
+		td, cleanup := tempDir(t, "fspubsub-sub-err-*")
+		defer cleanup()
+
+		psTopic, _ := NewTopic(td)
+		defer psTopic.Shutdown(context.Background())
+		var drv *topic
+		psTopic.As(&drv)
+
+		// Watcher error - remove pending dir
+		os.RemoveAll(filepath.Join(td, pendingDir))
+		_, err := newSubscription(drv, time.Minute)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "failed to watch directory")
+
+		// Recreate pending and cause recover error
+		os.MkdirAll(filepath.Join(td, pendingDir), 0o755)
+		procPath := filepath.Join(td, processingDir)
+		os.Chmod(procPath, 0o000)
+		defer os.Chmod(procPath, 0o755)
+		_, err = newSubscription(drv, time.Minute)
+		So(err, ShouldNotBeNil)
+
+		// Empty path
+		_, err = pubsub.OpenSubscription(context.Background(), "file://")
+		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestEncodeDecode(t *testing.T) {
+	Convey("encode/decode roundtrip and AsFunc", t, func() {
+		original := &driver.Message{Body: []byte("test"), Metadata: map[string]string{"k": "v"}, AckID: 42}
+		encoded, _ := encodeMessage(original)
+		decoded, _ := decodeMessage(encoded)
+		So(string(decoded.Body), ShouldEqual, "test")
+		So(decoded.Metadata["k"], ShouldEqual, "v")
+		So(decoded.AsFunc("x"), ShouldBeFalse)
+	})
+}
+
+func TestConsumeBehavior(t *testing.T) {
+	Convey("Consume context cancel and retry", t, func() {
+		td, cleanup := tempDir(t, "fpubqueue-consume-*")
+		defer cleanup()
+
+		// Context cancel
+		ctx, cancel := context.WithCancel(context.Background())
+		q := &fpubQueue{}
+		queue, _ := q.OpenURL(ctx, mustParseURL("fpub://"+td+"?name=ctx"))
+		queue.Consume(func(ctx context.Context, msgs ...broker.Message) {})
+		cancel()
+		time.Sleep(100 * time.Millisecond)
+		queue.Close(context.Background())
+
+		// Retry after error
+		ctx2 := context.Background()
+		queue2, _ := q.OpenURL(ctx2, mustParseURL("fpub://"+td+"?name=retry"))
+		defer queue2.Close(ctx2)
+		consumed := make(chan struct{}, 1)
+		queue2.Consume(func(ctx context.Context, msgs ...broker.Message) { consumed <- struct{}{} })
+
+		fq := queue2.(*fpubQueue)
+		var drv *topic
+		fq.topic.As(&drv)
+		pendPath := filepath.Join(drv.basePath, pendingDir)
+		os.RemoveAll(pendPath)
+		time.Sleep(100 * time.Millisecond)
+		os.MkdirAll(pendPath, 0o755)
+		queue2.Push(ctx2, &emptypb.Empty{})
+
+		select {
+		case <-consumed:
+		case <-time.After(3 * time.Second):
+		}
+	})
+}
+
+func TestFpubQueueCloseAndOpenErrors(t *testing.T) {
+	Convey("fpubQueue close idempotent, name, and open errors", t, func() {
+		td, cleanup := tempDir(t, "fpubqueue-close-*")
+		defer cleanup()
+		ctx := context.Background()
+		q := &fpubQueue{}
+
+		queue, _ := q.OpenURL(ctx, mustParseURL("fpub://"+td+"?name=myqueue"))
+		fq := queue.(*fpubQueue)
+		So(fq.name, ShouldEqual, "myqueue")
+		So(queue.Close(ctx), ShouldBeNil)
+		So(queue.Close(ctx), ShouldBeNil)
+
+		// Subscription creation error
+		topicPath := filepath.Join(td, "fpub-suberr")
+		os.MkdirAll(filepath.Join(topicPath, pendingDir), 0o755)
+		os.MkdirAll(filepath.Join(topicPath, processingDir), 0o000)
+		defer os.Chmod(filepath.Join(topicPath, processingDir), 0o755)
+		os.MkdirAll(filepath.Join(topicPath, tmpDir), 0o755)
+		_, err := q.OpenURL(ctx, mustParseURL("fpub://"+td+"?name=suberr"))
+		So(err, ShouldNotBeNil)
 	})
 }

--- a/common/broker/fsqueue/fspubsub_test.go
+++ b/common/broker/fsqueue/fspubsub_test.go
@@ -22,9 +22,11 @@ package filepubsub
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -247,7 +249,7 @@ func TestFpubQueue(t *testing.T) {
 }
 
 func TestRecovery(t *testing.T) {
-	Convey("Test recovery of processing messages", t, func() {
+	Convey("Test recovery of processing messages with ordering", t, func() {
 		testDir, err := os.MkdirTemp("", "filepubsub-recovery-*")
 		So(err, ShouldBeNil)
 		defer os.RemoveAll(testDir)
@@ -255,26 +257,70 @@ func TestRecovery(t *testing.T) {
 		topicPath := filepath.Join(testDir, "recovery-topic")
 		ctx := context.Background()
 
-		// Create topic and send message
+		// Phase 1: Send multiple messages
 		topic, err := NewTopic(topicPath)
 		So(err, ShouldBeNil)
 
-		err = topic.Send(ctx, &pubsub.Message{Body: []byte("recover me")})
-		So(err, ShouldBeNil)
+		messages := []string{"msg1", "msg2", "recover me", "msg4"}
+		for _, msg := range messages {
+			err = topic.Send(ctx, &pubsub.Message{Body: []byte(msg)})
+			So(err, ShouldBeNil)
+			time.Sleep(10 * time.Millisecond) // Ensure different timestamps for ordering
+		}
 
+		// Phase 2: Receive and selectively ack
 		sub, err := NewSubscription(topic, time.Minute)
 		So(err, ShouldBeNil)
 
-		// Receive but don't ack (simulate crash)
-		msg, err := sub.Receive(ctx)
+		// Receive msg1 and ack (should be gone)
+		msg1, err := sub.Receive(ctx)
 		So(err, ShouldBeNil)
-		_ = msg // intentionally not acking
+		So(string(msg1.Body), ShouldEqual, "msg1")
+		msg1.Ack()
 
-		// Shutdown without ack
+		// Receive msg2 and ack (should be gone)
+		msg2, err := sub.Receive(ctx)
+		So(err, ShouldBeNil)
+		So(string(msg2.Body), ShouldEqual, "msg2")
+		msg2.Ack()
+
+		// Receive "recover me" but DON'T ack (simulate crash with in-flight message)
+		msgRecover, err := sub.Receive(ctx)
+		So(err, ShouldBeNil)
+		So(string(msgRecover.Body), ShouldEqual, "recover me")
+		_ = msgRecover // Intentionally NOT acking
+
+		// Receive msg4 and ack (should be gone)
+		msg4, err := sub.Receive(ctx)
+		So(err, ShouldBeNil)
+		So(string(msg4.Body), ShouldEqual, "msg4")
+		msg4.Ack()
+
+		// Phase 3: Verify state before crash
+		// Pending should be empty (all processed)
+		pendingDir := filepath.Join(topicPath, "pending")
+		pendingEntries, _ := os.ReadDir(pendingDir)
+		So(len(pendingEntries), ShouldEqual, 0) // All moved to processing
+
+		// Processing should have "recover me" (unacked)
+		// Phase 3: Verify state before crash
+		processingDir := filepath.Join(topicPath, "processing")
+		procEntries, _ := os.ReadDir(processingDir)
+		So(len(procEntries), ShouldEqual, 1)
+
+		// Optionally verify the file contains "recover me"
+		filePath := filepath.Join(processingDir, procEntries[0].Name())
+		data, err := os.ReadFile(filePath)
+		So(err, ShouldBeNil)
+		msg, err := decodeMessage(data)
+		So(err, ShouldBeNil)
+		So(string(msg.Body), ShouldEqual, "recover me") // ✅ Correct - checks file content
+
+		// Phase 4: Simulate crash - shutdown without acking the last message
 		sub.Shutdown(ctx)
 		topic.Shutdown(ctx)
 
-		// Re-open - should recover stuck message
+		// Phase 5: Recovery - re-open and verify
 		topic2, err := NewTopic(topicPath)
 		So(err, ShouldBeNil)
 		defer topic2.Shutdown(ctx)
@@ -283,10 +329,23 @@ func TestRecovery(t *testing.T) {
 		So(err, ShouldBeNil)
 		defer sub2.Shutdown(ctx)
 
-		msg2, err := sub2.Receive(ctx)
+		// Should recover "recover me" (was in processing, moved back to pending)
+		recoveredMsg, err := sub2.Receive(ctx)
 		So(err, ShouldBeNil)
-		So(string(msg2.Body), ShouldEqual, "recover me")
-		msg2.Ack()
+		So(string(recoveredMsg.Body), ShouldEqual, "recover me")
+		recoveredMsg.Ack()
+
+		// Should NOT receive msg1, msg2, or msg4 (they were acked)
+		ctx2, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+
+		extraMsg, err := sub2.Receive(ctx2)
+		So(err, ShouldNotBeNil) // Timeout or cancelled
+		So(extraMsg, ShouldBeNil)
+
+		// Verify processing dir is now clean
+		procEntries2, _ := os.ReadDir(processingDir)
+		So(len(procEntries2), ShouldEqual, 0)
 	})
 }
 
@@ -327,5 +386,234 @@ func TestErrorCases(t *testing.T) {
 			_, err := pubsub.OpenTopic(ctx, "file://")
 			So(err, ShouldNotBeNil)
 		})
+	})
+}
+func TestFuzzyOrderingWithFolderStructure(t *testing.T) {
+	Convey("Test ordering with deep folder structure and many messages", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-fuzzy-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		// Create 3-layer deep folder structure with various files
+		deepPath := filepath.Join(testDir, "layer1", "layer2", "layer3")
+		os.MkdirAll(deepPath, 0o755)
+
+		// Add some noise/junk files in the structure
+		os.WriteFile(filepath.Join(testDir, "layer1", "junk.txt"), []byte("noise"), 0o644)
+		os.WriteFile(filepath.Join(testDir, "layer1", "layer2", ".hidden"), []byte("hidden"), 0o644)
+		os.WriteFile(filepath.Join(testDir, "layer1", "layer2", "layer3", "readme.md"), []byte("readme"), 0o644)
+
+		// Create topic in deep folder
+		topicPath := filepath.Join(deepPath, "topic")
+		ctx := context.Background()
+
+		topic, err := NewTopic(topicPath)
+		So(err, ShouldBeNil)
+		defer topic.Shutdown(ctx)
+
+		// Phase 1: Send many messages rapidly with various payload sizes
+		// TODO configure
+		numMessages := 20
+		expectedBodies := make([]string, numMessages)
+
+		for i := 0; i < numMessages; i++ {
+			payload := fmt.Sprintf("msg-%05d-payload-with-longer-content-for-variety-%s",
+				i, strings.Repeat("x", i%100))
+			expectedBodies[i] = payload
+
+			err = topic.Send(ctx, &pubsub.Message{Body: []byte(payload)})
+			So(err, ShouldBeNil)
+
+			// Vary timing slightly to test timestamp handling
+			if i%5 == 0 {
+				time.Sleep(1 * time.Millisecond)
+			}
+		}
+
+		// Verify pending directory state
+		pendingDir := filepath.Join(topicPath, pendingDir)
+		pendingFiles, err := os.ReadDir(pendingDir)
+		So(err, ShouldBeNil)
+		So(len(pendingFiles), ShouldEqual, numMessages)
+
+		// Phase 2: Create subscription and receive in order
+		sub, err := NewSubscription(topic, time.Minute)
+		So(err, ShouldBeNil)
+		defer sub.Shutdown(ctx)
+
+		receivedBodies := make([]string, 0, numMessages)
+
+		for i := 0; i < numMessages; i++ {
+			msg, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(msg, ShouldNotBeNil)
+
+			body := string(msg.Body)
+			receivedBodies = append(receivedBodies, body)
+			msg.Ack()
+
+			// Verify processing directory has exactly 1 file at a time (due to batcher)
+			procDir := filepath.Join(topicPath, processingDir)
+			procFiles, _ := os.ReadDir(procDir)
+			So(len(procFiles), ShouldBeLessThanOrEqualTo, 1) // Can be 0 if already cleaned
+		}
+
+		// Phase 3: Assert ordering matches send order
+		So(len(receivedBodies), ShouldEqual, numMessages)
+		var orderErrors []string
+		for i := 0; i < numMessages; i++ {
+			if receivedBodies[i] != expectedBodies[i] {
+				orderErrors = append(orderErrors, fmt.Sprintf("pos %d: got %s, expected %s", i, receivedBodies[i], expectedBodies[i]))
+			}
+		}
+		So(orderErrors, ShouldBeEmpty)
+
+		// Phase 4: Verify pending/processing directories are now clean
+		pendingFiles, _ = os.ReadDir(pendingDir)
+		So(len(pendingFiles), ShouldEqual, 0)
+
+		procFiles, _ := os.ReadDir(filepath.Join(topicPath, processingDir))
+		So(len(procFiles), ShouldEqual, 0)
+
+		// Phase 5: Verify no extra messages are available
+		ctx2, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+		defer cancel()
+
+		extraMsg, err := sub.Receive(ctx2)
+		So(err, ShouldNotBeNil) // Should timeout
+		So(extraMsg, ShouldBeNil)
+
+		// Phase 6: Verify original junk files still exist (not affected by topic)
+		layer1Junk, err := os.ReadFile(filepath.Join(testDir, "layer1", "junk.txt"))
+		So(err, ShouldBeNil)
+		So(string(layer1Junk), ShouldEqual, "noise")
+
+		layer2Hidden, err := os.ReadFile(filepath.Join(testDir, "layer1", "layer2", ".hidden"))
+		So(err, ShouldBeNil)
+		So(string(layer2Hidden), ShouldEqual, "hidden")
+	})
+}
+
+func TestWatcherOrderPreservation(t *testing.T) {
+	Convey("Test watcher preserves order on rapid batch publish", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-watcher-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		topicPath := filepath.Join(testDir, "watcher-topic")
+		ctx := context.Background()
+
+		// Create topic and subscription
+		topic, err := NewTopic(topicPath)
+		So(err, ShouldBeNil)
+		defer topic.Shutdown(ctx)
+
+		sub, err := NewSubscription(topic, time.Minute)
+		So(err, ShouldBeNil)
+		defer sub.Shutdown(ctx)
+
+		// Rapidly publish many messages (not as batch, but rapid individual sends)
+		for i := 0; i < 50; i++ {
+			err = topic.Send(ctx, &pubsub.Message{Body: []byte(fmt.Sprintf("msg-%03d", i))})
+			So(err, ShouldBeNil)
+		}
+
+		// Wait briefly for watcher to fire
+		time.Sleep(100 * time.Millisecond)
+
+		// Receive messages and verify ordering
+		var received []string
+		for i := 0; i < 50; i++ {
+			msg, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(msg, ShouldNotBeNil)
+
+			received = append(received, string(msg.Body))
+			msg.Ack()
+		}
+
+		// Verify all messages received in order
+		So(len(received), ShouldEqual, 50)
+		var orderErrors []string
+		for i, msgBody := range received {
+			expectedBody := fmt.Sprintf("msg-%03d", i)
+			if msgBody != expectedBody {
+				orderErrors = append(orderErrors, fmt.Sprintf("pos %d: got %s, expected %s", i, msgBody, expectedBody))
+			}
+		}
+		So(orderErrors, ShouldBeEmpty)
+
+		// Verify no more messages available
+		ctx2, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+		_, err = sub.Receive(ctx2)
+		So(err, ShouldNotBeNil) // Should timeout
+	})
+}
+
+func TestRapidBatchOrdering(t *testing.T) {
+	Convey("Test rapid batch publishing preserves order", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-batch-order-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		topicPath := filepath.Join(testDir, "batch-order-topic")
+		ctx := context.Background()
+
+		topic, err := NewTopic(topicPath)
+		So(err, ShouldBeNil)
+		defer topic.Shutdown(ctx)
+
+		sub, err := NewSubscription(topic, time.Minute)
+		So(err, ShouldBeNil)
+		defer sub.Shutdown(ctx)
+
+		// Publish messages as rapidly as possible without delays
+		totalMessages := 0
+		for batch := 0; batch < 3; batch++ {
+			for i := 0; i < 20; i++ {
+				err = topic.Send(ctx, &pubsub.Message{
+					Body: []byte(fmt.Sprintf("%04d", totalMessages)),
+				})
+				So(err, ShouldBeNil)
+				totalMessages++
+			}
+			// Minimal delay between batches - still rapid
+			time.Sleep(500 * time.Microsecond)
+		}
+
+		// Wait for all files to be written
+		time.Sleep(200 * time.Millisecond)
+
+		// Receive all messages and extract their sequence numbers
+		var received []int
+		for i := 0; i < totalMessages; i++ {
+			msg, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(msg, ShouldNotBeNil)
+
+			seqNum := 0
+			_, err = fmt.Sscanf(string(msg.Body), "%d", &seqNum)
+			So(err, ShouldBeNil)
+			received = append(received, seqNum)
+
+			msg.Ack()
+		}
+
+		// Verify strictly sequential ordering
+		So(len(received), ShouldEqual, 60)
+		var orderErrors []string
+		for i, seqNum := range received {
+			if seqNum != i {
+				orderErrors = append(orderErrors, fmt.Sprintf("pos %d: got %d, expected %d", i, seqNum, i))
+			}
+		}
+		So(orderErrors, ShouldBeEmpty)
+
+		// Verify no more messages
+		ctx2, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+		_, err = sub.Receive(ctx2)
+		So(err, ShouldNotBeNil)
 	})
 }

--- a/common/broker/fsqueue/fspubsub_test.go
+++ b/common/broker/fsqueue/fspubsub_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"gocloud.dev/pubsub"
+	"gocloud.dev/pubsub/batcher"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/pydio/cells/v5/common/broker"
@@ -615,5 +616,210 @@ func TestRapidBatchOrdering(t *testing.T) {
 		defer cancel()
 		_, err = sub.Receive(ctx2)
 		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestTopicWithBatchOptions(t *testing.T) {
+	Convey("Test topic creation with custom batch options", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-topic-opts-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		ctx := context.Background()
+
+		Convey("Should accept custom send batch size", func() {
+			topicOpts := &TopicOptions{
+				BatcherOptions: batcher.Options{
+					MaxBatchSize: 5,
+				},
+			}
+			topic, err := NewTopicWithOptions(testDir, topicOpts)
+			So(err, ShouldBeNil)
+			So(topic, ShouldNotBeNil)
+			defer topic.Shutdown(ctx)
+
+			// Verify topic was created successfully
+			pendingPath := filepath.Join(testDir, pendingDir)
+			_, err = os.Stat(pendingPath)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Should use defaults when nil options provided", func() {
+			topic, err := NewTopicWithOptions(testDir, nil)
+			So(err, ShouldBeNil)
+			So(topic, ShouldNotBeNil)
+			defer topic.Shutdown(ctx)
+		})
+	})
+}
+
+func TestSubscriptionWithBatchOptions(t *testing.T) {
+	Convey("Test subscription creation with custom batch options", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-sub-opts-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		ctx := context.Background()
+
+		topic, err := NewTopic(testDir)
+		So(err, ShouldBeNil)
+		defer topic.Shutdown(ctx)
+
+		Convey("Should accept custom receive batch size", func() {
+			subOpts := &SubscriptionOptions{
+				ReceiveBatcherOptions: batcher.Options{
+					MaxBatchSize: 10,
+					MaxHandlers:  1, // Keep ordering
+				},
+			}
+			sub, err := NewSubscriptionWithOptions(topic, time.Minute, subOpts)
+			So(err, ShouldBeNil)
+			So(sub, ShouldNotBeNil)
+			defer sub.Shutdown(ctx)
+		})
+
+		Convey("Should use defaults when nil options provided", func() {
+			sub, err := NewSubscriptionWithOptions(topic, time.Minute, nil)
+			So(err, ShouldBeNil)
+			So(sub, ShouldNotBeNil)
+			defer sub.Shutdown(ctx)
+		})
+	})
+}
+
+func TestBatchSizePreservesOrdering(t *testing.T) {
+	Convey("Test that batch size > 1 preserves ordering with MaxHandlers=1", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-batch-ordering-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		ctx := context.Background()
+
+		// Create topic with batch size 10
+		topicOpts := &TopicOptions{
+			BatcherOptions: batcher.Options{
+				MaxBatchSize: 10,
+			},
+		}
+		topic, err := NewTopicWithOptions(testDir, topicOpts)
+		So(err, ShouldBeNil)
+		defer topic.Shutdown(ctx)
+
+		// Create subscription with receive batch size 5 but MaxHandlers=1
+		subOpts := &SubscriptionOptions{
+			ReceiveBatcherOptions: batcher.Options{
+				MaxBatchSize: 5,
+				MaxHandlers:  1, // Single handler maintains order
+			},
+		}
+		sub, err := NewSubscriptionWithOptions(topic, time.Minute, subOpts)
+		So(err, ShouldBeNil)
+		defer sub.Shutdown(ctx)
+
+		// Publish 20 messages
+		totalMessages := 20
+		for i := 0; i < totalMessages; i++ {
+			err = topic.Send(ctx, &pubsub.Message{
+				Body: []byte(fmt.Sprintf("%04d", i)),
+			})
+			So(err, ShouldBeNil)
+		}
+
+		// Wait for writes
+		time.Sleep(200 * time.Millisecond)
+
+		// Receive all messages and verify order
+		var received []int
+		for i := 0; i < totalMessages; i++ {
+			msg, err := sub.Receive(ctx)
+			So(err, ShouldBeNil)
+			So(msg, ShouldNotBeNil)
+
+			seqNum := 0
+			_, err = fmt.Sscanf(string(msg.Body), "%d", &seqNum)
+			So(err, ShouldBeNil)
+			received = append(received, seqNum)
+
+			msg.Ack()
+		}
+
+		// Verify strict ordering maintained despite batching
+		So(len(received), ShouldEqual, totalMessages)
+		for i, seqNum := range received {
+			So(seqNum, ShouldEqual, i)
+		}
+	})
+}
+
+func TestSendBatchSizeAffectsThroughput(t *testing.T) {
+	Convey("Test that larger send batch reduces filesystem operations", t, func() {
+		testDir, err := os.MkdirTemp("", "filepubsub-batch-throughput-*")
+		So(err, ShouldBeNil)
+		defer os.RemoveAll(testDir)
+
+		ctx := context.Background()
+
+		Convey("Small batch size (1)", func() {
+			topicOpts := &TopicOptions{
+				BatcherOptions: batcher.Options{
+					MaxBatchSize: 1,
+				},
+			}
+			topic, err := NewTopicWithOptions(testDir, topicOpts)
+			So(err, ShouldBeNil)
+			defer topic.Shutdown(ctx)
+
+			start := time.Now()
+			for i := 0; i < 100; i++ {
+				err = topic.Send(ctx, &pubsub.Message{
+					Body: []byte(fmt.Sprintf("msg-%d", i)),
+				})
+				So(err, ShouldBeNil)
+			}
+			smallBatchDuration := time.Since(start)
+
+			// Verify all files written
+			pendingPath := filepath.Join(testDir, pendingDir)
+			entries, err := os.ReadDir(pendingPath)
+			So(err, ShouldBeNil)
+			So(len(entries), ShouldEqual, 100)
+
+			t.Logf("Small batch (1): %v for 100 messages", smallBatchDuration)
+		})
+
+		// Clean up for next test
+		os.RemoveAll(testDir)
+		testDir, err = os.MkdirTemp("", "filepubsub-batch-throughput-*")
+		So(err, ShouldBeNil)
+
+		Convey("Large batch size (20)", func() {
+			topicOpts := &TopicOptions{
+				BatcherOptions: batcher.Options{
+					MaxBatchSize: 20,
+				},
+			}
+			topic, err := NewTopicWithOptions(testDir, topicOpts)
+			So(err, ShouldBeNil)
+			defer topic.Shutdown(ctx)
+
+			start := time.Now()
+			for i := 0; i < 100; i++ {
+				err = topic.Send(ctx, &pubsub.Message{
+					Body: []byte(fmt.Sprintf("msg-%d", i)),
+				})
+				So(err, ShouldBeNil)
+			}
+			// Force flush
+			topic.Shutdown(ctx)
+			largeBatchDuration := time.Since(start)
+
+			// Verify all files written
+			pendingPath := filepath.Join(testDir, pendingDir)
+			entries, err := os.ReadDir(pendingPath)
+			So(err, ShouldBeNil)
+			So(len(entries), ShouldEqual, 100)
+
+			t.Logf("Large batch (20): %v for 100 messages", largeBatchDuration)
+		})
 	})
 }

--- a/common/storage/indexer/batch.go
+++ b/common/storage/indexer/batch.go
@@ -135,6 +135,7 @@ type batch struct {
 }
 
 func (b *batch) watchInserts() {
+outer:
 	for {
 		select {
 		case msg, open := <-b.inserts:
@@ -142,11 +143,12 @@ func (b *batch) watchInserts() {
 				continue
 			}
 			b.flushLock.Lock()
+
 			for _, f := range b.opts.InsertCallback {
 				if err := f(msg); err != nil {
 					b.opts.ErrorHandler(err)
 					b.flushLock.Unlock()
-					continue
+					continue outer
 				}
 			}
 
@@ -159,13 +161,14 @@ func (b *batch) watchInserts() {
 		case msg, open := <-b.deletes:
 			if !open {
 				continue
+
 			}
 			b.flushLock.Lock()
 			for _, f := range b.opts.DeleteCallback {
 				if err := f(msg); err != nil {
 					b.opts.ErrorHandler(err)
 					b.flushLock.Unlock()
-					continue
+					continue outer
 				}
 			}
 

--- a/main.go
+++ b/main.go
@@ -8,13 +8,16 @@ import (
 	_ "github.com/pydio/cells/v5/common/telemetry/log/otlp"
 	_ "github.com/pydio/cells/v5/common/telemetry/log/service"
 	_ "github.com/pydio/cells/v5/common/telemetry/log/stdout"
+
 	// Tracing
 	_ "github.com/pydio/cells/v5/common/telemetry/tracing/jaeger"
 	_ "github.com/pydio/cells/v5/common/telemetry/tracing/otlp"
 	_ "github.com/pydio/cells/v5/common/telemetry/tracing/stdout"
+
 	// Metrics
 	_ "github.com/pydio/cells/v5/common/telemetry/metrics/otlp"
 	_ "github.com/pydio/cells/v5/common/telemetry/metrics/prometheus"
+
 	// Profiling
 	_ "github.com/pydio/cells/v5/common/telemetry/profile/http_pull"
 	_ "github.com/pydio/cells/v5/common/telemetry/profile/pyroscope"
@@ -104,6 +107,7 @@ import (
 
 	// Cache
 	_ "github.com/pydio/cells/v5/common/broker/debounce"
+	_ "github.com/pydio/cells/v5/common/broker/fsqueue"
 	_ "github.com/pydio/cells/v5/common/broker/goque"
 	_ "github.com/pydio/cells/v5/common/broker/jetstream"
 	_ "github.com/pydio/cells/v5/common/utils/cache/bigcache"
@@ -174,6 +178,7 @@ import (
 	_ "github.com/pydio/cells/v5/common/broker/grpcpubsub"
 	_ "github.com/pydio/cells/v5/common/broker/nats"
 	_ "gocloud.dev/pubsub/mempubsub"
+
 	// _ "gocloud.dev/pubsub/natspubsub"
 	_ "gocloud.dev/pubsub/rabbitpubsub"
 
@@ -182,6 +187,7 @@ import (
 	_ "github.com/pydio/cells/v5/common/config/file"
 	_ "github.com/pydio/cells/v5/common/config/memory"
 	_ "github.com/pydio/cells/v5/common/config/vault"
+
 	// _ "github.com/pydio/cells/v5/common/config/sql"
 	//_ "github.com/pydio/cells/v5/common/config/viper"
 

--- a/main.go
+++ b/main.go
@@ -9,13 +9,16 @@ import (
 	_ "github.com/pydio/cells/v5/common/telemetry/log/otlp"
 	_ "github.com/pydio/cells/v5/common/telemetry/log/service"
 	_ "github.com/pydio/cells/v5/common/telemetry/log/stdout"
+
 	// Tracing
 	_ "github.com/pydio/cells/v5/common/telemetry/tracing/jaeger"
 	_ "github.com/pydio/cells/v5/common/telemetry/tracing/otlp"
 	_ "github.com/pydio/cells/v5/common/telemetry/tracing/stdout"
+
 	// Metrics
 	_ "github.com/pydio/cells/v5/common/telemetry/metrics/otlp"
 	_ "github.com/pydio/cells/v5/common/telemetry/metrics/prometheus"
+
 	// Profiling
 	_ "github.com/pydio/cells/v5/common/telemetry/profile/http_pull"
 	_ "github.com/pydio/cells/v5/common/telemetry/profile/pyroscope"
@@ -105,6 +108,7 @@ import (
 
 	// Cache
 	_ "github.com/pydio/cells/v5/common/broker/debounce"
+	_ "github.com/pydio/cells/v5/common/broker/fsqueue"
 	_ "github.com/pydio/cells/v5/common/broker/goque"
 	_ "github.com/pydio/cells/v5/common/broker/jetstream"
 	_ "github.com/pydio/cells/v5/common/utils/cache/bigcache"
@@ -175,6 +179,7 @@ import (
 	_ "github.com/pydio/cells/v5/common/broker/grpcpubsub"
 	_ "github.com/pydio/cells/v5/common/broker/nats"
 	_ "gocloud.dev/pubsub/mempubsub"
+
 	// _ "gocloud.dev/pubsub/natspubsub"
 	_ "gocloud.dev/pubsub/rabbitpubsub"
 
@@ -183,6 +188,7 @@ import (
 	_ "github.com/pydio/cells/v5/common/config/file"
 	_ "github.com/pydio/cells/v5/common/config/memory"
 	_ "github.com/pydio/cells/v5/common/config/vault"
+
 	// _ "github.com/pydio/cells/v5/common/config/sql"
 	//_ "github.com/pydio/cells/v5/common/config/viper"
 


### PR DESCRIPTION
- Implement pubsub for file system pb events
- Implement Async queue wrapper for Publish & Consume sync endpoints
- Unit test
- Remove redundant timestamp from filenames
  - Filenames: %020d-%s.pb (AckID-UUID)
- AckID is monotonically increasing and works for strict FIFO
- Lexicographic sort on filenames = chronological order
-  Batch publish and subscribe number of messages

Order is preserved via:
1. SendBatch assigns sequential AckIDs
2. receiveNoWait() sorts by filename lexicographically
4. Unacked messages recovered to pending on restart

[ticket](https://wearezeta.atlassian.net/browse/WPB-24031)

Coverage report:

PASS
```
coverage: 95.4% of statements
ok      github.com/pydio/cells/v5/common/broker/fsqueue 5.003s
github.com/pydio/cells/v5/common/broker/fsqueue/adapter.go:83:          OpenURL                         92.6%
github.com/pydio/cells/v5/common/broker/fsqueue/adapter.go:185:         Consume                         92.9%
github.com/pydio/cells/v5/common/broker/fsqueue/adapter.go:242:         Close                           82.4%
github.com/pydio/cells/v5/common/broker/fsqueue/fspubsub.go:120:        OpenTopicURL                    95.0%
github.com/pydio/cells/v5/common/broker/fsqueue/fspubsub.go:152:        OpenSubscriptionURL             92.6%
github.com/pydio/cells/v5/common/broker/fsqueue/fspubsub.go:232:        SendBatch                       92.3%
github.com/pydio/cells/v5/common/broker/fsqueue/fspubsub.go:374:        NewSubscriptionWithOptions      88.9%
github.com/pydio/cells/v5/common/broker/fsqueue/fspubsub.go:487:        receiveNoWait                   91.9%
github.com/pydio/cells/v5/common/broker/fsqueue/fspubsub.go:694:        ErrorCode                       83.3%
github.com/pydio/cells/v5/common/broker/fsqueue/fspubsub.go:717:        encodeMessage                   83.3%
total:                                                                  (statements)                    95.4%
```