### PR TITLE
fix(namespace) Default namespace read policy logic

### DIFF
--- a/idm/policy/dao/sql/upgrades_test.go
+++ b/idm/policy/dao/sql/upgrades_test.go
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2018. Abstrium SAS <team (at) pydio.com>
+ * This file is part of Pydio Cells.
+ *
+ * Pydio Cells is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio Cells is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pydio/cells/v5/common/proto/idm"
+	"github.com/pydio/cells/v5/common/runtime/manager"
+	"github.com/pydio/cells/v5/common/storage/test"
+	"github.com/pydio/cells/v5/idm/policy"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	upgradeCases = test.TemplateSQL(NewDAO)
+)
+
+// TestUpgrade4993 tests the Upgrade4993 migration which adds namespace resources
+// to the user-meta-read policy for the rest-apis-default-accesses group.
+// Follows the same test infrastructure pattern as Test() in sql_test.go.
+//
+// Run with: go test -v --tags=storage ./idm/policy/dao/sql/... -run TestUpgrade4993
+func TestUpgrade4993(t *testing.T) {
+	test.RunStorageTests(upgradeCases, t, func(ctx context.Context) {
+
+		dao, err := manager.Resolve[policy.DAO](ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		Convey("Upgrade4993 namespace resource migration", t, func() {
+
+			createGroup := func(uuid, policyID string, resources []string) *idm.PolicyGroup {
+				return &idm.PolicyGroup{
+					Uuid: uuid,
+					Policies: []*idm.Policy{{
+						ID:        policyID,
+						Resources: resources,
+					}},
+				}
+			}
+
+			findGroup := func(uuid string) *idm.PolicyGroup {
+				groups, _ := dao.ListPolicyGroups(ctx, nil)
+				for _, g := range groups {
+					if g.Uuid == uuid {
+						return g
+					}
+				}
+				return nil
+			}
+
+			Convey("Adds missing namespace resources", func() {
+				g := createGroup("rest-apis-default-accesses", "user-meta-read", []string{"rest:/user-meta"})
+				_, err := dao.StorePolicyGroup(ctx, g)
+				So(err, ShouldBeNil)
+
+				err = policy.Upgrade4993(ctx)
+				So(err, ShouldBeNil)
+
+				group := findGroup("rest-apis-default-accesses")
+				So(group, ShouldNotBeNil)
+				So(len(group.Policies[0].Resources), ShouldEqual, 3)
+				So(group.Policies[0].Resources, ShouldContain, "rest:/user-meta/namespace")
+				So(group.Policies[0].Resources, ShouldContain, "rest:/user-meta/namespace/<.+>")
+			})
+
+			Convey("Is idempotent", func() {
+				g := createGroup("rest-apis-default-accesses", "user-meta-read",
+					[]string{"rest:/user-meta", "rest:/user-meta/namespace", "rest:/user-meta/namespace/<.+>"})
+				_, err := dao.StorePolicyGroup(ctx, g)
+				So(err, ShouldBeNil)
+
+				err = policy.Upgrade4993(ctx)
+				So(err, ShouldBeNil)
+
+				group := findGroup("rest-apis-default-accesses")
+				So(len(group.Policies[0].Resources), ShouldEqual, 3)
+			})
+
+			Convey("Adds one missing resource when namespace exists", func() {
+				g := createGroup("rest-apis-default-accesses", "user-meta-read", []string{"rest:/user-meta/namespace"})
+				_, err := dao.StorePolicyGroup(ctx, g)
+				So(err, ShouldBeNil)
+
+				err = policy.Upgrade4993(ctx)
+				So(err, ShouldBeNil)
+
+				group := findGroup("rest-apis-default-accesses")
+				So(len(group.Policies[0].Resources), ShouldEqual, 2)
+				So(group.Policies[0].Resources, ShouldContain, "rest:/user-meta/namespace/<.+>")
+			})
+
+			Convey("Skips non-matching groups", func() {
+				_, err := dao.StorePolicyGroup(ctx, createGroup("other-group", "other-policy", []string{}))
+				So(err, ShouldBeNil)
+
+				g := createGroup("rest-apis-default-accesses", "user-meta-read", []string{"rest:/user-meta"})
+				_, err = dao.StorePolicyGroup(ctx, g)
+				So(err, ShouldBeNil)
+
+				err = policy.Upgrade4993(ctx)
+				So(err, ShouldBeNil)
+
+				other := findGroup("other-group")
+				So(len(other.Policies[0].Resources), ShouldEqual, 0)
+
+				target := findGroup("rest-apis-default-accesses")
+				So(len(target.Policies[0].Resources), ShouldEqual, 3)
+			})
+		})
+	})
+}
+
+func TestUpgrade4993ResolveError(t *testing.T) {
+	Convey("Returns error when DAO not in context", t, func() {
+		err := policy.Upgrade4993(context.Background())
+		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestUpgrade4993ListError(t *testing.T) {
+	test.RunStorageTests(upgradeCases, t, func(ctx context.Context) {
+		dao, err := manager.Resolve[policy.DAO](ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		Convey("Returns error when policy table is missing", t, func() {
+			impl := dao.(*sqlimpl)
+			So(impl.DB.Migrator().DropTable(&idm.PolicyGroup{}), ShouldBeNil)
+
+			err := policy.Upgrade4993(ctx)
+			So(err, ShouldNotBeNil)
+		})
+	})
+}

--- a/idm/policy/defaults.go
+++ b/idm/policy/defaults.go
@@ -759,7 +759,8 @@ func Upgrade4993(ctx context.Context) error {
 				if p.GetID() == "user-meta-read" {
 					if !slices.Contains(p.Resources, "rest:/user-meta/namespace") {
 						p.Resources = append(p.Resources, "rest:/user-meta/namespace")
-					} else if !slices.Contains(p.Resources, "rest:/user-meta/namespace/<.+>") {
+					}
+					if !slices.Contains(p.Resources, "rest:/user-meta/namespace/<.+>") {
 						p.Resources = append(p.Resources, "rest:/user-meta/namespace/<.+>")
 					}
 				}


### PR DESCRIPTION
### Changes
- Remove buggy else
- Should create default read policy for use-meta/namespace/</+> resource to prevent basic user from automatic logout
- Implement test for policy migration function
- Use test.RunStorageTests pattern
- Cover 4 scenarios: add missing resources, idempotency, partial resources, skip non-matching groups
- Add error path tests: missing DAO in context, missing policy table


### Tests with Coverage:
`CELLS_TEST_SKIP_SQLITE=true CELLS_TEST_MYSQL_DSN="mysql-dsn" go test -v -tags=storage -
coverprofile=coverage.out -coverpkg=./idm/policy ./idm/policy/dao/sql/... -run "TestUpgrade4993"`

### Coverage:
- `github.com/pydio/cells/v5/idm/policy/defaults.go:747:   Upgrade4993     94.7%` 
- Coverage Report: [coverage.html](https://github.com/user-attachments/files/26823042/coverage.html)
