### PR TITLE
refactor: WPB-19709 remove imaging dependency from image flows

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -73,7 +73,7 @@
  - github.com/dgraph-io/ristretto/z ([MIT](https://github.com/dgraph-io/ristretto/blob/v0.1.0/z/LICENSE))
  - github.com/dgryski/go-farm ([MIT](https://github.com/dgryski/go-farm/blob/a6ae2369ad13/LICENSE))
  - github.com/dgryski/go-rendezvous ([MIT](https://github.com/dgryski/go-rendezvous/blob/9f7001d12a5f/LICENSE))
- - github.com/disintegration/imaging ([MIT](https://github.com/disintegration/imaging/blob/v1.6.2/LICENSE))
+ - github.com/boxes-ltd/imaging ([MIT](https://github.com/boxes-ltd/imaging/blob/v1.7.5/LICENSE))
  - github.com/djherbis/atime ([MIT](https://github.com/djherbis/atime/blob/v1.0.0/LICENSE))
  - github.com/dlclark/regexp2 ([MIT](https://github.com/dlclark/regexp2/blob/v1.4.0/LICENSE))
  - github.com/doug-martin/goqu/v9 ([MIT](https://github.com/doug-martin/goqu/blob/v9.18.0/LICENSE))

--- a/frontend/rest/bin-thumb.go
+++ b/frontend/rest/bin-thumb.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/disintegration/imaging"
+	"github.com/boxes-ltd/imaging"
 	"github.com/rwcarlsen/goexif/exif"
 	"go.uber.org/zap"
 	"golang.org/x/image/colornames"

--- a/go.mod
+++ b/go.mod
@@ -18,12 +18,12 @@ require (
 	github.com/bep/debounce v1.2.1
 	github.com/blevesearch/bleve/v2 v2.5.7
 	github.com/blevesearch/bleve_index_api v1.3.2
+	github.com/boxes-ltd/imaging v1.7.5
 	github.com/bufbuild/protovalidate-go v0.8.0
 	github.com/caddyserver/caddy/v2 v2.11.2
 	github.com/caddyserver/certmagic v0.25.2
 	github.com/cskr/pubsub v1.0.2
 	github.com/disintegration/imageorient v0.0.0-20180920195336-8147d86e83ec
-	github.com/disintegration/imaging v1.6.2
 	github.com/dsoprea/go-exif/v3 v3.0.1
 	github.com/dsoprea/go-jpeg-image-structure v0.0.0-20221012074422-4f3f7e934102
 	github.com/dsoprea/go-png-image-structure v0.0.0-20210512210324-29b889a6093d

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,8 @@ github.com/blevesearch/zapx/v15 v15.4.2/go.mod h1:1pssev/59FsuWcgSnTa0OeEpOzmhtm
 github.com/blevesearch/zapx/v16 v16.2.8 h1:SlnzF0YGtSlrsOE3oE7EgEX6BIepGpeqxs1IjMbHLQI=
 github.com/blevesearch/zapx/v16 v16.2.8/go.mod h1:murSoCJPCk25MqURrcJaBQ1RekuqSCSfMjXH4rHyA14=
 github.com/boltdb/bolt v1.3.1-0.20170131192018-e9cf4fae01b5/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
+github.com/boxes-ltd/imaging v1.7.5 h1:k4kYxJEhysoGhEEN1IEeKoSbnG8/8snjj7M48Ok0fnk=
+github.com/boxes-ltd/imaging v1.7.5/go.mod h1:+8H+oRvis3InOFtTpcoCCB1RDXqo6p9tQBtjZfWnrC8=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -350,8 +352,6 @@ github.com/disintegration/gift v1.1.2 h1:9ZyHJr+kPamiH10FX3Pynt1AxFUob812bU9Wt4G
 github.com/disintegration/gift v1.1.2/go.mod h1:Jh2i7f7Q2BM7Ezno3PhfezbR1xpUg9dUg3/RlKGr4HI=
 github.com/disintegration/imageorient v0.0.0-20180920195336-8147d86e83ec h1:YrB6aVr9touOt75I9O1SiancmR2GMg45U9UYf0gtgWg=
 github.com/disintegration/imageorient v0.0.0-20180920195336-8147d86e83ec/go.mod h1:K0KBFIr1gWu/C1Gp10nFAcAE4hsB7JxE6OgLijrJ8Sk=
-github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
-github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/djherbis/atime v1.0.0 h1:ySLvBAM0EvOGaX7TI4dAM5lWj+RdJUCKtGSEHN8SGBg=
@@ -1771,7 +1771,6 @@ golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 h1:fQsdNF2N+/YewlRZiricy4P1i
 golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93/go.mod h1:EPRbTFwzwjXj9NpYyyrvenVh9Y+GFeEvMNh7Xuz7xgU=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
 golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/scheduler/actions/images/encoding/codec.go
+++ b/scheduler/actions/images/encoding/codec.go
@@ -25,8 +25,8 @@ import (
 	"image/color"
 	"io"
 
+	"github.com/boxes-ltd/imaging"
 	"github.com/disintegration/imageorient"
-	"github.com/disintegration/imaging"
 	_ "golang.org/x/image/tiff"
 	_ "golang.org/x/image/webp"
 )
@@ -71,7 +71,7 @@ type ImageCodec interface {
 	Overlay(dst, src image.Image, pos image.Point, opacity float64) image.Image
 }
 
-// defaultCodec implements ImageCodec using the github.com/disintegration/imaging package
+// defaultCodec implements ImageCodec using the github.com/boxes-ltd/imaging package
 type defaultCodec struct {
 	format ImageFormat
 }


### PR DESCRIPTION
Refer to https://wearezeta.atlassian.net/browse/WPB-19709 replacing `github.com/disintegration/imaging`