### PR TITLE
fix: escape dots in MariaDB 10.1 version regex

### DIFF
--- a/discovery/install/lib/database.go
+++ b/discovery/install/lib/database.go
@@ -191,7 +191,7 @@ func specificVersionsChecks(ctx context.Context, driver string, infos *sql2.Serv
 		return errors.WithMessage(ErrMySQLVersionNotSupported, "version 8.0.22 is not supported")
 	}
 	mysqlMatched, _ := regexp.MatchString("^5.[456].*$", version)
-	mariaMatched, _ := regexp.MatchString("^10.1.*-MariaDB$", version)
+	mariaMatched, _ := regexp.MatchString(`^10\.1\.[0-9]+-MariaDB(-.*)?$`, version)
 	if (mariaMatched || mysqlMatched) && infos.DbCharset == "utf8mb4" {
 		return errors.WithMessage(ErrMySQLCharsetNotSupported, "This DB version has issues with utf8mb4 charset")
 	}

--- a/discovery/install/lib/database_test.go
+++ b/discovery/install/lib/database_test.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2018. Abstrium SAS <team (at) pydio.com>
+ * This file is part of Pydio Cells.
+ *
+ * Pydio Cells is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio Cells is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+package lib
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/pydio/cells/v5/common/errors"
+	sql2 "github.com/pydio/cells/v5/common/storage/sql"
+)
+
+func TestSpecificVersionsChecks(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name      string
+		driver    string
+		version   string
+		charset   string
+		expectErr error
+	}{
+		{
+			name:    "MariaDB 10.11 with utf8mb4 is allowed (regression: unescaped dot false positive)",
+			driver:  "mysql",
+			version: "10.11.14-MariaDB",
+			charset: "utf8mb4",
+		},
+		{
+			name:      "MariaDB 10.1.x with utf8mb4 is rejected",
+			driver:    "mysql",
+			version:   "10.1.48-MariaDB",
+			charset:   "utf8mb4",
+			expectErr: ErrMySQLCharsetNotSupported,
+		},
+		{
+			name:      "MariaDB 10.1.x with distro suffix and utf8mb4 is rejected",
+			driver:    "mysql",
+			version:   "10.1.48-MariaDB-0+deb9u2",
+			charset:   "utf8mb4",
+			expectErr: ErrMySQLCharsetNotSupported,
+		},
+		{
+			name:    "MariaDB 10.1.x with utf8mb3 is allowed",
+			driver:  "mysql",
+			version: "10.1.48-MariaDB",
+			charset: "utf8mb3",
+		},
+		{
+			name:      "MySQL 5.5.x with utf8mb4 is rejected",
+			driver:    "mysql",
+			version:   "5.5.62",
+			charset:   "utf8mb4",
+			expectErr: ErrMySQLCharsetNotSupported,
+		},
+		{
+			name:      "MySQL 8.0.22 is not supported",
+			driver:    "mysql",
+			version:   "8.0.22",
+			charset:   "utf8mb4",
+			expectErr: ErrMySQLVersionNotSupported,
+		},
+		{
+			name:    "non-mysql driver is skipped",
+			driver:  "sqlite",
+			version: "10.1.48-MariaDB",
+			charset: "utf8mb4",
+		},
+	}
+
+	Convey("specificVersionsChecks", t, func() {
+		for _, tc := range cases {
+			Convey(tc.name, func() {
+				err := specificVersionsChecks(ctx, tc.driver, &sql2.ServerInfos{
+					DbVersion: tc.version,
+					DbCharset: tc.charset,
+				})
+				if tc.expectErr == nil {
+					So(err, ShouldBeNil)
+				} else {
+					So(err, ShouldNotBeNil)
+					So(errors.Is(err, tc.expectErr), ShouldBeTrue)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
It looks like the regex intended to match MariaDB 10.1.x versions had
unescaped dots, causing false positives for every MariaDB 10.1X.

    The install wizard incorrectly rejects
    the utf8mb4 charset:

    "This DB version has issues with utf8mb4 charset: Charset is not
    supported for this version of MySQL"

Escape the dots and require digits for the patch component. Use a raw
string literal so the backslashes land literally in the regex.

Tested against MariaDB 10.11.14.

Test covering different name cases added: database_test.go:
cd into cells and then, go test -run TestSpecificVersionsChecks -v
./discovery/install/lib/

```
=== RUN   TestSpecificVersionsChecks

  specificVersionsChecks
    MariaDB 10.11 with utf8mb4 is allowed (regression: unescaped dot false positive) �[32m✔�[0m
    MariaDB 10.1.x with utf8mb4 is rejected �[32m✔�[0m�[32m✔�[0m
    MariaDB 10.1.x with distro suffix and utf8mb4 is rejected �[32m✔�[0m�[32m✔�[0m
    MariaDB 10.1.x with utf8mb3 is allowed �[32m✔�[0m
    MySQL 5.5.x with utf8mb4 is rejected �[32m✔�[0m�[32m✔�[0m
    MySQL 8.0.22 is not supported �[32m✔�[0m�[32m✔�[0m
    non-mysql driver is skipped �[32m✔�[0m

�[31m�[0m�[33m�[0m�[32m
11 total assertions�[0m

--- PASS: TestSpecificVersionsChecks (0.00s)
PASS
ok
github.com/pydio/cells/v5/discovery/install/lib	(cached)
```

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
