### PR TITLE
fix: WPB-23974 Restrict /frontend/enroll access for shared link users 

### DIFF
--- a/idm/policy/defaults.go
+++ b/idm/policy/defaults.go
@@ -854,17 +854,21 @@ func splitFrontendPostPolicies(policies []*idm.Policy) ([]*idm.Policy, bool) {
 // - "frontend-post" for profile:standard (unchanged, backward compatible name)
 // - "frontend-post-shared" for profile:shared (excludes /frontend/enroll)
 func Upgrade4994(ctx context.Context) error {
-	dao, er := manager.Resolve[DAO](ctx)
-	if er != nil {
-		return er
+	const targetGroupUUID = "rest-apis-default-accesses"
+
+	dao, err := manager.Resolve[DAO](ctx)
+	if err != nil {
+		return err
 	}
-	groups, e := dao.ListPolicyGroups(ctx, nil)
-	if e != nil {
-		return e
+
+	groups, err := dao.ListPolicyGroups(ctx, nil)
+	if err != nil {
+		return err
 	}
+
 	log.Logger(ctx).Info(fmt.Sprintf("Upgrade4994: scanning %d policy groups", len(groups)))
 	for _, group := range groups {
-		if group.GetUuid() != "rest-apis-default-accesses" {
+		if group.GetUuid() != targetGroupUUID {
 			continue
 		}
 
@@ -882,8 +886,8 @@ func Upgrade4994(ctx context.Context) error {
 		}
 
 		group.Policies = newPolicies
-		if _, er := dao.StorePolicyGroup(ctx, group); er != nil {
-			log.Logger(ctx).Error("Upgrade4994: could not update policy group "+group.GetUuid(), zap.Error(er))
+		if _, err = dao.StorePolicyGroup(ctx, group); err != nil {
+			log.Logger(ctx).Error("Upgrade4994: could not update policy group "+group.GetUuid(), zap.Error(err))
 			continue
 		}
 

--- a/idm/policy/defaults.go
+++ b/idm/policy/defaults.go
@@ -22,6 +22,7 @@ package policy
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -799,6 +800,9 @@ func splitFrontendPostPolicies(policies []*idm.Policy) ([]*idm.Policy, bool) {
 			for _, s := range p.OrmSubjects {
 				hasSubjects[s.Template] = true
 			}
+			for _, s := range p.Subjects {
+				hasSubjects[s] = true
+			}
 
 			// If it has both profiles, it's the old unified policy - replace it
 			if hasSubjects["profile:standard"] && hasSubjects["profile:shared"] {
@@ -849,7 +853,7 @@ func splitFrontendPostPolicies(policies []*idm.Policy) ([]*idm.Policy, bool) {
 // The old unified "frontend-post" policy (profile:standard + profile:shared) is replaced with two:
 // - "frontend-post" for profile:standard (unchanged, backward compatible name)
 // - "frontend-post-shared" for profile:shared (excludes /frontend/enroll)
-func Upgrade5000(ctx context.Context) error {
+func Upgrade4994(ctx context.Context) error {
 	dao, er := manager.Resolve[DAO](ctx)
 	if er != nil {
 		return er
@@ -858,18 +862,28 @@ func Upgrade5000(ctx context.Context) error {
 	if e != nil {
 		return e
 	}
+	log.Logger(ctx).Info(fmt.Sprintf("Upgrade4994: scanning %d policy groups", len(groups)))
 	for _, group := range groups {
 		if group.GetUuid() == "rest-apis-default-accesses" {
+			policyIDs := make([]string, 0, len(group.Policies))
+			for _, p := range group.Policies {
+				policyIDs = append(policyIDs, p.GetID())
+			}
+			log.Logger(ctx).Info(fmt.Sprintf("Upgrade4994: found target group %s with policies=%v", group.GetUuid(), policyIDs))
+
 			newPolicies, changed := splitFrontendPostPolicies(group.Policies)
+			log.Logger(ctx).Info(fmt.Sprintf("Upgrade4994: splitFrontendPostPolicies changed=%v (before=%d after=%d)", changed, len(group.Policies), len(newPolicies)))
 
 			// Only update if we found the old unified policy
 			if changed {
 				group.Policies = newPolicies
 				if _, er := dao.StorePolicyGroup(ctx, group); er != nil {
-					log.Logger(ctx).Error("could not update policy group "+group.GetUuid(), zap.Error(er))
+					log.Logger(ctx).Error("Upgrade4994: could not update policy group "+group.GetUuid(), zap.Error(er))
 				} else {
-					log.Logger(ctx).Info("Updated policy group " + group.GetUuid() + " - split frontend-post for shared profile (WPB-23974)")
+					log.Logger(ctx).Info("Upgrade4994: updated policy group " + group.GetUuid() + " - split frontend-post for shared profile (WPB-23974)")
 				}
+			} else {
+				log.Logger(ctx).Info("Upgrade4994: no change required for group " + group.GetUuid())
 			}
 		}
 	}
@@ -888,7 +902,7 @@ var DefaultsServiceMigrationsAfter4416 = []*service.Migration{
 	},
 	{
 		TargetVersion: service.ValidVersion("4.9.94"),
-		Up:            Upgrade5000,
+		Up:            Upgrade4994,
 	},
 }
 

--- a/idm/policy/defaults.go
+++ b/idm/policy/defaults.go
@@ -787,6 +787,63 @@ func Upgrade4993(ctx context.Context) error {
 	return nil
 }
 
+func splitFrontendPostPolicies(policies []*idm.Policy) ([]*idm.Policy, bool) {
+	var newPolicies []*idm.Policy
+	var hasStandardPolicy, hasSharedPolicy bool
+	var replacedUnifiedPolicy bool
+
+	for _, p := range policies {
+		// Check for the old unified frontend-post policy (both subjects together)
+		if p.GetID() == "frontend-post" {
+			hasSubjects := make(map[string]bool)
+			for _, s := range p.OrmSubjects {
+				hasSubjects[s.Template] = true
+			}
+
+			// If it has both profiles, it's the old unified policy - replace it
+			if hasSubjects["profile:standard"] && hasSubjects["profile:shared"] {
+				// Standard profile keeps all POST endpoints including /frontend/enroll
+				newPolicies = append(newPolicies, converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
+					ID:          "frontend-post",
+					Description: "PolicyGroup.LoggedUsers.Rule6",
+					Subjects:    []string{"profile:standard"},
+					Resources: []string{
+						"rest:/frontend/binaries/USER/<.+>",
+						"rest:/frontend/enroll",
+						"rest:/frontend/session",
+					},
+					Actions: []string{"POST"},
+					Effect:  ladon.AllowAccess,
+				}))
+				hasStandardPolicy = true
+				// Shared profile excludes /frontend/enroll (WPB-23974 security fix)
+				newPolicies = append(newPolicies, converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
+					ID:          "frontend-post-shared",
+					Description: "PolicyGroup.LoggedUsers.Rule6Shared",
+					Subjects:    []string{"profile:shared"},
+					Resources: []string{
+						"rest:/frontend/binaries/USER/<.+>",
+						"rest:/frontend/session",
+					},
+					Actions: []string{"POST"},
+					Effect:  ladon.AllowAccess,
+				}))
+				hasSharedPolicy = true
+				replacedUnifiedPolicy = true
+				continue
+			}
+		}
+		if p.GetID() == "frontend-post" {
+			hasStandardPolicy = true
+		} else if p.GetID() == "frontend-post-shared" {
+			hasSharedPolicy = true
+		}
+		newPolicies = append(newPolicies, p)
+	}
+
+	return newPolicies, replacedUnifiedPolicy && hasStandardPolicy && hasSharedPolicy
+}
+
 // Upgrade5000 splits frontend-post policy to restrict /frontend/enroll for shared profile users (WPB-23974).
 // This prevents shared link users from enrolling MFA and causing DoS on the shared link.
 // The old unified "frontend-post" policy (profile:standard + profile:shared) is replaced with two:
@@ -803,59 +860,10 @@ func Upgrade5000(ctx context.Context) error {
 	}
 	for _, group := range groups {
 		if group.GetUuid() == "rest-apis-default-accesses" {
-			var newPolicies []*idm.Policy
-			var hasStandardPolicy, hasSharedPolicy bool
-
-			for _, p := range group.Policies {
-				// Check for the old unified frontend-post policy (both subjects together)
-				if p.GetID() == "frontend-post" {
-					hasSubjects := make(map[string]bool)
-					for _, s := range p.OrmSubjects {
-						hasSubjects[s.Template] = true
-					}
-
-					// If it has both profiles, it's the old unified policy - replace it
-					if hasSubjects["profile:standard"] && hasSubjects["profile:shared"] {
-						// Standard profile keeps all POST endpoints including /frontend/enroll
-						newPolicies = append(newPolicies, converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
-							ID:          "frontend-post",
-							Description: "PolicyGroup.LoggedUsers.Rule6",
-							Subjects:    []string{"profile:standard"},
-							Resources: []string{
-								"rest:/frontend/binaries/USER/<.+>",
-								"rest:/frontend/enroll",
-								"rest:/frontend/session",
-							},
-							Actions: []string{"POST"},
-							Effect:  ladon.AllowAccess,
-						}))
-						hasStandardPolicy = true
-						// Shared profile excludes /frontend/enroll (WPB-23974 security fix)
-						newPolicies = append(newPolicies, converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
-							ID:          "frontend-post-shared",
-							Description: "PolicyGroup.LoggedUsers.Rule6Shared",
-							Subjects:    []string{"profile:shared"},
-							Resources: []string{
-								"rest:/frontend/binaries/USER/<.+>",
-								"rest:/frontend/session",
-							},
-							Actions: []string{"POST"},
-							Effect:  ladon.AllowAccess,
-						}))
-						hasSharedPolicy = true
-						continue
-					}
-				}
-				if p.GetID() == "frontend-post" {
-					hasStandardPolicy = true
-				} else if p.GetID() == "frontend-post-shared" {
-					hasSharedPolicy = true
-				}
-				newPolicies = append(newPolicies, p)
-			}
+			newPolicies, changed := splitFrontendPostPolicies(group.Policies)
 
 			// Only update if we found the old unified policy
-			if hasStandardPolicy && hasSharedPolicy {
+			if changed {
 				group.Policies = newPolicies
 				if _, er := dao.StorePolicyGroup(ctx, group); er != nil {
 					log.Logger(ctx).Error("could not update policy group "+group.GetUuid(), zap.Error(er))

--- a/idm/policy/defaults.go
+++ b/idm/policy/defaults.go
@@ -873,7 +873,7 @@ func Upgrade5000(ctx context.Context) error {
 			}
 		}
 	}
-	log.Logger(ctx).Info("Upgraded policy model to v5.0.0 - restricted /frontend/enroll for shared profile users")
+	log.Logger(ctx).Info("Upgraded policy model to v4.9.94 - restricted /frontend/enroll for shared profile users")
 	return nil
 }
 
@@ -887,7 +887,7 @@ var DefaultsServiceMigrationsAfter4416 = []*service.Migration{
 		Up:            Upgrade4993,
 	},
 	{
-		TargetVersion: service.ValidVersion("5.0.0"),
+		TargetVersion: service.ValidVersion("4.9.94"),
 		Up:            Upgrade5000,
 	},
 }

--- a/idm/policy/defaults.go
+++ b/idm/policy/defaults.go
@@ -202,10 +202,21 @@ var (
 				converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
 					ID:          "frontend-post",
 					Description: "PolicyGroup.LoggedUsers.Rule6",
-					Subjects:    []string{"profile:standard", "profile:shared"},
+					Subjects:    []string{"profile:standard"},
 					Resources: []string{
 						"rest:/frontend/binaries/USER/<.+>",
 						"rest:/frontend/enroll",
+						"rest:/frontend/session",
+					},
+					Actions: []string{"POST"},
+					Effect:  ladon.AllowAccess,
+				}),
+				converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
+					ID:          "frontend-post-shared",
+					Description: "PolicyGroup.LoggedUsers.Rule6Shared",
+					Subjects:    []string{"profile:shared"},
+					Resources: []string{
+						"rest:/frontend/binaries/USER/<.+>",
 						"rest:/frontend/session",
 					},
 					Actions: []string{"POST"},
@@ -776,6 +787,88 @@ func Upgrade4993(ctx context.Context) error {
 	return nil
 }
 
+// Upgrade5000 splits frontend-post policy to restrict /frontend/enroll for shared profile users (WPB-23974).
+// This prevents shared link users from enrolling MFA and causing DoS on the shared link.
+// The old unified "frontend-post" policy (profile:standard + profile:shared) is replaced with two:
+// - "frontend-post" for profile:standard (unchanged, backward compatible name)
+// - "frontend-post-shared" for profile:shared (excludes /frontend/enroll)
+func Upgrade5000(ctx context.Context) error {
+	dao, er := manager.Resolve[DAO](ctx)
+	if er != nil {
+		return er
+	}
+	groups, e := dao.ListPolicyGroups(ctx, nil)
+	if e != nil {
+		return e
+	}
+	for _, group := range groups {
+		if group.GetUuid() == "rest-apis-default-accesses" {
+			var newPolicies []*idm.Policy
+			var hasStandardPolicy, hasSharedPolicy bool
+
+			for _, p := range group.Policies {
+				// Check for the old unified frontend-post policy (both subjects together)
+				if p.GetID() == "frontend-post" {
+					hasSubjects := make(map[string]bool)
+					for _, s := range p.OrmSubjects {
+						hasSubjects[s.Template] = true
+					}
+
+					// If it has both profiles, it's the old unified policy - replace it
+					if hasSubjects["profile:standard"] && hasSubjects["profile:shared"] {
+						// Standard profile keeps all POST endpoints including /frontend/enroll
+						newPolicies = append(newPolicies, converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
+							ID:          "frontend-post",
+							Description: "PolicyGroup.LoggedUsers.Rule6",
+							Subjects:    []string{"profile:standard"},
+							Resources: []string{
+								"rest:/frontend/binaries/USER/<.+>",
+								"rest:/frontend/enroll",
+								"rest:/frontend/session",
+							},
+							Actions: []string{"POST"},
+							Effect:  ladon.AllowAccess,
+						}))
+						hasStandardPolicy = true
+						// Shared profile excludes /frontend/enroll (WPB-23974 security fix)
+						newPolicies = append(newPolicies, converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
+							ID:          "frontend-post-shared",
+							Description: "PolicyGroup.LoggedUsers.Rule6Shared",
+							Subjects:    []string{"profile:shared"},
+							Resources: []string{
+								"rest:/frontend/binaries/USER/<.+>",
+								"rest:/frontend/session",
+							},
+							Actions: []string{"POST"},
+							Effect:  ladon.AllowAccess,
+						}))
+						hasSharedPolicy = true
+						continue
+					}
+				}
+				if p.GetID() == "frontend-post" {
+					hasStandardPolicy = true
+				} else if p.GetID() == "frontend-post-shared" {
+					hasSharedPolicy = true
+				}
+				newPolicies = append(newPolicies, p)
+			}
+
+			// Only update if we found the old unified policy
+			if hasStandardPolicy && hasSharedPolicy {
+				group.Policies = newPolicies
+				if _, er := dao.StorePolicyGroup(ctx, group); er != nil {
+					log.Logger(ctx).Error("could not update policy group "+group.GetUuid(), zap.Error(er))
+				} else {
+					log.Logger(ctx).Info("Updated policy group " + group.GetUuid() + " - split frontend-post for shared profile (WPB-23974)")
+				}
+			}
+		}
+	}
+	log.Logger(ctx).Info("Upgraded policy model to v5.0.0 - restricted /frontend/enroll for shared profile users")
+	return nil
+}
+
 var DefaultsServiceMigrationsAfter4416 = []*service.Migration{
 	{
 		TargetVersion: service.ValidVersion("4.5.0"),
@@ -784,6 +877,10 @@ var DefaultsServiceMigrationsAfter4416 = []*service.Migration{
 	{
 		TargetVersion: service.ValidVersion("4.9.93"),
 		Up:            Upgrade4993,
+	},
+	{
+		TargetVersion: service.ValidVersion("5.0.0"),
+		Up:            Upgrade5000,
 	},
 }
 

--- a/idm/policy/defaults.go
+++ b/idm/policy/defaults.go
@@ -848,7 +848,7 @@ func splitFrontendPostPolicies(policies []*idm.Policy) ([]*idm.Policy, bool) {
 	return newPolicies, replacedUnifiedPolicy && hasStandardPolicy && hasSharedPolicy
 }
 
-// Upgrade5000 splits frontend-post policy to restrict /frontend/enroll for shared profile users (WPB-23974).
+// Upgrade4994 splits frontend-post policy to restrict /frontend/enroll for shared profile users (WPB-23974).
 // This prevents shared link users from enrolling MFA and causing DoS on the shared link.
 // The old unified "frontend-post" policy (profile:standard + profile:shared) is replaced with two:
 // - "frontend-post" for profile:standard (unchanged, backward compatible name)
@@ -864,29 +864,32 @@ func Upgrade4994(ctx context.Context) error {
 	}
 	log.Logger(ctx).Info(fmt.Sprintf("Upgrade4994: scanning %d policy groups", len(groups)))
 	for _, group := range groups {
-		if group.GetUuid() == "rest-apis-default-accesses" {
-			policyIDs := make([]string, 0, len(group.Policies))
-			for _, p := range group.Policies {
-				policyIDs = append(policyIDs, p.GetID())
-			}
-			log.Logger(ctx).Info(fmt.Sprintf("Upgrade4994: found target group %s with policies=%v", group.GetUuid(), policyIDs))
-
-			newPolicies, changed := splitFrontendPostPolicies(group.Policies)
-			log.Logger(ctx).Info(fmt.Sprintf("Upgrade4994: splitFrontendPostPolicies changed=%v (before=%d after=%d)", changed, len(group.Policies), len(newPolicies)))
-
-			// Only update if we found the old unified policy
-			if changed {
-				group.Policies = newPolicies
-				if _, er := dao.StorePolicyGroup(ctx, group); er != nil {
-					log.Logger(ctx).Error("Upgrade4994: could not update policy group "+group.GetUuid(), zap.Error(er))
-				} else {
-					log.Logger(ctx).Info("Upgrade4994: updated policy group " + group.GetUuid() + " - split frontend-post for shared profile (WPB-23974)")
-				}
-			} else {
-				log.Logger(ctx).Info("Upgrade4994: no change required for group " + group.GetUuid())
-			}
+		if group.GetUuid() != "rest-apis-default-accesses" {
+			continue
 		}
+
+		policyIDs := make([]string, 0, len(group.Policies))
+		for _, p := range group.Policies {
+			policyIDs = append(policyIDs, p.GetID())
+		}
+		log.Logger(ctx).Info(fmt.Sprintf("Upgrade4994: found target group %s with policies=%v", group.GetUuid(), policyIDs))
+
+		newPolicies, changed := splitFrontendPostPolicies(group.Policies)
+		log.Logger(ctx).Info(fmt.Sprintf("Upgrade4994: splitFrontendPostPolicies changed=%v (before=%d after=%d)", changed, len(group.Policies), len(newPolicies)))
+		if !changed {
+			log.Logger(ctx).Info("Upgrade4994: no change required for group " + group.GetUuid())
+			continue
+		}
+
+		group.Policies = newPolicies
+		if _, er := dao.StorePolicyGroup(ctx, group); er != nil {
+			log.Logger(ctx).Error("Upgrade4994: could not update policy group "+group.GetUuid(), zap.Error(er))
+			continue
+		}
+
+		log.Logger(ctx).Info("Upgrade4994: updated policy group " + group.GetUuid() + " - split frontend-post for shared profile (WPB-23974)")
 	}
+
 	log.Logger(ctx).Info("Upgraded policy model to v4.9.94 - restricted /frontend/enroll for shared profile users")
 	return nil
 }

--- a/idm/policy/defaults_test.go
+++ b/idm/policy/defaults_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestSplitFrontendPostPolicies(t *testing.T) {
-	Convey("happy path: it splits old unified frontend-post policy for migration", t, func() {
+	Convey("split unified frontend-post", t, func() {
 		oldUnified := converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
 			ID:          "frontend-post",
 			Description: "old unified policy",
@@ -61,7 +61,7 @@ func TestSplitFrontendPostPolicies(t *testing.T) {
 		So(hasResource(sharedPolicy, "rest:/frontend/session"), ShouldBeTrue)
 	})
 
-	Convey("happy path: it also splits when subjects are stored in orm subjects", t, func() {
+	Convey("split when subjects are in orm subjects", t, func() {
 		oldUnified := &idm.Policy{
 			ID: "frontend-post",
 			OrmSubjects: []*idm.PolicySubject{
@@ -78,7 +78,7 @@ func TestSplitFrontendPostPolicies(t *testing.T) {
 		So(findPolicyByID(policies, "frontend-post-shared"), ShouldNotBeNil)
 	})
 
-	Convey("non-happy path: it does nothing when policies are already split", t, func() {
+	Convey("do nothing when already split", t, func() {
 		standard := converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
 			ID:        "frontend-post",
 			Subjects:  []string{"profile:standard"},
@@ -102,7 +102,7 @@ func TestSplitFrontendPostPolicies(t *testing.T) {
 		So(policies[1], ShouldEqual, shared)
 	})
 
-	Convey("non-happy path: it does nothing when frontend-post does not contain both profiles", t, func() {
+	Convey("do nothing when both profiles are not present", t, func() {
 		onlyShared := converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
 			ID:        "frontend-post",
 			Subjects:  []string{"profile:shared"},
@@ -118,7 +118,7 @@ func TestSplitFrontendPostPolicies(t *testing.T) {
 		So(policies[0], ShouldEqual, onlyShared)
 	})
 
-	Convey("non-happy path: it ignores unrelated policies", t, func() {
+	Convey("ignore unrelated policies", t, func() {
 		untouched := &idm.Policy{ID: "keep-me"}
 
 		policies, changed := splitFrontendPostPolicies([]*idm.Policy{untouched})
@@ -130,7 +130,7 @@ func TestSplitFrontendPostPolicies(t *testing.T) {
 }
 
 func TestUpgrade4994(t *testing.T) {
-	Convey("it updates target group when old unified policy exists", t, func() {
+	Convey("update target group when unified policy exists", t, func() {
 		dao := &fakePolicyDAO{
 			groups: []*idm.PolicyGroup{{
 				Uuid: "rest-apis-default-accesses",
@@ -163,7 +163,7 @@ func TestUpgrade4994(t *testing.T) {
 		So(findPolicyByID(dao.storedGroups[0].Policies, "frontend-post-shared"), ShouldNotBeNil)
 	})
 
-	Convey("it does not store when target group is absent", t, func() {
+	Convey("skip when target group is absent", t, func() {
 		dao := &fakePolicyDAO{
 			groups: []*idm.PolicyGroup{{Uuid: "other-group", Policies: []*idm.Policy{{ID: "keep-me"}}}},
 		}
@@ -177,7 +177,7 @@ func TestUpgrade4994(t *testing.T) {
 		So(dao.storeCalls, ShouldEqual, 0)
 	})
 
-	Convey("it does not store when target group is already migrated", t, func() {
+	Convey("skip when target group is already migrated", t, func() {
 		dao := &fakePolicyDAO{
 			groups: []*idm.PolicyGroup{{
 				Uuid: "rest-apis-default-accesses",
@@ -197,7 +197,7 @@ func TestUpgrade4994(t *testing.T) {
 		So(dao.storeCalls, ShouldEqual, 0)
 	})
 
-	Convey("it returns list error", t, func() {
+	Convey("return list error", t, func() {
 		dao := &fakePolicyDAO{listErr: errors.New("list failed")}
 
 		ctx, err := manager.DSNtoContextDAO(t.Context(), []string{}, func(context.Context) DAO { return dao })
@@ -209,7 +209,7 @@ func TestUpgrade4994(t *testing.T) {
 		So(err.Error(), ShouldContainSubstring, "list failed")
 	})
 
-	Convey("it logs store error and continues", t, func() {
+	Convey("log store error and continue", t, func() {
 		dao := &fakePolicyDAO{
 			groups: []*idm.PolicyGroup{{
 				Uuid: "rest-apis-default-accesses",

--- a/idm/policy/defaults_test.go
+++ b/idm/policy/defaults_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSplitFrontendPostPolicies(t *testing.T) {
-	Convey("it splits old unified frontend-post policy for migration", t, func() {
+	Convey("happy path: it splits old unified frontend-post policy for migration", t, func() {
 		oldUnified := converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
 			ID:          "frontend-post",
 			Description: "old unified policy",
@@ -52,7 +52,24 @@ func TestSplitFrontendPostPolicies(t *testing.T) {
 		So(hasResource(sharedPolicy, "rest:/frontend/session"), ShouldBeTrue)
 	})
 
-	Convey("it does nothing when policies are already split", t, func() {
+	Convey("happy path: it also splits when subjects are stored in orm subjects", t, func() {
+		oldUnified := &idm.Policy{
+			ID: "frontend-post",
+			OrmSubjects: []*idm.PolicySubject{
+				{Template: "profile:standard"},
+				{Template: "profile:shared"},
+			},
+		}
+
+		policies, changed := splitFrontendPostPolicies([]*idm.Policy{oldUnified})
+
+		So(changed, ShouldBeTrue)
+		So(policies, ShouldHaveLength, 2)
+		So(findPolicyByID(policies, "frontend-post"), ShouldNotBeNil)
+		So(findPolicyByID(policies, "frontend-post-shared"), ShouldNotBeNil)
+	})
+
+	Convey("non-happy path: it does nothing when policies are already split", t, func() {
 		standard := converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
 			ID:        "frontend-post",
 			Subjects:  []string{"profile:standard"},
@@ -74,6 +91,32 @@ func TestSplitFrontendPostPolicies(t *testing.T) {
 		So(policies, ShouldHaveLength, 2)
 		So(policies[0], ShouldEqual, standard)
 		So(policies[1], ShouldEqual, shared)
+	})
+
+	Convey("non-happy path: it does nothing when frontend-post does not contain both profiles", t, func() {
+		onlyShared := converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
+			ID:        "frontend-post",
+			Subjects:  []string{"profile:shared"},
+			Resources: []string{"rest:/frontend/session"},
+			Actions:   []string{"POST"},
+			Effect:    ladon.AllowAccess,
+		})
+
+		policies, changed := splitFrontendPostPolicies([]*idm.Policy{onlyShared})
+
+		So(changed, ShouldBeFalse)
+		So(policies, ShouldHaveLength, 1)
+		So(policies[0], ShouldEqual, onlyShared)
+	})
+
+	Convey("non-happy path: it ignores unrelated policies", t, func() {
+		untouched := &idm.Policy{ID: "keep-me"}
+
+		policies, changed := splitFrontendPostPolicies([]*idm.Policy{untouched})
+
+		So(changed, ShouldBeFalse)
+		So(policies, ShouldHaveLength, 1)
+		So(policies[0], ShouldEqual, untouched)
 	})
 }
 

--- a/idm/policy/defaults_test.go
+++ b/idm/policy/defaults_test.go
@@ -1,225 +1,114 @@
-/*
- * Copyright (c) 2026. Abstrium SAS <team (at) pydio.com>
- * This file is part of Pydio Cells.
- *
- * Pydio Cells is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Pydio Cells is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
- *
- * The latest code can be found at <https://pydio.com>.
- */
-
 package policy
 
 import (
 	"testing"
 
+	"github.com/ory/ladon"
 	"github.com/pydio/cells/v5/common/proto/idm"
+	"github.com/pydio/cells/v5/idm/policy/converter"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestDefaultPolicyGroupsFrontendPostSplit(t *testing.T) {
+func TestSplitFrontendPostPolicies(t *testing.T) {
+	Convey("it splits old unified frontend-post policy for migration", t, func() {
+		oldUnified := converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
+			ID:          "frontend-post",
+			Description: "old unified policy",
+			Subjects:    []string{"profile:standard", "profile:shared"},
+			Resources: []string{
+				"rest:/frontend/binaries/USER/<.+>",
+				"rest:/frontend/enroll",
+				"rest:/frontend/session",
+			},
+			Actions: []string{"POST"},
+			Effect:  ladon.AllowAccess,
+		})
 
-	Convey("Test default policies split frontend-post by profile", t, func() {
+		untouched := &idm.Policy{ID: "keep-me"}
 
-		// Find the rest-apis-default-accesses policy group
-		var restApiGroup *idm.PolicyGroup
-		for _, pg := range DefaultPolicyGroups {
-			if pg.Uuid == "rest-apis-default-accesses" {
-				restApiGroup = pg
-				break
-			}
-		}
+		policies, changed := splitFrontendPostPolicies([]*idm.Policy{untouched, oldUnified})
 
-		So(restApiGroup, ShouldNotBeNil)
+		So(changed, ShouldBeTrue)
+		So(policies, ShouldHaveLength, 3)
+		So(policies[0].GetID(), ShouldEqual, "keep-me")
 
-		// Find the two split policies (frontend-post for standard, frontend-post-shared for shared)
-		// Note: "frontend-post" keeps its original name for backward compatibility
-		var standardPolicy, sharedPolicy *idm.Policy
-		for _, p := range restApiGroup.Policies {
-			if p.GetID() == "frontend-post" {
-				standardPolicy = p
-			} else if p.GetID() == "frontend-post-shared" {
-				sharedPolicy = p
-			}
-		}
+		standardPolicy := findPolicyByID(policies, "frontend-post")
+		sharedPolicy := findPolicyByID(policies, "frontend-post-shared")
 
 		So(standardPolicy, ShouldNotBeNil)
 		So(sharedPolicy, ShouldNotBeNil)
 
-		// Verify "frontend-post" only applies to standard profile (not the old unified version with both)
-		hasStandardOnly := func(p *idm.Policy) bool {
-			hasStandard := false
-			hasShared := false
-			for _, s := range p.OrmSubjects {
-				if s.Template == "profile:standard" {
-					hasStandard = true
-				}
-				if s.Template == "profile:shared" {
-					hasShared = true
-				}
-			}
-			return hasStandard && !hasShared
-		}
-		So(hasStandardOnly(standardPolicy), ShouldBeTrue)
-
-		// Helper to check if policy contains a subject
-		hasSubject := func(p *idm.Policy, subject string) bool {
-			for _, s := range p.OrmSubjects {
-				if s.Template == subject {
-					return true
-				}
-			}
-			return false
-		}
-
-		// Helper to check if policy contains a resource
-		hasResource := func(p *idm.Policy, resource string) bool {
-			for _, r := range p.OrmResources {
-				if r.Template == resource {
-					return true
-				}
-			}
-			return false
-		}
-
-		// Verify standard profile has /frontend/enroll
 		So(hasSubject(standardPolicy, "profile:standard"), ShouldBeTrue)
+		So(hasSubject(standardPolicy, "profile:shared"), ShouldBeFalse)
+		So(hasAction(standardPolicy, "POST"), ShouldBeTrue)
 		So(hasResource(standardPolicy, "rest:/frontend/enroll"), ShouldBeTrue)
+		So(hasResource(standardPolicy, "rest:/frontend/session"), ShouldBeTrue)
 
-		// Verify shared profile does NOT have /frontend/enroll (WPB-23974 fix)
 		So(hasSubject(sharedPolicy, "profile:shared"), ShouldBeTrue)
+		So(hasSubject(sharedPolicy, "profile:standard"), ShouldBeFalse)
+		So(hasAction(sharedPolicy, "POST"), ShouldBeTrue)
 		So(hasResource(sharedPolicy, "rest:/frontend/enroll"), ShouldBeFalse)
-
-		// Verify shared profile still has session and binaries
 		So(hasResource(sharedPolicy, "rest:/frontend/session"), ShouldBeTrue)
-		So(hasResource(sharedPolicy, "rest:/frontend/binaries/USER/<.+>"), ShouldBeTrue)
 	})
 
-	Convey("Test shared profile cannot POST to /frontend/enroll", t, func() {
+	Convey("it does nothing when policies are already split", t, func() {
+		standard := converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
+			ID:        "frontend-post",
+			Subjects:  []string{"profile:standard"},
+			Resources: []string{"rest:/frontend/enroll", "rest:/frontend/session"},
+			Actions:   []string{"POST"},
+			Effect:    ladon.AllowAccess,
+		})
+		shared := converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
+			ID:        "frontend-post-shared",
+			Subjects:  []string{"profile:shared"},
+			Resources: []string{"rest:/frontend/session"},
+			Actions:   []string{"POST"},
+			Effect:    ladon.AllowAccess,
+		})
 
-		var restApiGroup *idm.PolicyGroup
-		for _, pg := range DefaultPolicyGroups {
-			if pg.Uuid == "rest-apis-default-accesses" {
-				restApiGroup = pg
-				break
-			}
-		}
+		policies, changed := splitFrontendPostPolicies([]*idm.Policy{standard, shared})
 
-		So(restApiGroup, ShouldNotBeNil)
-
-		// Helper functions
-		hasSubject := func(p *idm.Policy, subject string) bool {
-			for _, s := range p.OrmSubjects {
-				if s.Template == subject {
-					return true
-				}
-			}
-			return false
-		}
-
-		hasResource := func(p *idm.Policy, resource string) bool {
-			for _, r := range p.OrmResources {
-				if r.Template == resource {
-					return true
-				}
-			}
-			return false
-		}
-
-		hasAction := func(p *idm.Policy, action string) bool {
-			for _, a := range p.OrmActions {
-				if a.Template == action {
-					return true
-				}
-			}
-			return false
-		}
-
-		// Collect all policies that apply to profile:shared with POST action
-		var sharedCanPostToEnroll bool
-		for _, p := range restApiGroup.Policies {
-			if hasSubject(p, "profile:shared") && hasAction(p, "POST") && hasResource(p, "rest:/frontend/enroll") {
-				sharedCanPostToEnroll = true
-				break
-			}
-		}
-
-		So(sharedCanPostToEnroll, ShouldBeFalse)
-
-		// Verify standard profile CAN POST to /frontend/enroll
-		var standardCanPostToEnroll bool
-		for _, p := range restApiGroup.Policies {
-			if hasSubject(p, "profile:standard") && hasAction(p, "POST") && hasResource(p, "rest:/frontend/enroll") {
-				standardCanPostToEnroll = true
-				break
-			}
-		}
-		So(standardCanPostToEnroll, ShouldBeTrue)
+		So(changed, ShouldBeFalse)
+		So(policies, ShouldHaveLength, 2)
+		So(policies[0], ShouldEqual, standard)
+		So(policies[1], ShouldEqual, shared)
 	})
+}
 
-	Convey("Test both profiles can still access /frontend/session", t, func() {
-
-		var restApiGroup *idm.PolicyGroup
-		for _, pg := range DefaultPolicyGroups {
-			if pg.Uuid == "rest-apis-default-accesses" {
-				restApiGroup = pg
-				break
-			}
+func findPolicyByID(policies []*idm.Policy, id string) *idm.Policy {
+	for _, p := range policies {
+		if p.GetID() == id {
+			return p
 		}
+	}
+	return nil
+}
 
-		So(restApiGroup, ShouldNotBeNil)
-
-		hasSubject := func(p *idm.Policy, subject string) bool {
-			for _, s := range p.OrmSubjects {
-				if s.Template == subject {
-					return true
-				}
-			}
-			return false
+func hasSubject(p *idm.Policy, subject string) bool {
+	for _, s := range p.OrmSubjects {
+		if s.Template == subject {
+			return true
 		}
+	}
+	return false
+}
 
-		hasResource := func(p *idm.Policy, resource string) bool {
-			for _, r := range p.OrmResources {
-				if r.Template == resource {
-					return true
-				}
-			}
-			return false
+func hasResource(p *idm.Policy, resource string) bool {
+	for _, r := range p.OrmResources {
+		if r.Template == resource {
+			return true
 		}
+	}
+	return false
+}
 
-		hasAction := func(p *idm.Policy, action string) bool {
-			for _, a := range p.OrmActions {
-				if a.Template == action {
-					return true
-				}
-			}
-			return false
+func hasAction(p *idm.Policy, action string) bool {
+	for _, a := range p.OrmActions {
+		if a.Template == action {
+			return true
 		}
-
-		var standardHasSession, sharedHasSession bool
-		for _, p := range restApiGroup.Policies {
-			if hasAction(p, "POST") && hasResource(p, "rest:/frontend/session") {
-				if hasSubject(p, "profile:standard") {
-					standardHasSession = true
-				}
-				if hasSubject(p, "profile:shared") {
-					sharedHasSession = true
-				}
-			}
-		}
-
-		So(standardHasSession, ShouldBeTrue)
-		So(sharedHasSession, ShouldBeTrue)
-	})
+	}
+	return false
 }

--- a/idm/policy/defaults_test.go
+++ b/idm/policy/defaults_test.go
@@ -1,11 +1,20 @@
 package policy
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/ory/ladon"
 	"github.com/pydio/cells/v5/common/proto/idm"
+	pb "github.com/pydio/cells/v5/common/proto/service"
+	"github.com/pydio/cells/v5/common/runtime/manager"
 	"github.com/pydio/cells/v5/idm/policy/converter"
+
+	_ "github.com/pydio/cells/v5/common/config/memory"
+	_ "github.com/pydio/cells/v5/common/config/viper"
+	_ "github.com/pydio/cells/v5/common/registry/config"
+	_ "github.com/pydio/cells/v5/common/registry/service"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -120,6 +129,107 @@ func TestSplitFrontendPostPolicies(t *testing.T) {
 	})
 }
 
+func TestUpgrade4994(t *testing.T) {
+	Convey("it updates target group when old unified policy exists", t, func() {
+		dao := &fakePolicyDAO{
+			groups: []*idm.PolicyGroup{{
+				Uuid: "rest-apis-default-accesses",
+				Policies: []*idm.Policy{
+					converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
+						ID:          "frontend-post",
+						Description: "old unified policy",
+						Subjects:    []string{"profile:standard", "profile:shared"},
+						Resources: []string{
+							"rest:/frontend/binaries/USER/<.+>",
+							"rest:/frontend/enroll",
+							"rest:/frontend/session",
+						},
+						Actions: []string{"POST"},
+						Effect:  ladon.AllowAccess,
+					}),
+				},
+			}},
+		}
+
+		ctx, err := manager.DSNtoContextDAO(t.Context(), []string{}, func(context.Context) DAO { return dao })
+		So(err, ShouldBeNil)
+
+		err = Upgrade4994(ctx)
+
+		So(err, ShouldBeNil)
+		So(dao.storeCalls, ShouldEqual, 1)
+		So(dao.storedGroups, ShouldHaveLength, 1)
+		So(findPolicyByID(dao.storedGroups[0].Policies, "frontend-post"), ShouldNotBeNil)
+		So(findPolicyByID(dao.storedGroups[0].Policies, "frontend-post-shared"), ShouldNotBeNil)
+	})
+
+	Convey("it does not store when target group is absent", t, func() {
+		dao := &fakePolicyDAO{
+			groups: []*idm.PolicyGroup{{Uuid: "other-group", Policies: []*idm.Policy{{ID: "keep-me"}}}},
+		}
+
+		ctx, err := manager.DSNtoContextDAO(t.Context(), []string{}, func(context.Context) DAO { return dao })
+		So(err, ShouldBeNil)
+
+		err = Upgrade4994(ctx)
+
+		So(err, ShouldBeNil)
+		So(dao.storeCalls, ShouldEqual, 0)
+	})
+
+	Convey("it does not store when target group is already migrated", t, func() {
+		dao := &fakePolicyDAO{
+			groups: []*idm.PolicyGroup{{
+				Uuid: "rest-apis-default-accesses",
+				Policies: []*idm.Policy{
+					converter.LadonToProtoPolicy(&ladon.DefaultPolicy{ID: "frontend-post", Subjects: []string{"profile:standard"}, Resources: []string{"rest:/frontend/enroll", "rest:/frontend/session"}, Actions: []string{"POST"}, Effect: ladon.AllowAccess}),
+					converter.LadonToProtoPolicy(&ladon.DefaultPolicy{ID: "frontend-post-shared", Subjects: []string{"profile:shared"}, Resources: []string{"rest:/frontend/session"}, Actions: []string{"POST"}, Effect: ladon.AllowAccess}),
+				},
+			}},
+		}
+
+		ctx, err := manager.DSNtoContextDAO(t.Context(), []string{}, func(context.Context) DAO { return dao })
+		So(err, ShouldBeNil)
+
+		err = Upgrade4994(ctx)
+
+		So(err, ShouldBeNil)
+		So(dao.storeCalls, ShouldEqual, 0)
+	})
+
+	Convey("it returns list error", t, func() {
+		dao := &fakePolicyDAO{listErr: errors.New("list failed")}
+
+		ctx, err := manager.DSNtoContextDAO(t.Context(), []string{}, func(context.Context) DAO { return dao })
+		So(err, ShouldBeNil)
+
+		err = Upgrade4994(ctx)
+
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "list failed")
+	})
+
+	Convey("it logs store error and continues", t, func() {
+		dao := &fakePolicyDAO{
+			groups: []*idm.PolicyGroup{{
+				Uuid: "rest-apis-default-accesses",
+				Policies: []*idm.Policy{
+					converter.LadonToProtoPolicy(&ladon.DefaultPolicy{ID: "frontend-post", Subjects: []string{"profile:standard", "profile:shared"}, Resources: []string{"rest:/frontend/enroll", "rest:/frontend/session"}, Actions: []string{"POST"}, Effect: ladon.AllowAccess}),
+				},
+			}},
+			storeErr: errors.New("store failed"),
+		}
+
+		ctx, err := manager.DSNtoContextDAO(t.Context(), []string{}, func(context.Context) DAO { return dao })
+		So(err, ShouldBeNil)
+
+		err = Upgrade4994(ctx)
+
+		So(err, ShouldBeNil)
+		So(dao.storeCalls, ShouldEqual, 1)
+	})
+}
+
 func findPolicyByID(policies []*idm.Policy, id string) *idm.Policy {
 	for _, p := range policies {
 		if p.GetID() == id {
@@ -155,3 +265,46 @@ func hasAction(p *idm.Policy, action string) bool {
 	}
 	return false
 }
+
+type fakePolicyDAO struct {
+	groups       []*idm.PolicyGroup
+	storedGroups []*idm.PolicyGroup
+	listErr      error
+	storeErr     error
+	storeCalls   int
+}
+
+func (f *fakePolicyDAO) Migrate(ctx context.Context) error { return nil }
+func (f *fakePolicyDAO) MigrateLegacy(ctx context.Context) error { return nil }
+func (f *fakePolicyDAO) IsAllowed(ctx context.Context, r *ladon.Request) error { return nil }
+func (f *fakePolicyDAO) Create(ctx context.Context, policy ladon.Policy) error { return nil }
+func (f *fakePolicyDAO) Update(ctx context.Context, policy ladon.Policy) error { return nil }
+func (f *fakePolicyDAO) Get(ctx context.Context, id string) (ladon.Policy, error) { return nil, nil }
+func (f *fakePolicyDAO) Delete(ctx context.Context, id string) error { return nil }
+func (f *fakePolicyDAO) GetAll(ctx context.Context, limit, offset int64) (ladon.Policies, error) {
+	return nil, nil
+}
+func (f *fakePolicyDAO) FindRequestCandidates(ctx context.Context, r *ladon.Request) (ladon.Policies, error) {
+	return nil, nil
+}
+func (f *fakePolicyDAO) FindPoliciesForSubject(ctx context.Context, subject string) (ladon.Policies, error) {
+	return nil, nil
+}
+func (f *fakePolicyDAO) FindPoliciesForResource(ctx context.Context, resource string) (ladon.Policies, error) {
+	return nil, nil
+}
+func (f *fakePolicyDAO) StorePolicyGroup(ctx context.Context, group *idm.PolicyGroup) (*idm.PolicyGroup, error) {
+	f.storeCalls++
+	f.storedGroups = append(f.storedGroups, group)
+	if f.storeErr != nil {
+		return nil, f.storeErr
+	}
+	return group, nil
+}
+func (f *fakePolicyDAO) ListPolicyGroups(ctx context.Context, query pb.Enquirer) ([]*idm.PolicyGroup, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.groups, nil
+}
+func (f *fakePolicyDAO) DeletePolicyGroup(ctx context.Context, group *idm.PolicyGroup) error { return nil }

--- a/idm/policy/defaults_test.go
+++ b/idm/policy/defaults_test.go
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026. Abstrium SAS <team (at) pydio.com>
+ * This file is part of Pydio Cells.
+ *
+ * Pydio Cells is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio Cells is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/pydio/cells/v5/common/proto/idm"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestDefaultPolicyGroupsFrontendPostSplit(t *testing.T) {
+
+	Convey("Test default policies split frontend-post by profile", t, func() {
+
+		// Find the rest-apis-default-accesses policy group
+		var restApiGroup *idm.PolicyGroup
+		for _, pg := range DefaultPolicyGroups {
+			if pg.Uuid == "rest-apis-default-accesses" {
+				restApiGroup = pg
+				break
+			}
+		}
+
+		So(restApiGroup, ShouldNotBeNil)
+
+		// Find the two split policies (frontend-post for standard, frontend-post-shared for shared)
+		// Note: "frontend-post" keeps its original name for backward compatibility
+		var standardPolicy, sharedPolicy *idm.Policy
+		for _, p := range restApiGroup.Policies {
+			if p.GetID() == "frontend-post" {
+				standardPolicy = p
+			} else if p.GetID() == "frontend-post-shared" {
+				sharedPolicy = p
+			}
+		}
+
+		So(standardPolicy, ShouldNotBeNil)
+		So(sharedPolicy, ShouldNotBeNil)
+
+		// Verify "frontend-post" only applies to standard profile (not the old unified version with both)
+		hasStandardOnly := func(p *idm.Policy) bool {
+			hasStandard := false
+			hasShared := false
+			for _, s := range p.OrmSubjects {
+				if s.Template == "profile:standard" {
+					hasStandard = true
+				}
+				if s.Template == "profile:shared" {
+					hasShared = true
+				}
+			}
+			return hasStandard && !hasShared
+		}
+		So(hasStandardOnly(standardPolicy), ShouldBeTrue)
+
+		// Helper to check if policy contains a subject
+		hasSubject := func(p *idm.Policy, subject string) bool {
+			for _, s := range p.OrmSubjects {
+				if s.Template == subject {
+					return true
+				}
+			}
+			return false
+		}
+
+		// Helper to check if policy contains a resource
+		hasResource := func(p *idm.Policy, resource string) bool {
+			for _, r := range p.OrmResources {
+				if r.Template == resource {
+					return true
+				}
+			}
+			return false
+		}
+
+		// Verify standard profile has /frontend/enroll
+		So(hasSubject(standardPolicy, "profile:standard"), ShouldBeTrue)
+		So(hasResource(standardPolicy, "rest:/frontend/enroll"), ShouldBeTrue)
+
+		// Verify shared profile does NOT have /frontend/enroll (WPB-23974 fix)
+		So(hasSubject(sharedPolicy, "profile:shared"), ShouldBeTrue)
+		So(hasResource(sharedPolicy, "rest:/frontend/enroll"), ShouldBeFalse)
+
+		// Verify shared profile still has session and binaries
+		So(hasResource(sharedPolicy, "rest:/frontend/session"), ShouldBeTrue)
+		So(hasResource(sharedPolicy, "rest:/frontend/binaries/USER/<.+>"), ShouldBeTrue)
+	})
+
+	Convey("Test shared profile cannot POST to /frontend/enroll", t, func() {
+
+		var restApiGroup *idm.PolicyGroup
+		for _, pg := range DefaultPolicyGroups {
+			if pg.Uuid == "rest-apis-default-accesses" {
+				restApiGroup = pg
+				break
+			}
+		}
+
+		So(restApiGroup, ShouldNotBeNil)
+
+		// Helper functions
+		hasSubject := func(p *idm.Policy, subject string) bool {
+			for _, s := range p.OrmSubjects {
+				if s.Template == subject {
+					return true
+				}
+			}
+			return false
+		}
+
+		hasResource := func(p *idm.Policy, resource string) bool {
+			for _, r := range p.OrmResources {
+				if r.Template == resource {
+					return true
+				}
+			}
+			return false
+		}
+
+		hasAction := func(p *idm.Policy, action string) bool {
+			for _, a := range p.OrmActions {
+				if a.Template == action {
+					return true
+				}
+			}
+			return false
+		}
+
+		// Collect all policies that apply to profile:shared with POST action
+		var sharedCanPostToEnroll bool
+		for _, p := range restApiGroup.Policies {
+			if hasSubject(p, "profile:shared") && hasAction(p, "POST") && hasResource(p, "rest:/frontend/enroll") {
+				sharedCanPostToEnroll = true
+				break
+			}
+		}
+
+		So(sharedCanPostToEnroll, ShouldBeFalse)
+
+		// Verify standard profile CAN POST to /frontend/enroll
+		var standardCanPostToEnroll bool
+		for _, p := range restApiGroup.Policies {
+			if hasSubject(p, "profile:standard") && hasAction(p, "POST") && hasResource(p, "rest:/frontend/enroll") {
+				standardCanPostToEnroll = true
+				break
+			}
+		}
+		So(standardCanPostToEnroll, ShouldBeTrue)
+	})
+
+	Convey("Test both profiles can still access /frontend/session", t, func() {
+
+		var restApiGroup *idm.PolicyGroup
+		for _, pg := range DefaultPolicyGroups {
+			if pg.Uuid == "rest-apis-default-accesses" {
+				restApiGroup = pg
+				break
+			}
+		}
+
+		So(restApiGroup, ShouldNotBeNil)
+
+		hasSubject := func(p *idm.Policy, subject string) bool {
+			for _, s := range p.OrmSubjects {
+				if s.Template == subject {
+					return true
+				}
+			}
+			return false
+		}
+
+		hasResource := func(p *idm.Policy, resource string) bool {
+			for _, r := range p.OrmResources {
+				if r.Template == resource {
+					return true
+				}
+			}
+			return false
+		}
+
+		hasAction := func(p *idm.Policy, action string) bool {
+			for _, a := range p.OrmActions {
+				if a.Template == action {
+					return true
+				}
+			}
+			return false
+		}
+
+		var standardHasSession, sharedHasSession bool
+		for _, p := range restApiGroup.Policies {
+			if hasAction(p, "POST") && hasResource(p, "rest:/frontend/session") {
+				if hasSubject(p, "profile:standard") {
+					standardHasSession = true
+				}
+				if hasSubject(p, "profile:shared") {
+					sharedHasSession = true
+				}
+			}
+		}
+
+		So(standardHasSession, ShouldBeTrue)
+		So(sharedHasSession, ShouldBeTrue)
+	})
+}


### PR DESCRIPTION
Refers to https://wearezeta.atlassian.net/browse/WPB-23974

- Split frontend-post policy by profile: standard and shared
- Shared profile users cannot enroll MFA to prevent DoS
- Standard profile behavior unchanged
- Add Upgrade5000 migration for existing databases
- Backward compatible: policy ID and standard profile access unchanged
