### PR TITLE
feat(ev): WPB-22900-Entity value policies

### DIFF
--- a/assets/start.yaml
+++ b/assets/start.yaml
@@ -223,6 +223,13 @@ services: &services
         - type: sql
           prefix: idm_usr_
           policies: idm_usr_meta_policies
+      meta-entities:
+        - type: sql
+          prefix: idm_usr_
+          policies: idm_usr_entity_policies
+      meta-entity-values:
+        - type: sql
+          prefix: idm_usr_
   pydio.grpc.data.index:
     storages:
       main:

--- a/assets/start.yaml
+++ b/assets/start.yaml
@@ -223,6 +223,14 @@ services: &services
         - type: sql
           prefix: idm_usr_
           policies: idm_usr_meta_policies
+      meta-entities:
+        - type: sql
+          prefix: idm_usr_
+          policies: idm_usr_entity_policies
+      meta-entity-values:
+        - type: sql
+          prefix: idm_usr_
+          policies: idm_usr_entity_values_policies
   pydio.grpc.data.index:
     storages:
       main:

--- a/common/proto/idm/cells-idm.pb.go
+++ b/common/proto/idm/cells-idm.pb.go
@@ -329,7 +329,7 @@ func (x UpdateUserMetaRequest_UserMetaOp) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use UpdateUserMetaRequest_UserMetaOp.Descriptor instead.
 func (UpdateUserMetaRequest_UserMetaOp) EnumDescriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{57, 0}
+	return file_cells_idm_proto_rawDescGZIP(), []int{65, 0}
 }
 
 type UpdateUserMetaEvent_UserMetaOpEvent int32
@@ -375,7 +375,7 @@ func (x UpdateUserMetaEvent_UserMetaOpEvent) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use UpdateUserMetaEvent_UserMetaOpEvent.Descriptor instead.
 func (UpdateUserMetaEvent_UserMetaOpEvent) EnumDescriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{59, 0}
+	return file_cells_idm_proto_rawDescGZIP(), []int{67, 0}
 }
 
 type UpdateUserMetaNamespaceRequest_UserMetaNsOp int32
@@ -421,7 +421,7 @@ func (x UpdateUserMetaNamespaceRequest_UserMetaNsOp) Number() protoreflect.EnumN
 
 // Deprecated: Use UpdateUserMetaNamespaceRequest_UserMetaNsOp.Descriptor instead.
 func (UpdateUserMetaNamespaceRequest_UserMetaNsOp) EnumDescriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{62, 0}
+	return file_cells_idm_proto_rawDescGZIP(), []int{70, 0}
 }
 
 // *****************************************************************************
@@ -3299,28 +3299,27 @@ func (x *CreateEntityResponse) GetEntity() *MetaEntity {
 	return nil
 }
 
-// Delete EntityValuesRequest, takes the EntityUuid and delete all its values and associations with metas
-type DeleteEntityValuesResponse struct {
+type DeleteEntityRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	RowsDeleted   int64                  `protobuf:"varint,1,opt,name=RowsDeleted,proto3" json:"RowsDeleted,omitempty"`
+	EntityId      string                 `protobuf:"bytes,1,opt,name=EntityId,proto3" json:"EntityId,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DeleteEntityValuesResponse) Reset() {
-	*x = DeleteEntityValuesResponse{}
+func (x *DeleteEntityRequest) Reset() {
+	*x = DeleteEntityRequest{}
 	mi := &file_cells_idm_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DeleteEntityValuesResponse) String() string {
+func (x *DeleteEntityRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DeleteEntityValuesResponse) ProtoMessage() {}
+func (*DeleteEntityRequest) ProtoMessage() {}
 
-func (x *DeleteEntityValuesResponse) ProtoReflect() protoreflect.Message {
+func (x *DeleteEntityRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_cells_idm_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -3332,12 +3331,321 @@ func (x *DeleteEntityValuesResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DeleteEntityValuesResponse.ProtoReflect.Descriptor instead.
-func (*DeleteEntityValuesResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use DeleteEntityRequest.ProtoReflect.Descriptor instead.
+func (*DeleteEntityRequest) Descriptor() ([]byte, []int) {
 	return file_cells_idm_proto_rawDescGZIP(), []int{48}
 }
 
-func (x *DeleteEntityValuesResponse) GetRowsDeleted() int64 {
+func (x *DeleteEntityRequest) GetEntityId() string {
+	if x != nil {
+		return x.EntityId
+	}
+	return ""
+}
+
+type DeleteEntityResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RowsDeleted   int64                  `protobuf:"varint,1,opt,name=RowsDeleted,proto3" json:"RowsDeleted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteEntityResponse) Reset() {
+	*x = DeleteEntityResponse{}
+	mi := &file_cells_idm_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteEntityResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteEntityResponse) ProtoMessage() {}
+
+func (x *DeleteEntityResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteEntityResponse.ProtoReflect.Descriptor instead.
+func (*DeleteEntityResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{49}
+}
+
+func (x *DeleteEntityResponse) GetRowsDeleted() int64 {
+	if x != nil {
+		return x.RowsDeleted
+	}
+	return 0
+}
+
+type ListEntitiesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EntityId      string                 `protobuf:"bytes,1,opt,name=EntityId,proto3" json:"EntityId,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListEntitiesRequest) Reset() {
+	*x = ListEntitiesRequest{}
+	mi := &file_cells_idm_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListEntitiesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListEntitiesRequest) ProtoMessage() {}
+
+func (x *ListEntitiesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListEntitiesRequest.ProtoReflect.Descriptor instead.
+func (*ListEntitiesRequest) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *ListEntitiesRequest) GetEntityId() string {
+	if x != nil {
+		return x.EntityId
+	}
+	return ""
+}
+
+type ListEntitiesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entity        []*MetaEntity          `protobuf:"bytes,1,rep,name=Entity,proto3" json:"Entity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListEntitiesResponse) Reset() {
+	*x = ListEntitiesResponse{}
+	mi := &file_cells_idm_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListEntitiesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListEntitiesResponse) ProtoMessage() {}
+
+func (x *ListEntitiesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListEntitiesResponse.ProtoReflect.Descriptor instead.
+func (*ListEntitiesResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{51}
+}
+
+func (x *ListEntitiesResponse) GetEntity() []*MetaEntity {
+	if x != nil {
+		return x.Entity
+	}
+	return nil
+}
+
+type GetEntityRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EntityUuid    string                 `protobuf:"bytes,1,opt,name=EntityUuid,proto3" json:"EntityUuid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetEntityRequest) Reset() {
+	*x = GetEntityRequest{}
+	mi := &file_cells_idm_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetEntityRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetEntityRequest) ProtoMessage() {}
+
+func (x *GetEntityRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetEntityRequest.ProtoReflect.Descriptor instead.
+func (*GetEntityRequest) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *GetEntityRequest) GetEntityUuid() string {
+	if x != nil {
+		return x.EntityUuid
+	}
+	return ""
+}
+
+type GetEntityResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entity        *MetaEntity            `protobuf:"bytes,1,opt,name=Entity,proto3" json:"Entity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetEntityResponse) Reset() {
+	*x = GetEntityResponse{}
+	mi := &file_cells_idm_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetEntityResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetEntityResponse) ProtoMessage() {}
+
+func (x *GetEntityResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetEntityResponse.ProtoReflect.Descriptor instead.
+func (*GetEntityResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *GetEntityResponse) GetEntity() *MetaEntity {
+	if x != nil {
+		return x.Entity
+	}
+	return nil
+}
+
+// Delete EntityValuesRequest, takes the EntityUuid and delete all its values and associations with metas
+type DeleteEntityValueRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	EntityValueUuid string                 `protobuf:"bytes,1,opt,name=EntityValueUuid,proto3" json:"EntityValueUuid,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *DeleteEntityValueRequest) Reset() {
+	*x = DeleteEntityValueRequest{}
+	mi := &file_cells_idm_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteEntityValueRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteEntityValueRequest) ProtoMessage() {}
+
+func (x *DeleteEntityValueRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteEntityValueRequest.ProtoReflect.Descriptor instead.
+func (*DeleteEntityValueRequest) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{54}
+}
+
+func (x *DeleteEntityValueRequest) GetEntityValueUuid() string {
+	if x != nil {
+		return x.EntityValueUuid
+	}
+	return ""
+}
+
+type DeleteEntityValueResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RowsDeleted   int64                  `protobuf:"varint,1,opt,name=RowsDeleted,proto3" json:"RowsDeleted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteEntityValueResponse) Reset() {
+	*x = DeleteEntityValueResponse{}
+	mi := &file_cells_idm_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteEntityValueResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteEntityValueResponse) ProtoMessage() {}
+
+func (x *DeleteEntityValueResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteEntityValueResponse.ProtoReflect.Descriptor instead.
+func (*DeleteEntityValueResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *DeleteEntityValueResponse) GetRowsDeleted() int64 {
 	if x != nil {
 		return x.RowsDeleted
 	}
@@ -3354,7 +3662,7 @@ type GetMetaEntityValuesRequest struct {
 
 func (x *GetMetaEntityValuesRequest) Reset() {
 	*x = GetMetaEntityValuesRequest{}
-	mi := &file_cells_idm_proto_msgTypes[49]
+	mi := &file_cells_idm_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3366,7 +3674,7 @@ func (x *GetMetaEntityValuesRequest) String() string {
 func (*GetMetaEntityValuesRequest) ProtoMessage() {}
 
 func (x *GetMetaEntityValuesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[49]
+	mi := &file_cells_idm_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3379,7 +3687,7 @@ func (x *GetMetaEntityValuesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMetaEntityValuesRequest.ProtoReflect.Descriptor instead.
 func (*GetMetaEntityValuesRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{49}
+	return file_cells_idm_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *GetMetaEntityValuesRequest) GetEntityUuid() string {
@@ -3399,7 +3707,7 @@ type MetaEntityValueResponse struct {
 
 func (x *MetaEntityValueResponse) Reset() {
 	*x = MetaEntityValueResponse{}
-	mi := &file_cells_idm_proto_msgTypes[50]
+	mi := &file_cells_idm_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3411,7 +3719,7 @@ func (x *MetaEntityValueResponse) String() string {
 func (*MetaEntityValueResponse) ProtoMessage() {}
 
 func (x *MetaEntityValueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[50]
+	mi := &file_cells_idm_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3424,7 +3732,7 @@ func (x *MetaEntityValueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetaEntityValueResponse.ProtoReflect.Descriptor instead.
 func (*MetaEntityValueResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{50}
+	return file_cells_idm_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *MetaEntityValueResponse) GetEntityValue() []*EntityValue {
@@ -3445,7 +3753,7 @@ type MetaToEntityValueRequest struct {
 
 func (x *MetaToEntityValueRequest) Reset() {
 	*x = MetaToEntityValueRequest{}
-	mi := &file_cells_idm_proto_msgTypes[51]
+	mi := &file_cells_idm_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3457,7 +3765,7 @@ func (x *MetaToEntityValueRequest) String() string {
 func (*MetaToEntityValueRequest) ProtoMessage() {}
 
 func (x *MetaToEntityValueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[51]
+	mi := &file_cells_idm_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3470,7 +3778,7 @@ func (x *MetaToEntityValueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetaToEntityValueRequest.ProtoReflect.Descriptor instead.
 func (*MetaToEntityValueRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{51}
+	return file_cells_idm_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *MetaToEntityValueRequest) GetMetaUuid() string {
@@ -3497,7 +3805,7 @@ type MetaToEntityValueResponse struct {
 
 func (x *MetaToEntityValueResponse) Reset() {
 	*x = MetaToEntityValueResponse{}
-	mi := &file_cells_idm_proto_msgTypes[52]
+	mi := &file_cells_idm_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3509,7 +3817,7 @@ func (x *MetaToEntityValueResponse) String() string {
 func (*MetaToEntityValueResponse) ProtoMessage() {}
 
 func (x *MetaToEntityValueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[52]
+	mi := &file_cells_idm_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3522,7 +3830,7 @@ func (x *MetaToEntityValueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetaToEntityValueResponse.ProtoReflect.Descriptor instead.
 func (*MetaToEntityValueResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{52}
+	return file_cells_idm_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *MetaToEntityValueResponse) GetSuccess() bool {
@@ -3555,7 +3863,7 @@ type UserMeta struct {
 
 func (x *UserMeta) Reset() {
 	*x = UserMeta{}
-	mi := &file_cells_idm_proto_msgTypes[53]
+	mi := &file_cells_idm_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3567,7 +3875,7 @@ func (x *UserMeta) String() string {
 func (*UserMeta) ProtoMessage() {}
 
 func (x *UserMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[53]
+	mi := &file_cells_idm_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3580,7 +3888,7 @@ func (x *UserMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserMeta.ProtoReflect.Descriptor instead.
 func (*UserMeta) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{53}
+	return file_cells_idm_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *UserMeta) GetUuid() string {
@@ -3658,14 +3966,16 @@ type UserMetaNamespace struct {
 	// Human-readable Description
 	Description string `protobuf:"bytes,11,opt,name=Description,proto3" json:"Description,omitempty"`
 	// Namespace Type  "boolean", "choice", "css_label", "date", "integer", "json", "multi_value", "stars_rate", "string", "tag_cloud", "tags", "textarea", "url"
-	FieldType     string `protobuf:"bytes,12,opt,name=FieldType,proto3" json:"FieldType,omitempty"`
+	FieldType string `protobuf:"bytes,12,opt,name=FieldType,proto3" json:"FieldType,omitempty"`
+	// Associated Entity UUID
+	EntityUUID    string `protobuf:"bytes,13,opt,name=EntityUUID,proto3" json:"EntityUUID,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *UserMetaNamespace) Reset() {
 	*x = UserMetaNamespace{}
-	mi := &file_cells_idm_proto_msgTypes[54]
+	mi := &file_cells_idm_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3677,7 +3987,7 @@ func (x *UserMetaNamespace) String() string {
 func (*UserMetaNamespace) ProtoMessage() {}
 
 func (x *UserMetaNamespace) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[54]
+	mi := &file_cells_idm_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3690,7 +4000,7 @@ func (x *UserMetaNamespace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserMetaNamespace.ProtoReflect.Descriptor instead.
 func (*UserMetaNamespace) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{54}
+	return file_cells_idm_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *UserMetaNamespace) GetNamespace() string {
@@ -3777,19 +4087,28 @@ func (x *UserMetaNamespace) GetFieldType() string {
 	return ""
 }
 
+func (x *UserMetaNamespace) GetEntityUUID() string {
+	if x != nil {
+		return x.EntityUUID
+	}
+	return ""
+}
+
 // MetaEntity represents a metadata entity (e.g., "Department", "Project")
 type MetaEntity struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Uuid          string                 `protobuf:"bytes,1,opt,name=Uuid,proto3" json:"Uuid,omitempty"`
-	Label         string                 `protobuf:"bytes,2,opt,name=Label,proto3" json:"Label,omitempty"`
-	Description   string                 `protobuf:"bytes,3,opt,name=Description,proto3" json:"Description,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                   protoimpl.MessageState    `protogen:"open.v1"`
+	Uuid                    string                    `protobuf:"bytes,1,opt,name=Uuid,proto3" json:"Uuid,omitempty"`
+	Label                   string                    `protobuf:"bytes,2,opt,name=Label,proto3" json:"Label,omitempty"`
+	Description             string                    `protobuf:"bytes,3,opt,name=Description,proto3" json:"Description,omitempty"`
+	Policies                []*service.ResourcePolicy `protobuf:"bytes,4,rep,name=Policies,proto3" json:"Policies,omitempty"`
+	PoliciesContextEditable bool                      `protobuf:"varint,5,opt,name=PoliciesContextEditable,proto3" json:"PoliciesContextEditable,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *MetaEntity) Reset() {
 	*x = MetaEntity{}
-	mi := &file_cells_idm_proto_msgTypes[55]
+	mi := &file_cells_idm_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3801,7 +4120,7 @@ func (x *MetaEntity) String() string {
 func (*MetaEntity) ProtoMessage() {}
 
 func (x *MetaEntity) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[55]
+	mi := &file_cells_idm_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3814,7 +4133,7 @@ func (x *MetaEntity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetaEntity.ProtoReflect.Descriptor instead.
 func (*MetaEntity) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{55}
+	return file_cells_idm_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *MetaEntity) GetUuid() string {
@@ -3838,20 +4157,37 @@ func (x *MetaEntity) GetDescription() string {
 	return ""
 }
 
+func (x *MetaEntity) GetPolicies() []*service.ResourcePolicy {
+	if x != nil {
+		return x.Policies
+	}
+	return nil
+}
+
+func (x *MetaEntity) GetPoliciesContextEditable() bool {
+	if x != nil {
+		return x.PoliciesContextEditable
+	}
+	return false
+}
+
 // EntityValue represents a value for an entity (e.g., "Engineering", "Sales")
 type EntityValue struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Uuid          string                 `protobuf:"bytes,1,opt,name=Uuid,proto3" json:"Uuid,omitempty"`
-	Label         string                 `protobuf:"bytes,2,opt,name=Label,proto3" json:"Label,omitempty"`
-	EntityUuid    string                 `protobuf:"bytes,3,opt,name=EntityUuid,proto3" json:"EntityUuid,omitempty"`
-	DisplayJSON   string                 `protobuf:"bytes,4,opt,name=DisplayJSON,proto3" json:"DisplayJSON,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                   protoimpl.MessageState    `protogen:"open.v1"`
+	Uuid                    string                    `protobuf:"bytes,1,opt,name=Uuid,proto3" json:"Uuid,omitempty"`
+	Label                   string                    `protobuf:"bytes,2,opt,name=Label,proto3" json:"Label,omitempty"`
+	EntityUuid              string                    `protobuf:"bytes,3,opt,name=EntityUuid,proto3" json:"EntityUuid,omitempty"`
+	DisplayJSON             string                    `protobuf:"bytes,4,opt,name=DisplayJSON,proto3" json:"DisplayJSON,omitempty"`
+	Policies                []*service.ResourcePolicy `protobuf:"bytes,5,rep,name=Policies,proto3" json:"Policies,omitempty"`
+	PoliciesContextEditable bool                      `protobuf:"varint,6,opt,name=PoliciesContextEditable,proto3" json:"PoliciesContextEditable,omitempty"`
+	MetaUuid                string                    `protobuf:"bytes,7,opt,name=MetaUuid,proto3" json:"MetaUuid,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *EntityValue) Reset() {
 	*x = EntityValue{}
-	mi := &file_cells_idm_proto_msgTypes[56]
+	mi := &file_cells_idm_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3863,7 +4199,7 @@ func (x *EntityValue) String() string {
 func (*EntityValue) ProtoMessage() {}
 
 func (x *EntityValue) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[56]
+	mi := &file_cells_idm_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3876,7 +4212,7 @@ func (x *EntityValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EntityValue.ProtoReflect.Descriptor instead.
 func (*EntityValue) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{56}
+	return file_cells_idm_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *EntityValue) GetUuid() string {
@@ -3907,6 +4243,95 @@ func (x *EntityValue) GetDisplayJSON() string {
 	return ""
 }
 
+func (x *EntityValue) GetPolicies() []*service.ResourcePolicy {
+	if x != nil {
+		return x.Policies
+	}
+	return nil
+}
+
+func (x *EntityValue) GetPoliciesContextEditable() bool {
+	if x != nil {
+		return x.PoliciesContextEditable
+	}
+	return false
+}
+
+func (x *EntityValue) GetMetaUuid() string {
+	if x != nil {
+		return x.MetaUuid
+	}
+	return ""
+}
+
+type UpsertUserMetaValue struct {
+	state         protoimpl.MessageState    `protogen:"open.v1"`
+	NodeUuid      string                    `protobuf:"bytes,1,opt,name=NodeUuid,proto3" json:"NodeUuid,omitempty"`
+	Namespace     string                    `protobuf:"bytes,2,opt,name=Namespace,proto3" json:"Namespace,omitempty"`
+	EntityValues  []*EntityValue            `protobuf:"bytes,3,rep,name=EntityValues,proto3" json:"EntityValues,omitempty"`
+	Policies      []*service.ResourcePolicy `protobuf:"bytes,5,rep,name=Policies,proto3" json:"Policies,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpsertUserMetaValue) Reset() {
+	*x = UpsertUserMetaValue{}
+	mi := &file_cells_idm_proto_msgTypes[64]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpsertUserMetaValue) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpsertUserMetaValue) ProtoMessage() {}
+
+func (x *UpsertUserMetaValue) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[64]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpsertUserMetaValue.ProtoReflect.Descriptor instead.
+func (*UpsertUserMetaValue) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{64}
+}
+
+func (x *UpsertUserMetaValue) GetNodeUuid() string {
+	if x != nil {
+		return x.NodeUuid
+	}
+	return ""
+}
+
+func (x *UpsertUserMetaValue) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *UpsertUserMetaValue) GetEntityValues() []*EntityValue {
+	if x != nil {
+		return x.EntityValues
+	}
+	return nil
+}
+
+func (x *UpsertUserMetaValue) GetPolicies() []*service.ResourcePolicy {
+	if x != nil {
+		return x.Policies
+	}
+	return nil
+}
+
 // Request for modifying UserMeta
 type UpdateUserMetaRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -3920,7 +4345,7 @@ type UpdateUserMetaRequest struct {
 
 func (x *UpdateUserMetaRequest) Reset() {
 	*x = UpdateUserMetaRequest{}
-	mi := &file_cells_idm_proto_msgTypes[57]
+	mi := &file_cells_idm_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3932,7 +4357,7 @@ func (x *UpdateUserMetaRequest) String() string {
 func (*UpdateUserMetaRequest) ProtoMessage() {}
 
 func (x *UpdateUserMetaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[57]
+	mi := &file_cells_idm_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3945,7 +4370,7 @@ func (x *UpdateUserMetaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaRequest.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{57}
+	return file_cells_idm_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *UpdateUserMetaRequest) GetOperation() UpdateUserMetaRequest_UserMetaOp {
@@ -3973,7 +4398,7 @@ type UpdateUserMetaResponse struct {
 
 func (x *UpdateUserMetaResponse) Reset() {
 	*x = UpdateUserMetaResponse{}
-	mi := &file_cells_idm_proto_msgTypes[58]
+	mi := &file_cells_idm_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3985,7 +4410,7 @@ func (x *UpdateUserMetaResponse) String() string {
 func (*UpdateUserMetaResponse) ProtoMessage() {}
 
 func (x *UpdateUserMetaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[58]
+	mi := &file_cells_idm_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3998,7 +4423,7 @@ func (x *UpdateUserMetaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaResponse.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{58}
+	return file_cells_idm_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *UpdateUserMetaResponse) GetMetaDatas() []*UserMeta {
@@ -4023,7 +4448,7 @@ type UpdateUserMetaEvent struct {
 
 func (x *UpdateUserMetaEvent) Reset() {
 	*x = UpdateUserMetaEvent{}
-	mi := &file_cells_idm_proto_msgTypes[59]
+	mi := &file_cells_idm_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4035,7 +4460,7 @@ func (x *UpdateUserMetaEvent) String() string {
 func (*UpdateUserMetaEvent) ProtoMessage() {}
 
 func (x *UpdateUserMetaEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[59]
+	mi := &file_cells_idm_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4048,7 +4473,7 @@ func (x *UpdateUserMetaEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaEvent.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaEvent) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{59}
+	return file_cells_idm_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *UpdateUserMetaEvent) GetEventMetadata() map[string]string {
@@ -4091,7 +4516,7 @@ type SearchUserMetaRequest struct {
 
 func (x *SearchUserMetaRequest) Reset() {
 	*x = SearchUserMetaRequest{}
-	mi := &file_cells_idm_proto_msgTypes[60]
+	mi := &file_cells_idm_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4103,7 +4528,7 @@ func (x *SearchUserMetaRequest) String() string {
 func (*SearchUserMetaRequest) ProtoMessage() {}
 
 func (x *SearchUserMetaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[60]
+	mi := &file_cells_idm_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4116,7 +4541,7 @@ func (x *SearchUserMetaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchUserMetaRequest.ProtoReflect.Descriptor instead.
 func (*SearchUserMetaRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{60}
+	return file_cells_idm_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *SearchUserMetaRequest) GetMetaUuids() []string {
@@ -4164,7 +4589,7 @@ type SearchUserMetaResponse struct {
 
 func (x *SearchUserMetaResponse) Reset() {
 	*x = SearchUserMetaResponse{}
-	mi := &file_cells_idm_proto_msgTypes[61]
+	mi := &file_cells_idm_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4176,7 +4601,7 @@ func (x *SearchUserMetaResponse) String() string {
 func (*SearchUserMetaResponse) ProtoMessage() {}
 
 func (x *SearchUserMetaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[61]
+	mi := &file_cells_idm_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4189,7 +4614,7 @@ func (x *SearchUserMetaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchUserMetaResponse.ProtoReflect.Descriptor instead.
 func (*SearchUserMetaResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{61}
+	return file_cells_idm_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *SearchUserMetaResponse) GetUserMeta() *UserMeta {
@@ -4210,7 +4635,7 @@ type UpdateUserMetaNamespaceRequest struct {
 
 func (x *UpdateUserMetaNamespaceRequest) Reset() {
 	*x = UpdateUserMetaNamespaceRequest{}
-	mi := &file_cells_idm_proto_msgTypes[62]
+	mi := &file_cells_idm_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4222,7 +4647,7 @@ func (x *UpdateUserMetaNamespaceRequest) String() string {
 func (*UpdateUserMetaNamespaceRequest) ProtoMessage() {}
 
 func (x *UpdateUserMetaNamespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[62]
+	mi := &file_cells_idm_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4235,7 +4660,7 @@ func (x *UpdateUserMetaNamespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaNamespaceRequest.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaNamespaceRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{62}
+	return file_cells_idm_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *UpdateUserMetaNamespaceRequest) GetOperation() UpdateUserMetaNamespaceRequest_UserMetaNsOp {
@@ -4262,7 +4687,7 @@ type UpdateUserMetaNamespaceResponse struct {
 
 func (x *UpdateUserMetaNamespaceResponse) Reset() {
 	*x = UpdateUserMetaNamespaceResponse{}
-	mi := &file_cells_idm_proto_msgTypes[63]
+	mi := &file_cells_idm_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4274,7 +4699,7 @@ func (x *UpdateUserMetaNamespaceResponse) String() string {
 func (*UpdateUserMetaNamespaceResponse) ProtoMessage() {}
 
 func (x *UpdateUserMetaNamespaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[63]
+	mi := &file_cells_idm_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4287,7 +4712,7 @@ func (x *UpdateUserMetaNamespaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaNamespaceResponse.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaNamespaceResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{63}
+	return file_cells_idm_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *UpdateUserMetaNamespaceResponse) GetNamespaces() []*UserMetaNamespace {
@@ -4306,7 +4731,7 @@ type ListUserMetaNamespaceRequest struct {
 
 func (x *ListUserMetaNamespaceRequest) Reset() {
 	*x = ListUserMetaNamespaceRequest{}
-	mi := &file_cells_idm_proto_msgTypes[64]
+	mi := &file_cells_idm_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4318,7 +4743,7 @@ func (x *ListUserMetaNamespaceRequest) String() string {
 func (*ListUserMetaNamespaceRequest) ProtoMessage() {}
 
 func (x *ListUserMetaNamespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[64]
+	mi := &file_cells_idm_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4331,7 +4756,7 @@ func (x *ListUserMetaNamespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUserMetaNamespaceRequest.ProtoReflect.Descriptor instead.
 func (*ListUserMetaNamespaceRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{64}
+	return file_cells_idm_proto_rawDescGZIP(), []int{72}
 }
 
 // Collection of results
@@ -4344,7 +4769,7 @@ type ListUserMetaNamespaceResponse struct {
 
 func (x *ListUserMetaNamespaceResponse) Reset() {
 	*x = ListUserMetaNamespaceResponse{}
-	mi := &file_cells_idm_proto_msgTypes[65]
+	mi := &file_cells_idm_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4356,7 +4781,7 @@ func (x *ListUserMetaNamespaceResponse) String() string {
 func (*ListUserMetaNamespaceResponse) ProtoMessage() {}
 
 func (x *ListUserMetaNamespaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[65]
+	mi := &file_cells_idm_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4369,7 +4794,7 @@ func (x *ListUserMetaNamespaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUserMetaNamespaceResponse.ProtoReflect.Descriptor instead.
 func (*ListUserMetaNamespaceResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{65}
+	return file_cells_idm_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *ListUserMetaNamespaceResponse) GetUserMetaNamespace() *UserMetaNamespace {
@@ -4388,7 +4813,7 @@ type GetFieldSchemaRequest struct {
 
 func (x *GetFieldSchemaRequest) Reset() {
 	*x = GetFieldSchemaRequest{}
-	mi := &file_cells_idm_proto_msgTypes[66]
+	mi := &file_cells_idm_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4400,7 +4825,7 @@ func (x *GetFieldSchemaRequest) String() string {
 func (*GetFieldSchemaRequest) ProtoMessage() {}
 
 func (x *GetFieldSchemaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[66]
+	mi := &file_cells_idm_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4413,7 +4838,7 @@ func (x *GetFieldSchemaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFieldSchemaRequest.ProtoReflect.Descriptor instead.
 func (*GetFieldSchemaRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{66}
+	return file_cells_idm_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *GetFieldSchemaRequest) GetFieldType() string {
@@ -4432,7 +4857,7 @@ type JsonSchemaResponse struct {
 
 func (x *JsonSchemaResponse) Reset() {
 	*x = JsonSchemaResponse{}
-	mi := &file_cells_idm_proto_msgTypes[67]
+	mi := &file_cells_idm_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4444,7 +4869,7 @@ func (x *JsonSchemaResponse) String() string {
 func (*JsonSchemaResponse) ProtoMessage() {}
 
 func (x *JsonSchemaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[67]
+	mi := &file_cells_idm_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4457,7 +4882,7 @@ func (x *JsonSchemaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JsonSchemaResponse.ProtoReflect.Descriptor instead.
 func (*JsonSchemaResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{67}
+	return file_cells_idm_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *JsonSchemaResponse) GetJsonSchema() *structpb.Struct {
@@ -4478,7 +4903,7 @@ type GetNamespaceSchemaRequest struct {
 
 func (x *GetNamespaceSchemaRequest) Reset() {
 	*x = GetNamespaceSchemaRequest{}
-	mi := &file_cells_idm_proto_msgTypes[68]
+	mi := &file_cells_idm_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4490,7 +4915,7 @@ func (x *GetNamespaceSchemaRequest) String() string {
 func (*GetNamespaceSchemaRequest) ProtoMessage() {}
 
 func (x *GetNamespaceSchemaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[68]
+	mi := &file_cells_idm_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4503,7 +4928,7 @@ func (x *GetNamespaceSchemaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNamespaceSchemaRequest.ProtoReflect.Descriptor instead.
 func (*GetNamespaceSchemaRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{68}
+	return file_cells_idm_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *GetNamespaceSchemaRequest) GetFieldType() string {
@@ -4527,6 +4952,86 @@ func (x *GetNamespaceSchemaRequest) GetFormat() string {
 	return ""
 }
 
+type GetEntitiesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetEntitiesRequest) Reset() {
+	*x = GetEntitiesRequest{}
+	mi := &file_cells_idm_proto_msgTypes[77]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetEntitiesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetEntitiesRequest) ProtoMessage() {}
+
+func (x *GetEntitiesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[77]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetEntitiesRequest.ProtoReflect.Descriptor instead.
+func (*GetEntitiesRequest) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{77}
+}
+
+type GetEntitiesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entities      []*MetaEntity          `protobuf:"bytes,1,rep,name=Entities,proto3" json:"Entities,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetEntitiesResponse) Reset() {
+	*x = GetEntitiesResponse{}
+	mi := &file_cells_idm_proto_msgTypes[78]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetEntitiesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetEntitiesResponse) ProtoMessage() {}
+
+func (x *GetEntitiesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[78]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetEntitiesResponse.ProtoReflect.Descriptor instead.
+func (*GetEntitiesResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{78}
+}
+
+func (x *GetEntitiesResponse) GetEntities() []*MetaEntity {
+	if x != nil {
+		return x.Entities
+	}
+	return nil
+}
+
 // Global Event message for IDM
 type ChangeEvent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -4544,7 +5049,7 @@ type ChangeEvent struct {
 
 func (x *ChangeEvent) Reset() {
 	*x = ChangeEvent{}
-	mi := &file_cells_idm_proto_msgTypes[69]
+	mi := &file_cells_idm_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4556,7 +5061,7 @@ func (x *ChangeEvent) String() string {
 func (*ChangeEvent) ProtoMessage() {}
 
 func (x *ChangeEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[69]
+	mi := &file_cells_idm_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4569,7 +5074,7 @@ func (x *ChangeEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeEvent.ProtoReflect.Descriptor instead.
 func (*ChangeEvent) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{69}
+	return file_cells_idm_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *ChangeEvent) GetJsonType() string {
@@ -4643,7 +5148,7 @@ type PolicyEngineRequest struct {
 
 func (x *PolicyEngineRequest) Reset() {
 	*x = PolicyEngineRequest{}
-	mi := &file_cells_idm_proto_msgTypes[70]
+	mi := &file_cells_idm_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4655,7 +5160,7 @@ func (x *PolicyEngineRequest) String() string {
 func (*PolicyEngineRequest) ProtoMessage() {}
 
 func (x *PolicyEngineRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[70]
+	mi := &file_cells_idm_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4668,7 +5173,7 @@ func (x *PolicyEngineRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyEngineRequest.ProtoReflect.Descriptor instead.
 func (*PolicyEngineRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{70}
+	return file_cells_idm_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *PolicyEngineRequest) GetResource() string {
@@ -4710,7 +5215,7 @@ type PolicyEngineResponse struct {
 
 func (x *PolicyEngineResponse) Reset() {
 	*x = PolicyEngineResponse{}
-	mi := &file_cells_idm_proto_msgTypes[71]
+	mi := &file_cells_idm_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4722,7 +5227,7 @@ func (x *PolicyEngineResponse) String() string {
 func (*PolicyEngineResponse) ProtoMessage() {}
 
 func (x *PolicyEngineResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[71]
+	mi := &file_cells_idm_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4735,7 +5240,7 @@ func (x *PolicyEngineResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyEngineResponse.ProtoReflect.Descriptor instead.
 func (*PolicyEngineResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{71}
+	return file_cells_idm_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *PolicyEngineResponse) GetAllowed() bool {
@@ -4769,7 +5274,7 @@ type PolicyCondition struct {
 
 func (x *PolicyCondition) Reset() {
 	*x = PolicyCondition{}
-	mi := &file_cells_idm_proto_msgTypes[72]
+	mi := &file_cells_idm_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4781,7 +5286,7 @@ func (x *PolicyCondition) String() string {
 func (*PolicyCondition) ProtoMessage() {}
 
 func (x *PolicyCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[72]
+	mi := &file_cells_idm_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4794,7 +5299,7 @@ func (x *PolicyCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyCondition.ProtoReflect.Descriptor instead.
 func (*PolicyCondition) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{72}
+	return file_cells_idm_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *PolicyCondition) GetType() string {
@@ -4818,9 +5323,9 @@ type Policy struct {
 	Subjects      []string                    `protobuf:"bytes,3,rep,name=Subjects,json=subjects,proto3" json:"Subjects,omitempty" gorm:"-:all"`
 	Resources     []string                    `protobuf:"bytes,4,rep,name=Resources,json=resources,proto3" json:"Resources,omitempty" gorm:"-:all"`
 	Actions       []string                    `protobuf:"bytes,5,rep,name=Actions,json=actions,proto3" json:"Actions,omitempty" gorm:"-:all"`
-	OrmSubjects   []*PolicySubject            `protobuf:"bytes,8,rep,name=OrmSubjects,proto3" json:"OrmSubjects,omitempty" gorm:"foreignKey:ID;references:ID;many2many:policy_subject_rel;joinForeignKey:Policy;joinReferences:Subject;constraint:OnDelete:CASCADE;"`
-	OrmResources  []*PolicyResource           `protobuf:"bytes,9,rep,name=OrmResources,proto3" json:"OrmResources,omitempty" gorm:"foreignKey:ID;references:ID;many2many:policy_resource_rel;joinForeignKey:Policy;joinReferences:Resource;constraint:OnDelete:CASCADE;"`
-	OrmActions    []*PolicyAction             `protobuf:"bytes,10,rep,name=OrmActions,proto3" json:"OrmActions,omitempty" gorm:"foreignKey:ID;references:ID;many2many:policy_action_rel;joinForeignKey:Policy;joinReferences:Action;constraint:OnDelete:CASCADE;"`
+	OrmSubjects   []*PolicySubject            `protobuf:"bytes,8,rep,name=OrmSubjects,proto3" json:"OrmSubjects,omitempty" gorm:"foreignKey:ID;references:ID;joinForeignKey:Policy;many2many:policy_subject_rel;joinReferences:Subject;constraint:OnDelete:CASCADE;"`
+	OrmResources  []*PolicyResource           `protobuf:"bytes,9,rep,name=OrmResources,proto3" json:"OrmResources,omitempty" gorm:"foreignKey:ID;references:ID;joinForeignKey:Policy;many2many:policy_resource_rel;joinReferences:Resource;constraint:OnDelete:CASCADE;"`
+	OrmActions    []*PolicyAction             `protobuf:"bytes,10,rep,name=OrmActions,proto3" json:"OrmActions,omitempty" gorm:"foreignKey:ID;references:ID;joinForeignKey:Policy;many2many:policy_action_rel;joinReferences:Action;constraint:OnDelete:CASCADE;"`
 	Effect        PolicyEffect                `protobuf:"varint,6,opt,name=Effect,json=effect,proto3,enum=idm.PolicyEffect" json:"Effect,omitempty" gorm:"column:effect;"`
 	Conditions    map[string]*PolicyCondition `protobuf:"bytes,7,rep,name=Conditions,json=conditions,proto3" json:"Conditions,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value" gorm:"column:conditions;serializer:json;"`
 	unknownFields protoimpl.UnknownFields
@@ -4829,7 +5334,7 @@ type Policy struct {
 
 func (x *Policy) Reset() {
 	*x = Policy{}
-	mi := &file_cells_idm_proto_msgTypes[73]
+	mi := &file_cells_idm_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4841,7 +5346,7 @@ func (x *Policy) String() string {
 func (*Policy) ProtoMessage() {}
 
 func (x *Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[73]
+	mi := &file_cells_idm_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4854,7 +5359,7 @@ func (x *Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy.ProtoReflect.Descriptor instead.
 func (*Policy) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{73}
+	return file_cells_idm_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *Policy) GetID() string {
@@ -4939,7 +5444,7 @@ type PolicySubject struct {
 
 func (x *PolicySubject) Reset() {
 	*x = PolicySubject{}
-	mi := &file_cells_idm_proto_msgTypes[74]
+	mi := &file_cells_idm_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4951,7 +5456,7 @@ func (x *PolicySubject) String() string {
 func (*PolicySubject) ProtoMessage() {}
 
 func (x *PolicySubject) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[74]
+	mi := &file_cells_idm_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4964,7 +5469,7 @@ func (x *PolicySubject) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySubject.ProtoReflect.Descriptor instead.
 func (*PolicySubject) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{74}
+	return file_cells_idm_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *PolicySubject) GetID() string {
@@ -5007,7 +5512,7 @@ type PolicyResource struct {
 
 func (x *PolicyResource) Reset() {
 	*x = PolicyResource{}
-	mi := &file_cells_idm_proto_msgTypes[75]
+	mi := &file_cells_idm_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5019,7 +5524,7 @@ func (x *PolicyResource) String() string {
 func (*PolicyResource) ProtoMessage() {}
 
 func (x *PolicyResource) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[75]
+	mi := &file_cells_idm_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5032,7 +5537,7 @@ func (x *PolicyResource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyResource.ProtoReflect.Descriptor instead.
 func (*PolicyResource) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{75}
+	return file_cells_idm_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *PolicyResource) GetID() string {
@@ -5075,7 +5580,7 @@ type PolicyAction struct {
 
 func (x *PolicyAction) Reset() {
 	*x = PolicyAction{}
-	mi := &file_cells_idm_proto_msgTypes[76]
+	mi := &file_cells_idm_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5087,7 +5592,7 @@ func (x *PolicyAction) String() string {
 func (*PolicyAction) ProtoMessage() {}
 
 func (x *PolicyAction) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[76]
+	mi := &file_cells_idm_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5100,7 +5605,7 @@ func (x *PolicyAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyAction.ProtoReflect.Descriptor instead.
 func (*PolicyAction) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{76}
+	return file_cells_idm_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *PolicyAction) GetID() string {
@@ -5141,7 +5646,7 @@ type PolicyResourceRel struct {
 
 func (x *PolicyResourceRel) Reset() {
 	*x = PolicyResourceRel{}
-	mi := &file_cells_idm_proto_msgTypes[77]
+	mi := &file_cells_idm_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5153,7 +5658,7 @@ func (x *PolicyResourceRel) String() string {
 func (*PolicyResourceRel) ProtoMessage() {}
 
 func (x *PolicyResourceRel) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[77]
+	mi := &file_cells_idm_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5166,7 +5671,7 @@ func (x *PolicyResourceRel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyResourceRel.ProtoReflect.Descriptor instead.
 func (*PolicyResourceRel) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{77}
+	return file_cells_idm_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *PolicyResourceRel) GetPolicy() string {
@@ -5193,7 +5698,7 @@ type PolicySubjectRel struct {
 
 func (x *PolicySubjectRel) Reset() {
 	*x = PolicySubjectRel{}
-	mi := &file_cells_idm_proto_msgTypes[78]
+	mi := &file_cells_idm_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5205,7 +5710,7 @@ func (x *PolicySubjectRel) String() string {
 func (*PolicySubjectRel) ProtoMessage() {}
 
 func (x *PolicySubjectRel) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[78]
+	mi := &file_cells_idm_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5218,7 +5723,7 @@ func (x *PolicySubjectRel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySubjectRel.ProtoReflect.Descriptor instead.
 func (*PolicySubjectRel) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{78}
+	return file_cells_idm_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *PolicySubjectRel) GetPolicy() string {
@@ -5245,7 +5750,7 @@ type PolicyActionRel struct {
 
 func (x *PolicyActionRel) Reset() {
 	*x = PolicyActionRel{}
-	mi := &file_cells_idm_proto_msgTypes[79]
+	mi := &file_cells_idm_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5257,7 +5762,7 @@ func (x *PolicyActionRel) String() string {
 func (*PolicyActionRel) ProtoMessage() {}
 
 func (x *PolicyActionRel) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[79]
+	mi := &file_cells_idm_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5270,7 +5775,7 @@ func (x *PolicyActionRel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyActionRel.ProtoReflect.Descriptor instead.
 func (*PolicyActionRel) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{79}
+	return file_cells_idm_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *PolicyActionRel) GetPolicy() string {
@@ -5298,7 +5803,7 @@ type PolicyRel struct {
 
 func (x *PolicyRel) Reset() {
 	*x = PolicyRel{}
-	mi := &file_cells_idm_proto_msgTypes[80]
+	mi := &file_cells_idm_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5310,7 +5815,7 @@ func (x *PolicyRel) String() string {
 func (*PolicyRel) ProtoMessage() {}
 
 func (x *PolicyRel) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[80]
+	mi := &file_cells_idm_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5323,7 +5828,7 @@ func (x *PolicyRel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyRel.ProtoReflect.Descriptor instead.
 func (*PolicyRel) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{80}
+	return file_cells_idm_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *PolicyRel) GetID() int64 {
@@ -5355,14 +5860,14 @@ type PolicyGroup struct {
 	OwnerUuid     string                 `protobuf:"bytes,4,opt,name=OwnerUuid,proto3" json:"OwnerUuid,omitempty" gorm:"column:owner_uuid;"`
 	ResourceGroup PolicyResourceGroup    `protobuf:"varint,5,opt,name=ResourceGroup,proto3,enum=idm.PolicyResourceGroup" json:"ResourceGroup,omitempty" gorm:"column:resource_group;"`
 	LastUpdated   int32                  `protobuf:"varint,6,opt,name=LastUpdated,proto3" json:"LastUpdated,omitempty" gorm:"column:last_updated;"`
-	Policies      []*Policy              `protobuf:"bytes,7,rep,name=Policies,proto3" json:"Policies,omitempty" gorm:"foreignKey:Uuid;references:ID;many2many:policy_rel;joinForeignKey:GroupUUID;joinReferences:PolicyID;"`
+	Policies      []*Policy              `protobuf:"bytes,7,rep,name=Policies,proto3" json:"Policies,omitempty" gorm:"foreignKey:Uuid;references:ID;joinForeignKey:GroupUUID;many2many:policy_rel;joinReferences:PolicyID;"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PolicyGroup) Reset() {
 	*x = PolicyGroup{}
-	mi := &file_cells_idm_proto_msgTypes[81]
+	mi := &file_cells_idm_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5374,7 +5879,7 @@ func (x *PolicyGroup) String() string {
 func (*PolicyGroup) ProtoMessage() {}
 
 func (x *PolicyGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[81]
+	mi := &file_cells_idm_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5387,7 +5892,7 @@ func (x *PolicyGroup) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyGroup.ProtoReflect.Descriptor instead.
 func (*PolicyGroup) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{81}
+	return file_cells_idm_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *PolicyGroup) GetUuid() string {
@@ -5449,7 +5954,7 @@ type StorePolicyGroupRequest struct {
 
 func (x *StorePolicyGroupRequest) Reset() {
 	*x = StorePolicyGroupRequest{}
-	mi := &file_cells_idm_proto_msgTypes[82]
+	mi := &file_cells_idm_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5461,7 +5966,7 @@ func (x *StorePolicyGroupRequest) String() string {
 func (*StorePolicyGroupRequest) ProtoMessage() {}
 
 func (x *StorePolicyGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[82]
+	mi := &file_cells_idm_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5474,7 +5979,7 @@ func (x *StorePolicyGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorePolicyGroupRequest.ProtoReflect.Descriptor instead.
 func (*StorePolicyGroupRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{82}
+	return file_cells_idm_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *StorePolicyGroupRequest) GetPolicyGroup() *PolicyGroup {
@@ -5493,7 +5998,7 @@ type StorePolicyGroupResponse struct {
 
 func (x *StorePolicyGroupResponse) Reset() {
 	*x = StorePolicyGroupResponse{}
-	mi := &file_cells_idm_proto_msgTypes[83]
+	mi := &file_cells_idm_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5505,7 +6010,7 @@ func (x *StorePolicyGroupResponse) String() string {
 func (*StorePolicyGroupResponse) ProtoMessage() {}
 
 func (x *StorePolicyGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[83]
+	mi := &file_cells_idm_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5518,7 +6023,7 @@ func (x *StorePolicyGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorePolicyGroupResponse.ProtoReflect.Descriptor instead.
 func (*StorePolicyGroupResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{83}
+	return file_cells_idm_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *StorePolicyGroupResponse) GetPolicyGroup() *PolicyGroup {
@@ -5537,7 +6042,7 @@ type DeletePolicyGroupRequest struct {
 
 func (x *DeletePolicyGroupRequest) Reset() {
 	*x = DeletePolicyGroupRequest{}
-	mi := &file_cells_idm_proto_msgTypes[84]
+	mi := &file_cells_idm_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5549,7 +6054,7 @@ func (x *DeletePolicyGroupRequest) String() string {
 func (*DeletePolicyGroupRequest) ProtoMessage() {}
 
 func (x *DeletePolicyGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[84]
+	mi := &file_cells_idm_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5562,7 +6067,7 @@ func (x *DeletePolicyGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeletePolicyGroupRequest.ProtoReflect.Descriptor instead.
 func (*DeletePolicyGroupRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{84}
+	return file_cells_idm_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *DeletePolicyGroupRequest) GetPolicyGroup() *PolicyGroup {
@@ -5581,7 +6086,7 @@ type DeletePolicyGroupResponse struct {
 
 func (x *DeletePolicyGroupResponse) Reset() {
 	*x = DeletePolicyGroupResponse{}
-	mi := &file_cells_idm_proto_msgTypes[85]
+	mi := &file_cells_idm_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5593,7 +6098,7 @@ func (x *DeletePolicyGroupResponse) String() string {
 func (*DeletePolicyGroupResponse) ProtoMessage() {}
 
 func (x *DeletePolicyGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[85]
+	mi := &file_cells_idm_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5606,7 +6111,7 @@ func (x *DeletePolicyGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeletePolicyGroupResponse.ProtoReflect.Descriptor instead.
 func (*DeletePolicyGroupResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{85}
+	return file_cells_idm_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *DeletePolicyGroupResponse) GetSuccess() bool {
@@ -5628,7 +6133,7 @@ type ListPolicyGroupsRequest struct {
 
 func (x *ListPolicyGroupsRequest) Reset() {
 	*x = ListPolicyGroupsRequest{}
-	mi := &file_cells_idm_proto_msgTypes[86]
+	mi := &file_cells_idm_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5640,7 +6145,7 @@ func (x *ListPolicyGroupsRequest) String() string {
 func (*ListPolicyGroupsRequest) ProtoMessage() {}
 
 func (x *ListPolicyGroupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[86]
+	mi := &file_cells_idm_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5653,7 +6158,7 @@ func (x *ListPolicyGroupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPolicyGroupsRequest.ProtoReflect.Descriptor instead.
 func (*ListPolicyGroupsRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{86}
+	return file_cells_idm_proto_rawDescGZIP(), []int{96}
 }
 
 // Deprecated: Marked as deprecated in cells-idm.proto.
@@ -5681,7 +6186,7 @@ type ListPolicyGroupsResponse struct {
 
 func (x *ListPolicyGroupsResponse) Reset() {
 	*x = ListPolicyGroupsResponse{}
-	mi := &file_cells_idm_proto_msgTypes[87]
+	mi := &file_cells_idm_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5693,7 +6198,7 @@ func (x *ListPolicyGroupsResponse) String() string {
 func (*ListPolicyGroupsResponse) ProtoMessage() {}
 
 func (x *ListPolicyGroupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[87]
+	mi := &file_cells_idm_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5706,7 +6211,7 @@ func (x *ListPolicyGroupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPolicyGroupsResponse.ProtoReflect.Descriptor instead.
 func (*ListPolicyGroupsResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{87}
+	return file_cells_idm_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *ListPolicyGroupsResponse) GetPolicyGroups() []*PolicyGroup {
@@ -5742,7 +6247,7 @@ type PolicyGroupSingleQuery struct {
 
 func (x *PolicyGroupSingleQuery) Reset() {
 	*x = PolicyGroupSingleQuery{}
-	mi := &file_cells_idm_proto_msgTypes[88]
+	mi := &file_cells_idm_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5754,7 +6259,7 @@ func (x *PolicyGroupSingleQuery) String() string {
 func (*PolicyGroupSingleQuery) ProtoMessage() {}
 
 func (x *PolicyGroupSingleQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[88]
+	mi := &file_cells_idm_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5767,7 +6272,7 @@ func (x *PolicyGroupSingleQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyGroupSingleQuery.ProtoReflect.Descriptor instead.
 func (*PolicyGroupSingleQuery) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{88}
+	return file_cells_idm_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *PolicyGroupSingleQuery) GetResourceGroup() string {
@@ -6069,8 +6574,24 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\x13CreateEntityRequest\x12'\n" +
 	"\x06Entity\x18\x01 \x01(\v2\x0f.idm.MetaEntityR\x06Entity\"?\n" +
 	"\x14CreateEntityResponse\x12'\n" +
-	"\x06Entity\x18\x01 \x01(\v2\x0f.idm.MetaEntityR\x06Entity\">\n" +
-	"\x1aDeleteEntityValuesResponse\x12 \n" +
+	"\x06Entity\x18\x01 \x01(\v2\x0f.idm.MetaEntityR\x06Entity\"1\n" +
+	"\x13DeleteEntityRequest\x12\x1a\n" +
+	"\bEntityId\x18\x01 \x01(\tR\bEntityId\"8\n" +
+	"\x14DeleteEntityResponse\x12 \n" +
+	"\vRowsDeleted\x18\x01 \x01(\x03R\vRowsDeleted\"1\n" +
+	"\x13ListEntitiesRequest\x12\x1a\n" +
+	"\bEntityId\x18\x01 \x01(\tR\bEntityId\"?\n" +
+	"\x14ListEntitiesResponse\x12'\n" +
+	"\x06Entity\x18\x01 \x03(\v2\x0f.idm.MetaEntityR\x06Entity\"2\n" +
+	"\x10GetEntityRequest\x12\x1e\n" +
+	"\n" +
+	"EntityUuid\x18\x01 \x01(\tR\n" +
+	"EntityUuid\"<\n" +
+	"\x11GetEntityResponse\x12'\n" +
+	"\x06Entity\x18\x01 \x01(\v2\x0f.idm.MetaEntityR\x06Entity\"D\n" +
+	"\x18DeleteEntityValueRequest\x12(\n" +
+	"\x0fEntityValueUuid\x18\x01 \x01(\tR\x0fEntityValueUuid\"=\n" +
+	"\x19DeleteEntityValueResponse\x12 \n" +
 	"\vRowsDeleted\x18\x01 \x01(\x03R\vRowsDeleted\"<\n" +
 	"\x1aGetMetaEntityValuesRequest\x12\x1e\n" +
 	"\n" +
@@ -6091,7 +6612,7 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\bPolicies\x18\x05 \x03(\v2\x17.service.ResourcePolicyR\bPolicies\x128\n" +
 	"\x17PoliciesContextEditable\x18\x06 \x01(\bR\x17PoliciesContextEditable\x12.\n" +
 	"\fResolvedNode\x18\a \x01(\v2\n" +
-	".tree.NodeR\fResolvedNode\"\xdb\x03\n" +
+	".tree.NodeR\fResolvedNode\"\xfb\x03\n" +
 	"\x11UserMetaNamespace\x12\x1c\n" +
 	"\tNamespace\x18\x01 \x01(\tR\tNamespace\x12\x14\n" +
 	"\x05Label\x18\x02 \x01(\tR\x05Label\x12\x14\n" +
@@ -6107,19 +6628,32 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\x0eEnforceDefault\x18\n" +
 	" \x01(\bR\x0eEnforceDefault\x12 \n" +
 	"\vDescription\x18\v \x01(\tR\vDescription\x12\x1c\n" +
-	"\tFieldType\x18\f \x01(\tR\tFieldType\"X\n" +
+	"\tFieldType\x18\f \x01(\tR\tFieldType\x12\x1e\n" +
+	"\n" +
+	"EntityUUID\x18\r \x01(\tR\n" +
+	"EntityUUID\"\xc7\x01\n" +
 	"\n" +
 	"MetaEntity\x12\x12\n" +
 	"\x04Uuid\x18\x01 \x01(\tR\x04Uuid\x12\x14\n" +
 	"\x05Label\x18\x02 \x01(\tR\x05Label\x12 \n" +
-	"\vDescription\x18\x03 \x01(\tR\vDescription\"y\n" +
+	"\vDescription\x18\x03 \x01(\tR\vDescription\x123\n" +
+	"\bPolicies\x18\x04 \x03(\v2\x17.service.ResourcePolicyR\bPolicies\x128\n" +
+	"\x17PoliciesContextEditable\x18\x05 \x01(\bR\x17PoliciesContextEditable\"\x84\x02\n" +
 	"\vEntityValue\x12\x12\n" +
 	"\x04Uuid\x18\x01 \x01(\tR\x04Uuid\x12\x14\n" +
 	"\x05Label\x18\x02 \x01(\tR\x05Label\x12\x1e\n" +
 	"\n" +
 	"EntityUuid\x18\x03 \x01(\tR\n" +
 	"EntityUuid\x12 \n" +
-	"\vDisplayJSON\x18\x04 \x01(\tR\vDisplayJSON\"\xac\x01\n" +
+	"\vDisplayJSON\x18\x04 \x01(\tR\vDisplayJSON\x123\n" +
+	"\bPolicies\x18\x05 \x03(\v2\x17.service.ResourcePolicyR\bPolicies\x128\n" +
+	"\x17PoliciesContextEditable\x18\x06 \x01(\bR\x17PoliciesContextEditable\x12\x1a\n" +
+	"\bMetaUuid\x18\a \x01(\tR\bMetaUuid\"\xba\x01\n" +
+	"\x13UpsertUserMetaValue\x12\x1a\n" +
+	"\bNodeUuid\x18\x01 \x01(\tR\bNodeUuid\x12\x1c\n" +
+	"\tNamespace\x18\x02 \x01(\tR\tNamespace\x124\n" +
+	"\fEntityValues\x18\x03 \x03(\v2\x10.idm.EntityValueR\fEntityValues\x123\n" +
+	"\bPolicies\x18\x05 \x03(\v2\x17.service.ResourcePolicyR\bPolicies\"\xac\x01\n" +
 	"\x15UpdateUserMetaRequest\x12C\n" +
 	"\tOperation\x18\x01 \x01(\x0e2%.idm.UpdateUserMetaRequest.UserMetaOpR\tOperation\x12+\n" +
 	"\tMetaDatas\x18\x03 \x03(\v2\r.idm.UserMetaR\tMetaDatas\"!\n" +
@@ -6174,7 +6708,10 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\x19GetNamespaceSchemaRequest\x12\x1c\n" +
 	"\tFieldType\x18\x01 \x01(\tR\tFieldType\x12\x1c\n" +
 	"\tNamespace\x18\x02 \x01(\tR\tNamespace\x12\x16\n" +
-	"\x06Format\x18\x03 \x01(\tR\x06Format\"\x97\x03\n" +
+	"\x06Format\x18\x03 \x01(\tR\x06Format\"\x14\n" +
+	"\x12GetEntitiesRequest\"B\n" +
+	"\x13GetEntitiesResponse\x12+\n" +
+	"\bEntities\x18\x01 \x03(\v2\x0f.idm.MetaEntityR\bEntities\"\x97\x03\n" +
 	"\vChangeEvent\x12\x17\n" +
 	"\bjsonType\x18\x01 \x01(\tR\x05@type\x12(\n" +
 	"\x04Type\x18\x02 \x01(\x0e2\x14.idm.ChangeEventTypeR\x04Type\x12\x1d\n" +
@@ -6422,7 +6959,8 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\tSearchACL\x12\x15.idm.SearchACLRequest\x1a\x16.idm.SearchACLResponse\"\x000\x01\x12@\n" +
 	"\tStreamACL\x12\x15.idm.SearchACLRequest\x1a\x16.idm.SearchACLResponse\"\x00(\x010\x01\x12?\n" +
 	"\n" +
-	"RestoreACL\x12\x16.idm.RestoreACLRequest\x1a\x17.idm.RestoreACLResponse\"\x002\xca\b\n" +
+	"RestoreACL\x12\x16.idm.RestoreACLRequest\x1a\x17.idm.RestoreACLResponse\"\x002\x98\n" +
+	"\n" +
 	"\x0fUserMetaService\x12K\n" +
 	"\x0eUpdateUserMeta\x12\x1a.idm.UpdateUserMetaRequest\x1a\x1b.idm.UpdateUserMetaResponse\"\x00\x12M\n" +
 	"\x0eSearchUserMeta\x12\x1a.idm.SearchUserMetaRequest\x1a\x1b.idm.SearchUserMetaResponse\"\x000\x01\x12f\n" +
@@ -6430,13 +6968,16 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\x15ListUserMetaNamespace\x12!.idm.ListUserMetaNamespaceRequest\x1a\".idm.ListUserMetaNamespaceResponse\"\x000\x01\x12G\n" +
 	"\x0eGetFieldSchema\x12\x1a.idm.GetFieldSchemaRequest\x1a\x17.idm.JsonSchemaResponse\"\x00\x12O\n" +
 	"\x12GetNamespaceSchema\x12\x1e.idm.GetNamespaceSchemaRequest\x1a\x17.idm.JsonSchemaResponse\"\x00\x12R\n" +
-	"\x0fGetEntityValues\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1c.idm.MetaEntityValueResponse\"\x00\x12R\n" +
-	"\fDeleteEntity\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1f.idm.DeleteEntityValuesResponse\"\x00\x12E\n" +
+	"\x0fGetEntityValues\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1c.idm.MetaEntityValueResponse\"\x00\x12E\n" +
+	"\fDeleteEntity\x12\x18.idm.DeleteEntityRequest\x1a\x19.idm.DeleteEntityResponse\"\x00\x12<\n" +
+	"\tGetEntity\x12\x15.idm.GetEntityRequest\x1a\x16.idm.GetEntityResponse\"\x00\x12E\n" +
+	"\fListEntities\x12\x18.idm.ListEntitiesRequest\x1a\x19.idm.ListEntitiesResponse\"\x00\x12E\n" +
 	"\fCreateEntity\x12\x18.idm.CreateEntityRequest\x1a\x19.idm.CreateEntityResponse\"\x00\x12U\n" +
 	"\x12CreateEntityValues\x12\x1d.idm.CreateEntityValueRequest\x1a\x1e.idm.CreateEntityValueResponse\"\x00\x12X\n" +
 	"\x15LinkMetaToEntityValue\x12\x1d.idm.MetaToEntityValueRequest\x1a\x1e.idm.MetaToEntityValueResponse\"\x00\x12\\\n" +
 	"\x19UnlinkMetaFromEntityValue\x12\x1d.idm.MetaToEntityValueRequest\x1a\x1e.idm.MetaToEntityValueResponse\"\x00\x127\n" +
-	"\vGetMetadata\x12\x17.idm.GetMetadataRequest\x1a\r.idm.UserMeta\"\x002\x9f\x03\n" +
+	"\vGetMetadata\x12\x17.idm.GetMetadataRequest\x1a\r.idm.UserMeta\"\x00\x12T\n" +
+	"\x11DeleteEntityValue\x12\x1d.idm.DeleteEntityValueRequest\x1a\x1e.idm.DeleteEntityValueResponse\"\x002\x9f\x03\n" +
 	"\x13PolicyEngineService\x12B\n" +
 	"\tIsAllowed\x12\x18.idm.PolicyEngineRequest\x1a\x19.idm.PolicyEngineResponse\"\x00\x12Q\n" +
 	"\x10StorePolicyGroup\x12\x1c.idm.StorePolicyGroupRequest\x1a\x1d.idm.StorePolicyGroupResponse\"\x00\x12Q\n" +
@@ -6457,7 +6998,7 @@ func file_cells_idm_proto_rawDescGZIP() []byte {
 }
 
 var file_cells_idm_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_cells_idm_proto_msgTypes = make([]protoimpl.MessageInfo, 95)
+var file_cells_idm_proto_msgTypes = make([]protoimpl.MessageInfo, 105)
 var file_cells_idm_proto_goTypes = []any{
 	(NodeType)(0),                                    // 0: idm.NodeType
 	(WorkspaceScope)(0),                              // 1: idm.WorkspaceScope
@@ -6515,228 +7056,251 @@ var file_cells_idm_proto_goTypes = []any{
 	(*CreateEntityValueResponse)(nil),                // 53: idm.CreateEntityValueResponse
 	(*CreateEntityRequest)(nil),                      // 54: idm.CreateEntityRequest
 	(*CreateEntityResponse)(nil),                     // 55: idm.CreateEntityResponse
-	(*DeleteEntityValuesResponse)(nil),               // 56: idm.DeleteEntityValuesResponse
-	(*GetMetaEntityValuesRequest)(nil),               // 57: idm.GetMetaEntityValuesRequest
-	(*MetaEntityValueResponse)(nil),                  // 58: idm.MetaEntityValueResponse
-	(*MetaToEntityValueRequest)(nil),                 // 59: idm.MetaToEntityValueRequest
-	(*MetaToEntityValueResponse)(nil),                // 60: idm.MetaToEntityValueResponse
-	(*UserMeta)(nil),                                 // 61: idm.UserMeta
-	(*UserMetaNamespace)(nil),                        // 62: idm.UserMetaNamespace
-	(*MetaEntity)(nil),                               // 63: idm.MetaEntity
-	(*EntityValue)(nil),                              // 64: idm.EntityValue
-	(*UpdateUserMetaRequest)(nil),                    // 65: idm.UpdateUserMetaRequest
-	(*UpdateUserMetaResponse)(nil),                   // 66: idm.UpdateUserMetaResponse
-	(*UpdateUserMetaEvent)(nil),                      // 67: idm.UpdateUserMetaEvent
-	(*SearchUserMetaRequest)(nil),                    // 68: idm.SearchUserMetaRequest
-	(*SearchUserMetaResponse)(nil),                   // 69: idm.SearchUserMetaResponse
-	(*UpdateUserMetaNamespaceRequest)(nil),           // 70: idm.UpdateUserMetaNamespaceRequest
-	(*UpdateUserMetaNamespaceResponse)(nil),          // 71: idm.UpdateUserMetaNamespaceResponse
-	(*ListUserMetaNamespaceRequest)(nil),             // 72: idm.ListUserMetaNamespaceRequest
-	(*ListUserMetaNamespaceResponse)(nil),            // 73: idm.ListUserMetaNamespaceResponse
-	(*GetFieldSchemaRequest)(nil),                    // 74: idm.GetFieldSchemaRequest
-	(*JsonSchemaResponse)(nil),                       // 75: idm.JsonSchemaResponse
-	(*GetNamespaceSchemaRequest)(nil),                // 76: idm.GetNamespaceSchemaRequest
-	(*ChangeEvent)(nil),                              // 77: idm.ChangeEvent
-	(*PolicyEngineRequest)(nil),                      // 78: idm.PolicyEngineRequest
-	(*PolicyEngineResponse)(nil),                     // 79: idm.PolicyEngineResponse
-	(*PolicyCondition)(nil),                          // 80: idm.PolicyCondition
-	(*Policy)(nil),                                   // 81: idm.Policy
-	(*PolicySubject)(nil),                            // 82: idm.PolicySubject
-	(*PolicyResource)(nil),                           // 83: idm.PolicyResource
-	(*PolicyAction)(nil),                             // 84: idm.PolicyAction
-	(*PolicyResourceRel)(nil),                        // 85: idm.PolicyResourceRel
-	(*PolicySubjectRel)(nil),                         // 86: idm.PolicySubjectRel
-	(*PolicyActionRel)(nil),                          // 87: idm.PolicyActionRel
-	(*PolicyRel)(nil),                                // 88: idm.PolicyRel
-	(*PolicyGroup)(nil),                              // 89: idm.PolicyGroup
-	(*StorePolicyGroupRequest)(nil),                  // 90: idm.StorePolicyGroupRequest
-	(*StorePolicyGroupResponse)(nil),                 // 91: idm.StorePolicyGroupResponse
-	(*DeletePolicyGroupRequest)(nil),                 // 92: idm.DeletePolicyGroupRequest
-	(*DeletePolicyGroupResponse)(nil),                // 93: idm.DeletePolicyGroupResponse
-	(*ListPolicyGroupsRequest)(nil),                  // 94: idm.ListPolicyGroupsRequest
-	(*ListPolicyGroupsResponse)(nil),                 // 95: idm.ListPolicyGroupsResponse
-	(*PolicyGroupSingleQuery)(nil),                   // 96: idm.PolicyGroupSingleQuery
-	nil,                                              // 97: idm.User.AttributesEntry
-	nil,                                              // 98: idm.Workspace.RootNodesEntry
-	nil,                                              // 99: idm.UpdateUserMetaEvent.EventMetadataEntry
-	nil,                                              // 100: idm.ChangeEvent.AttributesEntry
-	nil,                                              // 101: idm.PolicyEngineRequest.ContextEntry
-	nil,                                              // 102: idm.Policy.ConditionsEntry
-	(*service.Query)(nil),                            // 103: service.Query
-	(*service.ResourcePolicy)(nil),                   // 104: service.ResourcePolicy
-	(*tree.TreeNode)(nil),                            // 105: tree.TreeNode
-	(*tree.Node)(nil),                                // 106: tree.Node
-	(*structpb.Struct)(nil),                          // 107: google.protobuf.Struct
-	(*service.ResourcePolicyQuery)(nil),              // 108: service.ResourcePolicyQuery
+	(*DeleteEntityRequest)(nil),                      // 56: idm.DeleteEntityRequest
+	(*DeleteEntityResponse)(nil),                     // 57: idm.DeleteEntityResponse
+	(*ListEntitiesRequest)(nil),                      // 58: idm.ListEntitiesRequest
+	(*ListEntitiesResponse)(nil),                     // 59: idm.ListEntitiesResponse
+	(*GetEntityRequest)(nil),                         // 60: idm.GetEntityRequest
+	(*GetEntityResponse)(nil),                        // 61: idm.GetEntityResponse
+	(*DeleteEntityValueRequest)(nil),                 // 62: idm.DeleteEntityValueRequest
+	(*DeleteEntityValueResponse)(nil),                // 63: idm.DeleteEntityValueResponse
+	(*GetMetaEntityValuesRequest)(nil),               // 64: idm.GetMetaEntityValuesRequest
+	(*MetaEntityValueResponse)(nil),                  // 65: idm.MetaEntityValueResponse
+	(*MetaToEntityValueRequest)(nil),                 // 66: idm.MetaToEntityValueRequest
+	(*MetaToEntityValueResponse)(nil),                // 67: idm.MetaToEntityValueResponse
+	(*UserMeta)(nil),                                 // 68: idm.UserMeta
+	(*UserMetaNamespace)(nil),                        // 69: idm.UserMetaNamespace
+	(*MetaEntity)(nil),                               // 70: idm.MetaEntity
+	(*EntityValue)(nil),                              // 71: idm.EntityValue
+	(*UpsertUserMetaValue)(nil),                      // 72: idm.UpsertUserMetaValue
+	(*UpdateUserMetaRequest)(nil),                    // 73: idm.UpdateUserMetaRequest
+	(*UpdateUserMetaResponse)(nil),                   // 74: idm.UpdateUserMetaResponse
+	(*UpdateUserMetaEvent)(nil),                      // 75: idm.UpdateUserMetaEvent
+	(*SearchUserMetaRequest)(nil),                    // 76: idm.SearchUserMetaRequest
+	(*SearchUserMetaResponse)(nil),                   // 77: idm.SearchUserMetaResponse
+	(*UpdateUserMetaNamespaceRequest)(nil),           // 78: idm.UpdateUserMetaNamespaceRequest
+	(*UpdateUserMetaNamespaceResponse)(nil),          // 79: idm.UpdateUserMetaNamespaceResponse
+	(*ListUserMetaNamespaceRequest)(nil),             // 80: idm.ListUserMetaNamespaceRequest
+	(*ListUserMetaNamespaceResponse)(nil),            // 81: idm.ListUserMetaNamespaceResponse
+	(*GetFieldSchemaRequest)(nil),                    // 82: idm.GetFieldSchemaRequest
+	(*JsonSchemaResponse)(nil),                       // 83: idm.JsonSchemaResponse
+	(*GetNamespaceSchemaRequest)(nil),                // 84: idm.GetNamespaceSchemaRequest
+	(*GetEntitiesRequest)(nil),                       // 85: idm.GetEntitiesRequest
+	(*GetEntitiesResponse)(nil),                      // 86: idm.GetEntitiesResponse
+	(*ChangeEvent)(nil),                              // 87: idm.ChangeEvent
+	(*PolicyEngineRequest)(nil),                      // 88: idm.PolicyEngineRequest
+	(*PolicyEngineResponse)(nil),                     // 89: idm.PolicyEngineResponse
+	(*PolicyCondition)(nil),                          // 90: idm.PolicyCondition
+	(*Policy)(nil),                                   // 91: idm.Policy
+	(*PolicySubject)(nil),                            // 92: idm.PolicySubject
+	(*PolicyResource)(nil),                           // 93: idm.PolicyResource
+	(*PolicyAction)(nil),                             // 94: idm.PolicyAction
+	(*PolicyResourceRel)(nil),                        // 95: idm.PolicyResourceRel
+	(*PolicySubjectRel)(nil),                         // 96: idm.PolicySubjectRel
+	(*PolicyActionRel)(nil),                          // 97: idm.PolicyActionRel
+	(*PolicyRel)(nil),                                // 98: idm.PolicyRel
+	(*PolicyGroup)(nil),                              // 99: idm.PolicyGroup
+	(*StorePolicyGroupRequest)(nil),                  // 100: idm.StorePolicyGroupRequest
+	(*StorePolicyGroupResponse)(nil),                 // 101: idm.StorePolicyGroupResponse
+	(*DeletePolicyGroupRequest)(nil),                 // 102: idm.DeletePolicyGroupRequest
+	(*DeletePolicyGroupResponse)(nil),                // 103: idm.DeletePolicyGroupResponse
+	(*ListPolicyGroupsRequest)(nil),                  // 104: idm.ListPolicyGroupsRequest
+	(*ListPolicyGroupsResponse)(nil),                 // 105: idm.ListPolicyGroupsResponse
+	(*PolicyGroupSingleQuery)(nil),                   // 106: idm.PolicyGroupSingleQuery
+	nil,                                              // 107: idm.User.AttributesEntry
+	nil,                                              // 108: idm.Workspace.RootNodesEntry
+	nil,                                              // 109: idm.UpdateUserMetaEvent.EventMetadataEntry
+	nil,                                              // 110: idm.ChangeEvent.AttributesEntry
+	nil,                                              // 111: idm.PolicyEngineRequest.ContextEntry
+	nil,                                              // 112: idm.Policy.ConditionsEntry
+	(*service.Query)(nil),                            // 113: service.Query
+	(*service.ResourcePolicy)(nil),                   // 114: service.ResourcePolicy
+	(*tree.TreeNode)(nil),                            // 115: tree.TreeNode
+	(*tree.Node)(nil),                                // 116: tree.Node
+	(*structpb.Struct)(nil),                          // 117: google.protobuf.Struct
+	(*service.ResourcePolicyQuery)(nil),              // 118: service.ResourcePolicyQuery
 }
 var file_cells_idm_proto_depIdxs = []int32{
 	15,  // 0: idm.CreateRoleRequest.Role:type_name -> idm.Role
 	15,  // 1: idm.CreateRoleResponse.Role:type_name -> idm.Role
-	103, // 2: idm.DeleteRoleRequest.Query:type_name -> service.Query
-	103, // 3: idm.SearchRoleRequest.Query:type_name -> service.Query
+	113, // 2: idm.DeleteRoleRequest.Query:type_name -> service.Query
+	113, // 3: idm.SearchRoleRequest.Query:type_name -> service.Query
 	15,  // 4: idm.SearchRoleResponse.Role:type_name -> idm.Role
-	104, // 5: idm.Role.Policies:type_name -> service.ResourcePolicy
+	114, // 5: idm.Role.Policies:type_name -> service.ResourcePolicy
 	27,  // 6: idm.CreateUserRequest.User:type_name -> idm.User
 	27,  // 7: idm.CreateUserResponse.User:type_name -> idm.User
 	27,  // 8: idm.BindUserResponse.User:type_name -> idm.User
-	103, // 9: idm.DeleteUserRequest.Query:type_name -> service.Query
-	103, // 10: idm.SearchUserRequest.Query:type_name -> service.Query
+	113, // 9: idm.DeleteUserRequest.Query:type_name -> service.Query
+	113, // 10: idm.SearchUserRequest.Query:type_name -> service.Query
 	27,  // 11: idm.SearchUserResponse.User:type_name -> idm.User
-	105, // 12: idm.TreeUser.node:type_name -> tree.TreeNode
+	115, // 12: idm.TreeUser.node:type_name -> tree.TreeNode
 	27,  // 13: idm.TreeUser.user:type_name -> idm.User
-	97,  // 14: idm.User.Attributes:type_name -> idm.User.AttributesEntry
+	107, // 14: idm.User.Attributes:type_name -> idm.User.AttributesEntry
 	15,  // 15: idm.User.Roles:type_name -> idm.Role
-	104, // 16: idm.User.Policies:type_name -> service.ResourcePolicy
+	114, // 16: idm.User.Policies:type_name -> service.ResourcePolicy
 	0,   // 17: idm.UserSingleQuery.NodeType:type_name -> idm.NodeType
 	35,  // 18: idm.CreateWorkspaceRequest.Workspace:type_name -> idm.Workspace
 	35,  // 19: idm.CreateWorkspaceResponse.Workspace:type_name -> idm.Workspace
-	103, // 20: idm.DeleteWorkspaceRequest.Query:type_name -> service.Query
-	103, // 21: idm.SearchWorkspaceRequest.Query:type_name -> service.Query
+	113, // 20: idm.DeleteWorkspaceRequest.Query:type_name -> service.Query
+	113, // 21: idm.SearchWorkspaceRequest.Query:type_name -> service.Query
 	35,  // 22: idm.SearchWorkspaceResponse.Workspace:type_name -> idm.Workspace
 	1,   // 23: idm.Workspace.Scope:type_name -> idm.WorkspaceScope
-	104, // 24: idm.Workspace.Policies:type_name -> service.ResourcePolicy
-	98,  // 25: idm.Workspace.RootNodes:type_name -> idm.Workspace.RootNodesEntry
+	114, // 24: idm.Workspace.Policies:type_name -> service.ResourcePolicy
+	108, // 25: idm.Workspace.RootNodes:type_name -> idm.Workspace.RootNodesEntry
 	1,   // 26: idm.WorkspaceSingleQuery.scope:type_name -> idm.WorkspaceScope
 	48,  // 27: idm.CreateACLRequest.ACL:type_name -> idm.ACL
 	48,  // 28: idm.CreateACLRequest.Batch:type_name -> idm.ACL
 	48,  // 29: idm.CreateACLResponse.ACL:type_name -> idm.ACL
 	48,  // 30: idm.CreateACLResponse.Batch:type_name -> idm.ACL
-	103, // 31: idm.ExpireACLRequest.Query:type_name -> service.Query
-	103, // 32: idm.DeleteACLRequest.Query:type_name -> service.Query
-	103, // 33: idm.SearchACLRequest.Query:type_name -> service.Query
+	113, // 31: idm.ExpireACLRequest.Query:type_name -> service.Query
+	113, // 32: idm.DeleteACLRequest.Query:type_name -> service.Query
+	113, // 33: idm.SearchACLRequest.Query:type_name -> service.Query
 	48,  // 34: idm.SearchACLResponse.ACL:type_name -> idm.ACL
-	103, // 35: idm.RestoreACLRequest.Query:type_name -> service.Query
+	113, // 35: idm.RestoreACLRequest.Query:type_name -> service.Query
 	47,  // 36: idm.ACL.Action:type_name -> idm.ACLAction
 	47,  // 37: idm.ACLSingleQuery.Actions:type_name -> idm.ACLAction
-	64,  // 38: idm.CreateEntityValueRequest.EntityValue:type_name -> idm.EntityValue
-	64,  // 39: idm.CreateEntityValueResponse.EntityValue:type_name -> idm.EntityValue
-	63,  // 40: idm.CreateEntityRequest.Entity:type_name -> idm.MetaEntity
-	63,  // 41: idm.CreateEntityResponse.Entity:type_name -> idm.MetaEntity
-	64,  // 42: idm.MetaEntityValueResponse.EntityValue:type_name -> idm.EntityValue
-	104, // 43: idm.UserMeta.Policies:type_name -> service.ResourcePolicy
-	106, // 44: idm.UserMeta.ResolvedNode:type_name -> tree.Node
-	104, // 45: idm.UserMetaNamespace.Policies:type_name -> service.ResourcePolicy
-	107, // 46: idm.UserMetaNamespace.JsonSchema:type_name -> google.protobuf.Struct
-	5,   // 47: idm.UpdateUserMetaRequest.Operation:type_name -> idm.UpdateUserMetaRequest.UserMetaOp
-	61,  // 48: idm.UpdateUserMetaRequest.MetaDatas:type_name -> idm.UserMeta
-	61,  // 49: idm.UpdateUserMetaResponse.MetaDatas:type_name -> idm.UserMeta
-	99,  // 50: idm.UpdateUserMetaEvent.EventMetadata:type_name -> idm.UpdateUserMetaEvent.EventMetadataEntry
-	6,   // 51: idm.UpdateUserMetaEvent.Operation:type_name -> idm.UpdateUserMetaEvent.UserMetaOpEvent
-	61,  // 52: idm.UpdateUserMetaEvent.UserMeta:type_name -> idm.UserMeta
-	108, // 53: idm.SearchUserMetaRequest.ResourceQuery:type_name -> service.ResourcePolicyQuery
-	61,  // 54: idm.SearchUserMetaResponse.UserMeta:type_name -> idm.UserMeta
-	7,   // 55: idm.UpdateUserMetaNamespaceRequest.Operation:type_name -> idm.UpdateUserMetaNamespaceRequest.UserMetaNsOp
-	62,  // 56: idm.UpdateUserMetaNamespaceRequest.Namespaces:type_name -> idm.UserMetaNamespace
-	62,  // 57: idm.UpdateUserMetaNamespaceResponse.Namespaces:type_name -> idm.UserMetaNamespace
-	62,  // 58: idm.ListUserMetaNamespaceResponse.UserMetaNamespace:type_name -> idm.UserMetaNamespace
-	107, // 59: idm.JsonSchemaResponse.JsonSchema:type_name -> google.protobuf.Struct
-	2,   // 60: idm.ChangeEvent.Type:type_name -> idm.ChangeEventType
-	27,  // 61: idm.ChangeEvent.User:type_name -> idm.User
-	15,  // 62: idm.ChangeEvent.Role:type_name -> idm.Role
-	35,  // 63: idm.ChangeEvent.Workspace:type_name -> idm.Workspace
-	48,  // 64: idm.ChangeEvent.Acl:type_name -> idm.ACL
-	62,  // 65: idm.ChangeEvent.MetaNamespace:type_name -> idm.UserMetaNamespace
-	100, // 66: idm.ChangeEvent.Attributes:type_name -> idm.ChangeEvent.AttributesEntry
-	101, // 67: idm.PolicyEngineRequest.Context:type_name -> idm.PolicyEngineRequest.ContextEntry
-	82,  // 68: idm.Policy.OrmSubjects:type_name -> idm.PolicySubject
-	83,  // 69: idm.Policy.OrmResources:type_name -> idm.PolicyResource
-	84,  // 70: idm.Policy.OrmActions:type_name -> idm.PolicyAction
-	3,   // 71: idm.Policy.Effect:type_name -> idm.PolicyEffect
-	102, // 72: idm.Policy.Conditions:type_name -> idm.Policy.ConditionsEntry
-	4,   // 73: idm.PolicyGroup.ResourceGroup:type_name -> idm.PolicyResourceGroup
-	81,  // 74: idm.PolicyGroup.Policies:type_name -> idm.Policy
-	89,  // 75: idm.StorePolicyGroupRequest.PolicyGroup:type_name -> idm.PolicyGroup
-	89,  // 76: idm.StorePolicyGroupResponse.PolicyGroup:type_name -> idm.PolicyGroup
-	89,  // 77: idm.DeletePolicyGroupRequest.PolicyGroup:type_name -> idm.PolicyGroup
-	103, // 78: idm.ListPolicyGroupsRequest.Query:type_name -> service.Query
-	89,  // 79: idm.ListPolicyGroupsResponse.PolicyGroups:type_name -> idm.PolicyGroup
-	106, // 80: idm.Workspace.RootNodesEntry.value:type_name -> tree.Node
-	80,  // 81: idm.Policy.ConditionsEntry.value:type_name -> idm.PolicyCondition
-	8,   // 82: idm.RoleService.CreateRole:input_type -> idm.CreateRoleRequest
-	10,  // 83: idm.RoleService.DeleteRole:input_type -> idm.DeleteRoleRequest
-	12,  // 84: idm.RoleService.SearchRole:input_type -> idm.SearchRoleRequest
-	12,  // 85: idm.RoleService.StreamRole:input_type -> idm.SearchRoleRequest
-	12,  // 86: idm.RoleService.CountRole:input_type -> idm.SearchRoleRequest
-	17,  // 87: idm.UserService.CreateUser:input_type -> idm.CreateUserRequest
-	21,  // 88: idm.UserService.DeleteUser:input_type -> idm.DeleteUserRequest
-	19,  // 89: idm.UserService.BindUser:input_type -> idm.BindUserRequest
-	23,  // 90: idm.UserService.CountUser:input_type -> idm.SearchUserRequest
-	23,  // 91: idm.UserService.SearchOne:input_type -> idm.SearchUserRequest
-	23,  // 92: idm.UserService.SearchUser:input_type -> idm.SearchUserRequest
-	23,  // 93: idm.UserService.StreamUser:input_type -> idm.SearchUserRequest
-	29,  // 94: idm.WorkspaceService.CreateWorkspace:input_type -> idm.CreateWorkspaceRequest
-	31,  // 95: idm.WorkspaceService.DeleteWorkspace:input_type -> idm.DeleteWorkspaceRequest
-	33,  // 96: idm.WorkspaceService.SearchWorkspace:input_type -> idm.SearchWorkspaceRequest
-	33,  // 97: idm.WorkspaceService.StreamWorkspace:input_type -> idm.SearchWorkspaceRequest
-	37,  // 98: idm.ACLService.CreateACL:input_type -> idm.CreateACLRequest
-	39,  // 99: idm.ACLService.ExpireACL:input_type -> idm.ExpireACLRequest
-	41,  // 100: idm.ACLService.DeleteACL:input_type -> idm.DeleteACLRequest
-	43,  // 101: idm.ACLService.SearchACL:input_type -> idm.SearchACLRequest
-	43,  // 102: idm.ACLService.StreamACL:input_type -> idm.SearchACLRequest
-	45,  // 103: idm.ACLService.RestoreACL:input_type -> idm.RestoreACLRequest
-	65,  // 104: idm.UserMetaService.UpdateUserMeta:input_type -> idm.UpdateUserMetaRequest
-	68,  // 105: idm.UserMetaService.SearchUserMeta:input_type -> idm.SearchUserMetaRequest
-	70,  // 106: idm.UserMetaService.UpdateUserMetaNamespace:input_type -> idm.UpdateUserMetaNamespaceRequest
-	72,  // 107: idm.UserMetaService.ListUserMetaNamespace:input_type -> idm.ListUserMetaNamespaceRequest
-	74,  // 108: idm.UserMetaService.GetFieldSchema:input_type -> idm.GetFieldSchemaRequest
-	76,  // 109: idm.UserMetaService.GetNamespaceSchema:input_type -> idm.GetNamespaceSchemaRequest
-	57,  // 110: idm.UserMetaService.GetEntityValues:input_type -> idm.GetMetaEntityValuesRequest
-	57,  // 111: idm.UserMetaService.DeleteEntity:input_type -> idm.GetMetaEntityValuesRequest
-	54,  // 112: idm.UserMetaService.CreateEntity:input_type -> idm.CreateEntityRequest
-	52,  // 113: idm.UserMetaService.CreateEntityValues:input_type -> idm.CreateEntityValueRequest
-	59,  // 114: idm.UserMetaService.LinkMetaToEntityValue:input_type -> idm.MetaToEntityValueRequest
-	59,  // 115: idm.UserMetaService.UnlinkMetaFromEntityValue:input_type -> idm.MetaToEntityValueRequest
-	51,  // 116: idm.UserMetaService.GetMetadata:input_type -> idm.GetMetadataRequest
-	78,  // 117: idm.PolicyEngineService.IsAllowed:input_type -> idm.PolicyEngineRequest
-	90,  // 118: idm.PolicyEngineService.StorePolicyGroup:input_type -> idm.StorePolicyGroupRequest
-	94,  // 119: idm.PolicyEngineService.ListPolicyGroups:input_type -> idm.ListPolicyGroupsRequest
-	94,  // 120: idm.PolicyEngineService.StreamPolicyGroups:input_type -> idm.ListPolicyGroupsRequest
-	92,  // 121: idm.PolicyEngineService.DeletePolicyGroup:input_type -> idm.DeletePolicyGroupRequest
-	9,   // 122: idm.RoleService.CreateRole:output_type -> idm.CreateRoleResponse
-	11,  // 123: idm.RoleService.DeleteRole:output_type -> idm.DeleteRoleResponse
-	13,  // 124: idm.RoleService.SearchRole:output_type -> idm.SearchRoleResponse
-	13,  // 125: idm.RoleService.StreamRole:output_type -> idm.SearchRoleResponse
-	14,  // 126: idm.RoleService.CountRole:output_type -> idm.CountRoleResponse
-	18,  // 127: idm.UserService.CreateUser:output_type -> idm.CreateUserResponse
-	22,  // 128: idm.UserService.DeleteUser:output_type -> idm.DeleteUserResponse
-	20,  // 129: idm.UserService.BindUser:output_type -> idm.BindUserResponse
-	25,  // 130: idm.UserService.CountUser:output_type -> idm.CountUserResponse
-	24,  // 131: idm.UserService.SearchOne:output_type -> idm.SearchUserResponse
-	24,  // 132: idm.UserService.SearchUser:output_type -> idm.SearchUserResponse
-	24,  // 133: idm.UserService.StreamUser:output_type -> idm.SearchUserResponse
-	30,  // 134: idm.WorkspaceService.CreateWorkspace:output_type -> idm.CreateWorkspaceResponse
-	32,  // 135: idm.WorkspaceService.DeleteWorkspace:output_type -> idm.DeleteWorkspaceResponse
-	34,  // 136: idm.WorkspaceService.SearchWorkspace:output_type -> idm.SearchWorkspaceResponse
-	34,  // 137: idm.WorkspaceService.StreamWorkspace:output_type -> idm.SearchWorkspaceResponse
-	38,  // 138: idm.ACLService.CreateACL:output_type -> idm.CreateACLResponse
-	40,  // 139: idm.ACLService.ExpireACL:output_type -> idm.ExpireACLResponse
-	42,  // 140: idm.ACLService.DeleteACL:output_type -> idm.DeleteACLResponse
-	44,  // 141: idm.ACLService.SearchACL:output_type -> idm.SearchACLResponse
-	44,  // 142: idm.ACLService.StreamACL:output_type -> idm.SearchACLResponse
-	46,  // 143: idm.ACLService.RestoreACL:output_type -> idm.RestoreACLResponse
-	66,  // 144: idm.UserMetaService.UpdateUserMeta:output_type -> idm.UpdateUserMetaResponse
-	69,  // 145: idm.UserMetaService.SearchUserMeta:output_type -> idm.SearchUserMetaResponse
-	71,  // 146: idm.UserMetaService.UpdateUserMetaNamespace:output_type -> idm.UpdateUserMetaNamespaceResponse
-	73,  // 147: idm.UserMetaService.ListUserMetaNamespace:output_type -> idm.ListUserMetaNamespaceResponse
-	75,  // 148: idm.UserMetaService.GetFieldSchema:output_type -> idm.JsonSchemaResponse
-	75,  // 149: idm.UserMetaService.GetNamespaceSchema:output_type -> idm.JsonSchemaResponse
-	58,  // 150: idm.UserMetaService.GetEntityValues:output_type -> idm.MetaEntityValueResponse
-	56,  // 151: idm.UserMetaService.DeleteEntity:output_type -> idm.DeleteEntityValuesResponse
-	55,  // 152: idm.UserMetaService.CreateEntity:output_type -> idm.CreateEntityResponse
-	53,  // 153: idm.UserMetaService.CreateEntityValues:output_type -> idm.CreateEntityValueResponse
-	60,  // 154: idm.UserMetaService.LinkMetaToEntityValue:output_type -> idm.MetaToEntityValueResponse
-	60,  // 155: idm.UserMetaService.UnlinkMetaFromEntityValue:output_type -> idm.MetaToEntityValueResponse
-	61,  // 156: idm.UserMetaService.GetMetadata:output_type -> idm.UserMeta
-	79,  // 157: idm.PolicyEngineService.IsAllowed:output_type -> idm.PolicyEngineResponse
-	91,  // 158: idm.PolicyEngineService.StorePolicyGroup:output_type -> idm.StorePolicyGroupResponse
-	95,  // 159: idm.PolicyEngineService.ListPolicyGroups:output_type -> idm.ListPolicyGroupsResponse
-	89,  // 160: idm.PolicyEngineService.StreamPolicyGroups:output_type -> idm.PolicyGroup
-	93,  // 161: idm.PolicyEngineService.DeletePolicyGroup:output_type -> idm.DeletePolicyGroupResponse
-	122, // [122:162] is the sub-list for method output_type
-	82,  // [82:122] is the sub-list for method input_type
-	82,  // [82:82] is the sub-list for extension type_name
-	82,  // [82:82] is the sub-list for extension extendee
-	0,   // [0:82] is the sub-list for field type_name
+	71,  // 38: idm.CreateEntityValueRequest.EntityValue:type_name -> idm.EntityValue
+	71,  // 39: idm.CreateEntityValueResponse.EntityValue:type_name -> idm.EntityValue
+	70,  // 40: idm.CreateEntityRequest.Entity:type_name -> idm.MetaEntity
+	70,  // 41: idm.CreateEntityResponse.Entity:type_name -> idm.MetaEntity
+	70,  // 42: idm.ListEntitiesResponse.Entity:type_name -> idm.MetaEntity
+	70,  // 43: idm.GetEntityResponse.Entity:type_name -> idm.MetaEntity
+	71,  // 44: idm.MetaEntityValueResponse.EntityValue:type_name -> idm.EntityValue
+	114, // 45: idm.UserMeta.Policies:type_name -> service.ResourcePolicy
+	116, // 46: idm.UserMeta.ResolvedNode:type_name -> tree.Node
+	114, // 47: idm.UserMetaNamespace.Policies:type_name -> service.ResourcePolicy
+	117, // 48: idm.UserMetaNamespace.JsonSchema:type_name -> google.protobuf.Struct
+	114, // 49: idm.MetaEntity.Policies:type_name -> service.ResourcePolicy
+	114, // 50: idm.EntityValue.Policies:type_name -> service.ResourcePolicy
+	71,  // 51: idm.UpsertUserMetaValue.EntityValues:type_name -> idm.EntityValue
+	114, // 52: idm.UpsertUserMetaValue.Policies:type_name -> service.ResourcePolicy
+	5,   // 53: idm.UpdateUserMetaRequest.Operation:type_name -> idm.UpdateUserMetaRequest.UserMetaOp
+	68,  // 54: idm.UpdateUserMetaRequest.MetaDatas:type_name -> idm.UserMeta
+	68,  // 55: idm.UpdateUserMetaResponse.MetaDatas:type_name -> idm.UserMeta
+	109, // 56: idm.UpdateUserMetaEvent.EventMetadata:type_name -> idm.UpdateUserMetaEvent.EventMetadataEntry
+	6,   // 57: idm.UpdateUserMetaEvent.Operation:type_name -> idm.UpdateUserMetaEvent.UserMetaOpEvent
+	68,  // 58: idm.UpdateUserMetaEvent.UserMeta:type_name -> idm.UserMeta
+	118, // 59: idm.SearchUserMetaRequest.ResourceQuery:type_name -> service.ResourcePolicyQuery
+	68,  // 60: idm.SearchUserMetaResponse.UserMeta:type_name -> idm.UserMeta
+	7,   // 61: idm.UpdateUserMetaNamespaceRequest.Operation:type_name -> idm.UpdateUserMetaNamespaceRequest.UserMetaNsOp
+	69,  // 62: idm.UpdateUserMetaNamespaceRequest.Namespaces:type_name -> idm.UserMetaNamespace
+	69,  // 63: idm.UpdateUserMetaNamespaceResponse.Namespaces:type_name -> idm.UserMetaNamespace
+	69,  // 64: idm.ListUserMetaNamespaceResponse.UserMetaNamespace:type_name -> idm.UserMetaNamespace
+	117, // 65: idm.JsonSchemaResponse.JsonSchema:type_name -> google.protobuf.Struct
+	70,  // 66: idm.GetEntitiesResponse.Entities:type_name -> idm.MetaEntity
+	2,   // 67: idm.ChangeEvent.Type:type_name -> idm.ChangeEventType
+	27,  // 68: idm.ChangeEvent.User:type_name -> idm.User
+	15,  // 69: idm.ChangeEvent.Role:type_name -> idm.Role
+	35,  // 70: idm.ChangeEvent.Workspace:type_name -> idm.Workspace
+	48,  // 71: idm.ChangeEvent.Acl:type_name -> idm.ACL
+	69,  // 72: idm.ChangeEvent.MetaNamespace:type_name -> idm.UserMetaNamespace
+	110, // 73: idm.ChangeEvent.Attributes:type_name -> idm.ChangeEvent.AttributesEntry
+	111, // 74: idm.PolicyEngineRequest.Context:type_name -> idm.PolicyEngineRequest.ContextEntry
+	92,  // 75: idm.Policy.OrmSubjects:type_name -> idm.PolicySubject
+	93,  // 76: idm.Policy.OrmResources:type_name -> idm.PolicyResource
+	94,  // 77: idm.Policy.OrmActions:type_name -> idm.PolicyAction
+	3,   // 78: idm.Policy.Effect:type_name -> idm.PolicyEffect
+	112, // 79: idm.Policy.Conditions:type_name -> idm.Policy.ConditionsEntry
+	4,   // 80: idm.PolicyGroup.ResourceGroup:type_name -> idm.PolicyResourceGroup
+	91,  // 81: idm.PolicyGroup.Policies:type_name -> idm.Policy
+	99,  // 82: idm.StorePolicyGroupRequest.PolicyGroup:type_name -> idm.PolicyGroup
+	99,  // 83: idm.StorePolicyGroupResponse.PolicyGroup:type_name -> idm.PolicyGroup
+	99,  // 84: idm.DeletePolicyGroupRequest.PolicyGroup:type_name -> idm.PolicyGroup
+	113, // 85: idm.ListPolicyGroupsRequest.Query:type_name -> service.Query
+	99,  // 86: idm.ListPolicyGroupsResponse.PolicyGroups:type_name -> idm.PolicyGroup
+	116, // 87: idm.Workspace.RootNodesEntry.value:type_name -> tree.Node
+	90,  // 88: idm.Policy.ConditionsEntry.value:type_name -> idm.PolicyCondition
+	8,   // 89: idm.RoleService.CreateRole:input_type -> idm.CreateRoleRequest
+	10,  // 90: idm.RoleService.DeleteRole:input_type -> idm.DeleteRoleRequest
+	12,  // 91: idm.RoleService.SearchRole:input_type -> idm.SearchRoleRequest
+	12,  // 92: idm.RoleService.StreamRole:input_type -> idm.SearchRoleRequest
+	12,  // 93: idm.RoleService.CountRole:input_type -> idm.SearchRoleRequest
+	17,  // 94: idm.UserService.CreateUser:input_type -> idm.CreateUserRequest
+	21,  // 95: idm.UserService.DeleteUser:input_type -> idm.DeleteUserRequest
+	19,  // 96: idm.UserService.BindUser:input_type -> idm.BindUserRequest
+	23,  // 97: idm.UserService.CountUser:input_type -> idm.SearchUserRequest
+	23,  // 98: idm.UserService.SearchOne:input_type -> idm.SearchUserRequest
+	23,  // 99: idm.UserService.SearchUser:input_type -> idm.SearchUserRequest
+	23,  // 100: idm.UserService.StreamUser:input_type -> idm.SearchUserRequest
+	29,  // 101: idm.WorkspaceService.CreateWorkspace:input_type -> idm.CreateWorkspaceRequest
+	31,  // 102: idm.WorkspaceService.DeleteWorkspace:input_type -> idm.DeleteWorkspaceRequest
+	33,  // 103: idm.WorkspaceService.SearchWorkspace:input_type -> idm.SearchWorkspaceRequest
+	33,  // 104: idm.WorkspaceService.StreamWorkspace:input_type -> idm.SearchWorkspaceRequest
+	37,  // 105: idm.ACLService.CreateACL:input_type -> idm.CreateACLRequest
+	39,  // 106: idm.ACLService.ExpireACL:input_type -> idm.ExpireACLRequest
+	41,  // 107: idm.ACLService.DeleteACL:input_type -> idm.DeleteACLRequest
+	43,  // 108: idm.ACLService.SearchACL:input_type -> idm.SearchACLRequest
+	43,  // 109: idm.ACLService.StreamACL:input_type -> idm.SearchACLRequest
+	45,  // 110: idm.ACLService.RestoreACL:input_type -> idm.RestoreACLRequest
+	73,  // 111: idm.UserMetaService.UpdateUserMeta:input_type -> idm.UpdateUserMetaRequest
+	76,  // 112: idm.UserMetaService.SearchUserMeta:input_type -> idm.SearchUserMetaRequest
+	78,  // 113: idm.UserMetaService.UpdateUserMetaNamespace:input_type -> idm.UpdateUserMetaNamespaceRequest
+	80,  // 114: idm.UserMetaService.ListUserMetaNamespace:input_type -> idm.ListUserMetaNamespaceRequest
+	82,  // 115: idm.UserMetaService.GetFieldSchema:input_type -> idm.GetFieldSchemaRequest
+	84,  // 116: idm.UserMetaService.GetNamespaceSchema:input_type -> idm.GetNamespaceSchemaRequest
+	64,  // 117: idm.UserMetaService.GetEntityValues:input_type -> idm.GetMetaEntityValuesRequest
+	56,  // 118: idm.UserMetaService.DeleteEntity:input_type -> idm.DeleteEntityRequest
+	60,  // 119: idm.UserMetaService.GetEntity:input_type -> idm.GetEntityRequest
+	58,  // 120: idm.UserMetaService.ListEntities:input_type -> idm.ListEntitiesRequest
+	54,  // 121: idm.UserMetaService.CreateEntity:input_type -> idm.CreateEntityRequest
+	52,  // 122: idm.UserMetaService.CreateEntityValues:input_type -> idm.CreateEntityValueRequest
+	66,  // 123: idm.UserMetaService.LinkMetaToEntityValue:input_type -> idm.MetaToEntityValueRequest
+	66,  // 124: idm.UserMetaService.UnlinkMetaFromEntityValue:input_type -> idm.MetaToEntityValueRequest
+	51,  // 125: idm.UserMetaService.GetMetadata:input_type -> idm.GetMetadataRequest
+	62,  // 126: idm.UserMetaService.DeleteEntityValue:input_type -> idm.DeleteEntityValueRequest
+	88,  // 127: idm.PolicyEngineService.IsAllowed:input_type -> idm.PolicyEngineRequest
+	100, // 128: idm.PolicyEngineService.StorePolicyGroup:input_type -> idm.StorePolicyGroupRequest
+	104, // 129: idm.PolicyEngineService.ListPolicyGroups:input_type -> idm.ListPolicyGroupsRequest
+	104, // 130: idm.PolicyEngineService.StreamPolicyGroups:input_type -> idm.ListPolicyGroupsRequest
+	102, // 131: idm.PolicyEngineService.DeletePolicyGroup:input_type -> idm.DeletePolicyGroupRequest
+	9,   // 132: idm.RoleService.CreateRole:output_type -> idm.CreateRoleResponse
+	11,  // 133: idm.RoleService.DeleteRole:output_type -> idm.DeleteRoleResponse
+	13,  // 134: idm.RoleService.SearchRole:output_type -> idm.SearchRoleResponse
+	13,  // 135: idm.RoleService.StreamRole:output_type -> idm.SearchRoleResponse
+	14,  // 136: idm.RoleService.CountRole:output_type -> idm.CountRoleResponse
+	18,  // 137: idm.UserService.CreateUser:output_type -> idm.CreateUserResponse
+	22,  // 138: idm.UserService.DeleteUser:output_type -> idm.DeleteUserResponse
+	20,  // 139: idm.UserService.BindUser:output_type -> idm.BindUserResponse
+	25,  // 140: idm.UserService.CountUser:output_type -> idm.CountUserResponse
+	24,  // 141: idm.UserService.SearchOne:output_type -> idm.SearchUserResponse
+	24,  // 142: idm.UserService.SearchUser:output_type -> idm.SearchUserResponse
+	24,  // 143: idm.UserService.StreamUser:output_type -> idm.SearchUserResponse
+	30,  // 144: idm.WorkspaceService.CreateWorkspace:output_type -> idm.CreateWorkspaceResponse
+	32,  // 145: idm.WorkspaceService.DeleteWorkspace:output_type -> idm.DeleteWorkspaceResponse
+	34,  // 146: idm.WorkspaceService.SearchWorkspace:output_type -> idm.SearchWorkspaceResponse
+	34,  // 147: idm.WorkspaceService.StreamWorkspace:output_type -> idm.SearchWorkspaceResponse
+	38,  // 148: idm.ACLService.CreateACL:output_type -> idm.CreateACLResponse
+	40,  // 149: idm.ACLService.ExpireACL:output_type -> idm.ExpireACLResponse
+	42,  // 150: idm.ACLService.DeleteACL:output_type -> idm.DeleteACLResponse
+	44,  // 151: idm.ACLService.SearchACL:output_type -> idm.SearchACLResponse
+	44,  // 152: idm.ACLService.StreamACL:output_type -> idm.SearchACLResponse
+	46,  // 153: idm.ACLService.RestoreACL:output_type -> idm.RestoreACLResponse
+	74,  // 154: idm.UserMetaService.UpdateUserMeta:output_type -> idm.UpdateUserMetaResponse
+	77,  // 155: idm.UserMetaService.SearchUserMeta:output_type -> idm.SearchUserMetaResponse
+	79,  // 156: idm.UserMetaService.UpdateUserMetaNamespace:output_type -> idm.UpdateUserMetaNamespaceResponse
+	81,  // 157: idm.UserMetaService.ListUserMetaNamespace:output_type -> idm.ListUserMetaNamespaceResponse
+	83,  // 158: idm.UserMetaService.GetFieldSchema:output_type -> idm.JsonSchemaResponse
+	83,  // 159: idm.UserMetaService.GetNamespaceSchema:output_type -> idm.JsonSchemaResponse
+	65,  // 160: idm.UserMetaService.GetEntityValues:output_type -> idm.MetaEntityValueResponse
+	57,  // 161: idm.UserMetaService.DeleteEntity:output_type -> idm.DeleteEntityResponse
+	61,  // 162: idm.UserMetaService.GetEntity:output_type -> idm.GetEntityResponse
+	59,  // 163: idm.UserMetaService.ListEntities:output_type -> idm.ListEntitiesResponse
+	55,  // 164: idm.UserMetaService.CreateEntity:output_type -> idm.CreateEntityResponse
+	53,  // 165: idm.UserMetaService.CreateEntityValues:output_type -> idm.CreateEntityValueResponse
+	67,  // 166: idm.UserMetaService.LinkMetaToEntityValue:output_type -> idm.MetaToEntityValueResponse
+	67,  // 167: idm.UserMetaService.UnlinkMetaFromEntityValue:output_type -> idm.MetaToEntityValueResponse
+	68,  // 168: idm.UserMetaService.GetMetadata:output_type -> idm.UserMeta
+	63,  // 169: idm.UserMetaService.DeleteEntityValue:output_type -> idm.DeleteEntityValueResponse
+	89,  // 170: idm.PolicyEngineService.IsAllowed:output_type -> idm.PolicyEngineResponse
+	101, // 171: idm.PolicyEngineService.StorePolicyGroup:output_type -> idm.StorePolicyGroupResponse
+	105, // 172: idm.PolicyEngineService.ListPolicyGroups:output_type -> idm.ListPolicyGroupsResponse
+	99,  // 173: idm.PolicyEngineService.StreamPolicyGroups:output_type -> idm.PolicyGroup
+	103, // 174: idm.PolicyEngineService.DeletePolicyGroup:output_type -> idm.DeletePolicyGroupResponse
+	132, // [132:175] is the sub-list for method output_type
+	89,  // [89:132] is the sub-list for method input_type
+	89,  // [89:89] is the sub-list for extension type_name
+	89,  // [89:89] is the sub-list for extension extendee
+	0,   // [0:89] is the sub-list for field type_name
 }
 
 func init() { file_cells_idm_proto_init() }
@@ -6750,7 +7314,7 @@ func file_cells_idm_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cells_idm_proto_rawDesc), len(file_cells_idm_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   95,
+			NumMessages:   105,
 			NumExtensions: 0,
 			NumServices:   6,
 		},

--- a/common/proto/idm/cells-idm.pb.go
+++ b/common/proto/idm/cells-idm.pb.go
@@ -329,7 +329,7 @@ func (x UpdateUserMetaRequest_UserMetaOp) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use UpdateUserMetaRequest_UserMetaOp.Descriptor instead.
 func (UpdateUserMetaRequest_UserMetaOp) EnumDescriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{57, 0}
+	return file_cells_idm_proto_rawDescGZIP(), []int{64, 0}
 }
 
 type UpdateUserMetaEvent_UserMetaOpEvent int32
@@ -375,7 +375,7 @@ func (x UpdateUserMetaEvent_UserMetaOpEvent) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use UpdateUserMetaEvent_UserMetaOpEvent.Descriptor instead.
 func (UpdateUserMetaEvent_UserMetaOpEvent) EnumDescriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{59, 0}
+	return file_cells_idm_proto_rawDescGZIP(), []int{66, 0}
 }
 
 type UpdateUserMetaNamespaceRequest_UserMetaNsOp int32
@@ -421,7 +421,7 @@ func (x UpdateUserMetaNamespaceRequest_UserMetaNsOp) Number() protoreflect.EnumN
 
 // Deprecated: Use UpdateUserMetaNamespaceRequest_UserMetaNsOp.Descriptor instead.
 func (UpdateUserMetaNamespaceRequest_UserMetaNsOp) EnumDescriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{62, 0}
+	return file_cells_idm_proto_rawDescGZIP(), []int{69, 0}
 }
 
 // *****************************************************************************
@@ -3299,28 +3299,27 @@ func (x *CreateEntityResponse) GetEntity() *MetaEntity {
 	return nil
 }
 
-// Delete EntityValuesRequest, takes the EntityUuid and delete all its values and associations with metas
-type DeleteEntityValuesResponse struct {
+type DeleteEntityRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	RowsDeleted   int64                  `protobuf:"varint,1,opt,name=RowsDeleted,proto3" json:"RowsDeleted,omitempty"`
+	EntityId      string                 `protobuf:"bytes,1,opt,name=EntityId,proto3" json:"EntityId,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *DeleteEntityValuesResponse) Reset() {
-	*x = DeleteEntityValuesResponse{}
+func (x *DeleteEntityRequest) Reset() {
+	*x = DeleteEntityRequest{}
 	mi := &file_cells_idm_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *DeleteEntityValuesResponse) String() string {
+func (x *DeleteEntityRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*DeleteEntityValuesResponse) ProtoMessage() {}
+func (*DeleteEntityRequest) ProtoMessage() {}
 
-func (x *DeleteEntityValuesResponse) ProtoReflect() protoreflect.Message {
+func (x *DeleteEntityRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_cells_idm_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -3332,12 +3331,321 @@ func (x *DeleteEntityValuesResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use DeleteEntityValuesResponse.ProtoReflect.Descriptor instead.
-func (*DeleteEntityValuesResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use DeleteEntityRequest.ProtoReflect.Descriptor instead.
+func (*DeleteEntityRequest) Descriptor() ([]byte, []int) {
 	return file_cells_idm_proto_rawDescGZIP(), []int{48}
 }
 
-func (x *DeleteEntityValuesResponse) GetRowsDeleted() int64 {
+func (x *DeleteEntityRequest) GetEntityId() string {
+	if x != nil {
+		return x.EntityId
+	}
+	return ""
+}
+
+type DeleteEntityResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RowsDeleted   int64                  `protobuf:"varint,1,opt,name=RowsDeleted,proto3" json:"RowsDeleted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteEntityResponse) Reset() {
+	*x = DeleteEntityResponse{}
+	mi := &file_cells_idm_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteEntityResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteEntityResponse) ProtoMessage() {}
+
+func (x *DeleteEntityResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteEntityResponse.ProtoReflect.Descriptor instead.
+func (*DeleteEntityResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{49}
+}
+
+func (x *DeleteEntityResponse) GetRowsDeleted() int64 {
+	if x != nil {
+		return x.RowsDeleted
+	}
+	return 0
+}
+
+type ListEntitiesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EntityId      string                 `protobuf:"bytes,1,opt,name=EntityId,proto3" json:"EntityId,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListEntitiesRequest) Reset() {
+	*x = ListEntitiesRequest{}
+	mi := &file_cells_idm_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListEntitiesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListEntitiesRequest) ProtoMessage() {}
+
+func (x *ListEntitiesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListEntitiesRequest.ProtoReflect.Descriptor instead.
+func (*ListEntitiesRequest) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *ListEntitiesRequest) GetEntityId() string {
+	if x != nil {
+		return x.EntityId
+	}
+	return ""
+}
+
+type ListEntitiesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entity        []*MetaEntity          `protobuf:"bytes,1,rep,name=Entity,proto3" json:"Entity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListEntitiesResponse) Reset() {
+	*x = ListEntitiesResponse{}
+	mi := &file_cells_idm_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListEntitiesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListEntitiesResponse) ProtoMessage() {}
+
+func (x *ListEntitiesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListEntitiesResponse.ProtoReflect.Descriptor instead.
+func (*ListEntitiesResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{51}
+}
+
+func (x *ListEntitiesResponse) GetEntity() []*MetaEntity {
+	if x != nil {
+		return x.Entity
+	}
+	return nil
+}
+
+type GetEntityRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EntityUuid    string                 `protobuf:"bytes,1,opt,name=EntityUuid,proto3" json:"EntityUuid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetEntityRequest) Reset() {
+	*x = GetEntityRequest{}
+	mi := &file_cells_idm_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetEntityRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetEntityRequest) ProtoMessage() {}
+
+func (x *GetEntityRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetEntityRequest.ProtoReflect.Descriptor instead.
+func (*GetEntityRequest) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *GetEntityRequest) GetEntityUuid() string {
+	if x != nil {
+		return x.EntityUuid
+	}
+	return ""
+}
+
+type GetEntityResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entity        *MetaEntity            `protobuf:"bytes,1,opt,name=Entity,proto3" json:"Entity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetEntityResponse) Reset() {
+	*x = GetEntityResponse{}
+	mi := &file_cells_idm_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetEntityResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetEntityResponse) ProtoMessage() {}
+
+func (x *GetEntityResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetEntityResponse.ProtoReflect.Descriptor instead.
+func (*GetEntityResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *GetEntityResponse) GetEntity() *MetaEntity {
+	if x != nil {
+		return x.Entity
+	}
+	return nil
+}
+
+// Delete EntityValuesRequest, takes the EntityUuid and delete all its values and associations with metas
+type DeleteEntityValueRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	EntityValueUuid string                 `protobuf:"bytes,1,opt,name=EntityValueUuid,proto3" json:"EntityValueUuid,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *DeleteEntityValueRequest) Reset() {
+	*x = DeleteEntityValueRequest{}
+	mi := &file_cells_idm_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteEntityValueRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteEntityValueRequest) ProtoMessage() {}
+
+func (x *DeleteEntityValueRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteEntityValueRequest.ProtoReflect.Descriptor instead.
+func (*DeleteEntityValueRequest) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{54}
+}
+
+func (x *DeleteEntityValueRequest) GetEntityValueUuid() string {
+	if x != nil {
+		return x.EntityValueUuid
+	}
+	return ""
+}
+
+type DeleteEntityValueResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RowsDeleted   int64                  `protobuf:"varint,1,opt,name=RowsDeleted,proto3" json:"RowsDeleted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteEntityValueResponse) Reset() {
+	*x = DeleteEntityValueResponse{}
+	mi := &file_cells_idm_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteEntityValueResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteEntityValueResponse) ProtoMessage() {}
+
+func (x *DeleteEntityValueResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteEntityValueResponse.ProtoReflect.Descriptor instead.
+func (*DeleteEntityValueResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *DeleteEntityValueResponse) GetRowsDeleted() int64 {
 	if x != nil {
 		return x.RowsDeleted
 	}
@@ -3354,7 +3662,7 @@ type GetMetaEntityValuesRequest struct {
 
 func (x *GetMetaEntityValuesRequest) Reset() {
 	*x = GetMetaEntityValuesRequest{}
-	mi := &file_cells_idm_proto_msgTypes[49]
+	mi := &file_cells_idm_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3366,7 +3674,7 @@ func (x *GetMetaEntityValuesRequest) String() string {
 func (*GetMetaEntityValuesRequest) ProtoMessage() {}
 
 func (x *GetMetaEntityValuesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[49]
+	mi := &file_cells_idm_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3379,7 +3687,7 @@ func (x *GetMetaEntityValuesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMetaEntityValuesRequest.ProtoReflect.Descriptor instead.
 func (*GetMetaEntityValuesRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{49}
+	return file_cells_idm_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *GetMetaEntityValuesRequest) GetEntityUuid() string {
@@ -3399,7 +3707,7 @@ type MetaEntityValueResponse struct {
 
 func (x *MetaEntityValueResponse) Reset() {
 	*x = MetaEntityValueResponse{}
-	mi := &file_cells_idm_proto_msgTypes[50]
+	mi := &file_cells_idm_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3411,7 +3719,7 @@ func (x *MetaEntityValueResponse) String() string {
 func (*MetaEntityValueResponse) ProtoMessage() {}
 
 func (x *MetaEntityValueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[50]
+	mi := &file_cells_idm_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3424,7 +3732,7 @@ func (x *MetaEntityValueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetaEntityValueResponse.ProtoReflect.Descriptor instead.
 func (*MetaEntityValueResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{50}
+	return file_cells_idm_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *MetaEntityValueResponse) GetEntityValue() []*EntityValue {
@@ -3445,7 +3753,7 @@ type MetaToEntityValueRequest struct {
 
 func (x *MetaToEntityValueRequest) Reset() {
 	*x = MetaToEntityValueRequest{}
-	mi := &file_cells_idm_proto_msgTypes[51]
+	mi := &file_cells_idm_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3457,7 +3765,7 @@ func (x *MetaToEntityValueRequest) String() string {
 func (*MetaToEntityValueRequest) ProtoMessage() {}
 
 func (x *MetaToEntityValueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[51]
+	mi := &file_cells_idm_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3470,7 +3778,7 @@ func (x *MetaToEntityValueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetaToEntityValueRequest.ProtoReflect.Descriptor instead.
 func (*MetaToEntityValueRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{51}
+	return file_cells_idm_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *MetaToEntityValueRequest) GetMetaUuid() string {
@@ -3497,7 +3805,7 @@ type MetaToEntityValueResponse struct {
 
 func (x *MetaToEntityValueResponse) Reset() {
 	*x = MetaToEntityValueResponse{}
-	mi := &file_cells_idm_proto_msgTypes[52]
+	mi := &file_cells_idm_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3509,7 +3817,7 @@ func (x *MetaToEntityValueResponse) String() string {
 func (*MetaToEntityValueResponse) ProtoMessage() {}
 
 func (x *MetaToEntityValueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[52]
+	mi := &file_cells_idm_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3522,7 +3830,7 @@ func (x *MetaToEntityValueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetaToEntityValueResponse.ProtoReflect.Descriptor instead.
 func (*MetaToEntityValueResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{52}
+	return file_cells_idm_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *MetaToEntityValueResponse) GetSuccess() bool {
@@ -3555,7 +3863,7 @@ type UserMeta struct {
 
 func (x *UserMeta) Reset() {
 	*x = UserMeta{}
-	mi := &file_cells_idm_proto_msgTypes[53]
+	mi := &file_cells_idm_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3567,7 +3875,7 @@ func (x *UserMeta) String() string {
 func (*UserMeta) ProtoMessage() {}
 
 func (x *UserMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[53]
+	mi := &file_cells_idm_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3580,7 +3888,7 @@ func (x *UserMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserMeta.ProtoReflect.Descriptor instead.
 func (*UserMeta) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{53}
+	return file_cells_idm_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *UserMeta) GetUuid() string {
@@ -3665,7 +3973,7 @@ type UserMetaNamespace struct {
 
 func (x *UserMetaNamespace) Reset() {
 	*x = UserMetaNamespace{}
-	mi := &file_cells_idm_proto_msgTypes[54]
+	mi := &file_cells_idm_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3677,7 +3985,7 @@ func (x *UserMetaNamespace) String() string {
 func (*UserMetaNamespace) ProtoMessage() {}
 
 func (x *UserMetaNamespace) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[54]
+	mi := &file_cells_idm_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3690,7 +3998,7 @@ func (x *UserMetaNamespace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserMetaNamespace.ProtoReflect.Descriptor instead.
 func (*UserMetaNamespace) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{54}
+	return file_cells_idm_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *UserMetaNamespace) GetNamespace() string {
@@ -3779,17 +4087,19 @@ func (x *UserMetaNamespace) GetFieldType() string {
 
 // MetaEntity represents a metadata entity (e.g., "Department", "Project")
 type MetaEntity struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Uuid          string                 `protobuf:"bytes,1,opt,name=Uuid,proto3" json:"Uuid,omitempty"`
-	Label         string                 `protobuf:"bytes,2,opt,name=Label,proto3" json:"Label,omitempty"`
-	Description   string                 `protobuf:"bytes,3,opt,name=Description,proto3" json:"Description,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                   protoimpl.MessageState    `protogen:"open.v1"`
+	Uuid                    string                    `protobuf:"bytes,1,opt,name=Uuid,proto3" json:"Uuid,omitempty"`
+	Label                   string                    `protobuf:"bytes,2,opt,name=Label,proto3" json:"Label,omitempty"`
+	Description             string                    `protobuf:"bytes,3,opt,name=Description,proto3" json:"Description,omitempty"`
+	Policies                []*service.ResourcePolicy `protobuf:"bytes,4,rep,name=Policies,proto3" json:"Policies,omitempty"`
+	PoliciesContextEditable bool                      `protobuf:"varint,5,opt,name=PoliciesContextEditable,proto3" json:"PoliciesContextEditable,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *MetaEntity) Reset() {
 	*x = MetaEntity{}
-	mi := &file_cells_idm_proto_msgTypes[55]
+	mi := &file_cells_idm_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3801,7 +4111,7 @@ func (x *MetaEntity) String() string {
 func (*MetaEntity) ProtoMessage() {}
 
 func (x *MetaEntity) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[55]
+	mi := &file_cells_idm_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3814,7 +4124,7 @@ func (x *MetaEntity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetaEntity.ProtoReflect.Descriptor instead.
 func (*MetaEntity) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{55}
+	return file_cells_idm_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *MetaEntity) GetUuid() string {
@@ -3838,20 +4148,37 @@ func (x *MetaEntity) GetDescription() string {
 	return ""
 }
 
+func (x *MetaEntity) GetPolicies() []*service.ResourcePolicy {
+	if x != nil {
+		return x.Policies
+	}
+	return nil
+}
+
+func (x *MetaEntity) GetPoliciesContextEditable() bool {
+	if x != nil {
+		return x.PoliciesContextEditable
+	}
+	return false
+}
+
 // EntityValue represents a value for an entity (e.g., "Engineering", "Sales")
 type EntityValue struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Uuid          string                 `protobuf:"bytes,1,opt,name=Uuid,proto3" json:"Uuid,omitempty"`
-	Label         string                 `protobuf:"bytes,2,opt,name=Label,proto3" json:"Label,omitempty"`
-	EntityUuid    string                 `protobuf:"bytes,3,opt,name=EntityUuid,proto3" json:"EntityUuid,omitempty"`
-	DisplayJSON   string                 `protobuf:"bytes,4,opt,name=DisplayJSON,proto3" json:"DisplayJSON,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                   protoimpl.MessageState    `protogen:"open.v1"`
+	Uuid                    string                    `protobuf:"bytes,1,opt,name=Uuid,proto3" json:"Uuid,omitempty"`
+	Label                   string                    `protobuf:"bytes,2,opt,name=Label,proto3" json:"Label,omitempty"`
+	EntityUuid              string                    `protobuf:"bytes,3,opt,name=EntityUuid,proto3" json:"EntityUuid,omitempty"`
+	DisplayJSON             string                    `protobuf:"bytes,4,opt,name=DisplayJSON,proto3" json:"DisplayJSON,omitempty"`
+	Policies                []*service.ResourcePolicy `protobuf:"bytes,5,rep,name=Policies,proto3" json:"Policies,omitempty"`
+	PoliciesContextEditable bool                      `protobuf:"varint,6,opt,name=PoliciesContextEditable,proto3" json:"PoliciesContextEditable,omitempty"`
+	MetaUuid                string                    `protobuf:"bytes,7,opt,name=MetaUuid,proto3" json:"MetaUuid,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *EntityValue) Reset() {
 	*x = EntityValue{}
-	mi := &file_cells_idm_proto_msgTypes[56]
+	mi := &file_cells_idm_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3863,7 +4190,7 @@ func (x *EntityValue) String() string {
 func (*EntityValue) ProtoMessage() {}
 
 func (x *EntityValue) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[56]
+	mi := &file_cells_idm_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3876,7 +4203,7 @@ func (x *EntityValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EntityValue.ProtoReflect.Descriptor instead.
 func (*EntityValue) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{56}
+	return file_cells_idm_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *EntityValue) GetUuid() string {
@@ -3907,6 +4234,27 @@ func (x *EntityValue) GetDisplayJSON() string {
 	return ""
 }
 
+func (x *EntityValue) GetPolicies() []*service.ResourcePolicy {
+	if x != nil {
+		return x.Policies
+	}
+	return nil
+}
+
+func (x *EntityValue) GetPoliciesContextEditable() bool {
+	if x != nil {
+		return x.PoliciesContextEditable
+	}
+	return false
+}
+
+func (x *EntityValue) GetMetaUuid() string {
+	if x != nil {
+		return x.MetaUuid
+	}
+	return ""
+}
+
 // Request for modifying UserMeta
 type UpdateUserMetaRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -3920,7 +4268,7 @@ type UpdateUserMetaRequest struct {
 
 func (x *UpdateUserMetaRequest) Reset() {
 	*x = UpdateUserMetaRequest{}
-	mi := &file_cells_idm_proto_msgTypes[57]
+	mi := &file_cells_idm_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3932,7 +4280,7 @@ func (x *UpdateUserMetaRequest) String() string {
 func (*UpdateUserMetaRequest) ProtoMessage() {}
 
 func (x *UpdateUserMetaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[57]
+	mi := &file_cells_idm_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3945,7 +4293,7 @@ func (x *UpdateUserMetaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaRequest.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{57}
+	return file_cells_idm_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *UpdateUserMetaRequest) GetOperation() UpdateUserMetaRequest_UserMetaOp {
@@ -3973,7 +4321,7 @@ type UpdateUserMetaResponse struct {
 
 func (x *UpdateUserMetaResponse) Reset() {
 	*x = UpdateUserMetaResponse{}
-	mi := &file_cells_idm_proto_msgTypes[58]
+	mi := &file_cells_idm_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3985,7 +4333,7 @@ func (x *UpdateUserMetaResponse) String() string {
 func (*UpdateUserMetaResponse) ProtoMessage() {}
 
 func (x *UpdateUserMetaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[58]
+	mi := &file_cells_idm_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3998,7 +4346,7 @@ func (x *UpdateUserMetaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaResponse.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{58}
+	return file_cells_idm_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *UpdateUserMetaResponse) GetMetaDatas() []*UserMeta {
@@ -4023,7 +4371,7 @@ type UpdateUserMetaEvent struct {
 
 func (x *UpdateUserMetaEvent) Reset() {
 	*x = UpdateUserMetaEvent{}
-	mi := &file_cells_idm_proto_msgTypes[59]
+	mi := &file_cells_idm_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4035,7 +4383,7 @@ func (x *UpdateUserMetaEvent) String() string {
 func (*UpdateUserMetaEvent) ProtoMessage() {}
 
 func (x *UpdateUserMetaEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[59]
+	mi := &file_cells_idm_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4048,7 +4396,7 @@ func (x *UpdateUserMetaEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaEvent.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaEvent) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{59}
+	return file_cells_idm_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *UpdateUserMetaEvent) GetEventMetadata() map[string]string {
@@ -4091,7 +4439,7 @@ type SearchUserMetaRequest struct {
 
 func (x *SearchUserMetaRequest) Reset() {
 	*x = SearchUserMetaRequest{}
-	mi := &file_cells_idm_proto_msgTypes[60]
+	mi := &file_cells_idm_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4103,7 +4451,7 @@ func (x *SearchUserMetaRequest) String() string {
 func (*SearchUserMetaRequest) ProtoMessage() {}
 
 func (x *SearchUserMetaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[60]
+	mi := &file_cells_idm_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4116,7 +4464,7 @@ func (x *SearchUserMetaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchUserMetaRequest.ProtoReflect.Descriptor instead.
 func (*SearchUserMetaRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{60}
+	return file_cells_idm_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *SearchUserMetaRequest) GetMetaUuids() []string {
@@ -4164,7 +4512,7 @@ type SearchUserMetaResponse struct {
 
 func (x *SearchUserMetaResponse) Reset() {
 	*x = SearchUserMetaResponse{}
-	mi := &file_cells_idm_proto_msgTypes[61]
+	mi := &file_cells_idm_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4176,7 +4524,7 @@ func (x *SearchUserMetaResponse) String() string {
 func (*SearchUserMetaResponse) ProtoMessage() {}
 
 func (x *SearchUserMetaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[61]
+	mi := &file_cells_idm_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4189,7 +4537,7 @@ func (x *SearchUserMetaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchUserMetaResponse.ProtoReflect.Descriptor instead.
 func (*SearchUserMetaResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{61}
+	return file_cells_idm_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *SearchUserMetaResponse) GetUserMeta() *UserMeta {
@@ -4210,7 +4558,7 @@ type UpdateUserMetaNamespaceRequest struct {
 
 func (x *UpdateUserMetaNamespaceRequest) Reset() {
 	*x = UpdateUserMetaNamespaceRequest{}
-	mi := &file_cells_idm_proto_msgTypes[62]
+	mi := &file_cells_idm_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4222,7 +4570,7 @@ func (x *UpdateUserMetaNamespaceRequest) String() string {
 func (*UpdateUserMetaNamespaceRequest) ProtoMessage() {}
 
 func (x *UpdateUserMetaNamespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[62]
+	mi := &file_cells_idm_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4235,7 +4583,7 @@ func (x *UpdateUserMetaNamespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaNamespaceRequest.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaNamespaceRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{62}
+	return file_cells_idm_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *UpdateUserMetaNamespaceRequest) GetOperation() UpdateUserMetaNamespaceRequest_UserMetaNsOp {
@@ -4262,7 +4610,7 @@ type UpdateUserMetaNamespaceResponse struct {
 
 func (x *UpdateUserMetaNamespaceResponse) Reset() {
 	*x = UpdateUserMetaNamespaceResponse{}
-	mi := &file_cells_idm_proto_msgTypes[63]
+	mi := &file_cells_idm_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4274,7 +4622,7 @@ func (x *UpdateUserMetaNamespaceResponse) String() string {
 func (*UpdateUserMetaNamespaceResponse) ProtoMessage() {}
 
 func (x *UpdateUserMetaNamespaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[63]
+	mi := &file_cells_idm_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4287,7 +4635,7 @@ func (x *UpdateUserMetaNamespaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserMetaNamespaceResponse.ProtoReflect.Descriptor instead.
 func (*UpdateUserMetaNamespaceResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{63}
+	return file_cells_idm_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *UpdateUserMetaNamespaceResponse) GetNamespaces() []*UserMetaNamespace {
@@ -4306,7 +4654,7 @@ type ListUserMetaNamespaceRequest struct {
 
 func (x *ListUserMetaNamespaceRequest) Reset() {
 	*x = ListUserMetaNamespaceRequest{}
-	mi := &file_cells_idm_proto_msgTypes[64]
+	mi := &file_cells_idm_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4318,7 +4666,7 @@ func (x *ListUserMetaNamespaceRequest) String() string {
 func (*ListUserMetaNamespaceRequest) ProtoMessage() {}
 
 func (x *ListUserMetaNamespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[64]
+	mi := &file_cells_idm_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4331,7 +4679,7 @@ func (x *ListUserMetaNamespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUserMetaNamespaceRequest.ProtoReflect.Descriptor instead.
 func (*ListUserMetaNamespaceRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{64}
+	return file_cells_idm_proto_rawDescGZIP(), []int{71}
 }
 
 // Collection of results
@@ -4344,7 +4692,7 @@ type ListUserMetaNamespaceResponse struct {
 
 func (x *ListUserMetaNamespaceResponse) Reset() {
 	*x = ListUserMetaNamespaceResponse{}
-	mi := &file_cells_idm_proto_msgTypes[65]
+	mi := &file_cells_idm_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4356,7 +4704,7 @@ func (x *ListUserMetaNamespaceResponse) String() string {
 func (*ListUserMetaNamespaceResponse) ProtoMessage() {}
 
 func (x *ListUserMetaNamespaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[65]
+	mi := &file_cells_idm_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4369,7 +4717,7 @@ func (x *ListUserMetaNamespaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUserMetaNamespaceResponse.ProtoReflect.Descriptor instead.
 func (*ListUserMetaNamespaceResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{65}
+	return file_cells_idm_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *ListUserMetaNamespaceResponse) GetUserMetaNamespace() *UserMetaNamespace {
@@ -4388,7 +4736,7 @@ type GetFieldSchemaRequest struct {
 
 func (x *GetFieldSchemaRequest) Reset() {
 	*x = GetFieldSchemaRequest{}
-	mi := &file_cells_idm_proto_msgTypes[66]
+	mi := &file_cells_idm_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4400,7 +4748,7 @@ func (x *GetFieldSchemaRequest) String() string {
 func (*GetFieldSchemaRequest) ProtoMessage() {}
 
 func (x *GetFieldSchemaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[66]
+	mi := &file_cells_idm_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4413,7 +4761,7 @@ func (x *GetFieldSchemaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFieldSchemaRequest.ProtoReflect.Descriptor instead.
 func (*GetFieldSchemaRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{66}
+	return file_cells_idm_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *GetFieldSchemaRequest) GetFieldType() string {
@@ -4432,7 +4780,7 @@ type JsonSchemaResponse struct {
 
 func (x *JsonSchemaResponse) Reset() {
 	*x = JsonSchemaResponse{}
-	mi := &file_cells_idm_proto_msgTypes[67]
+	mi := &file_cells_idm_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4444,7 +4792,7 @@ func (x *JsonSchemaResponse) String() string {
 func (*JsonSchemaResponse) ProtoMessage() {}
 
 func (x *JsonSchemaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[67]
+	mi := &file_cells_idm_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4457,7 +4805,7 @@ func (x *JsonSchemaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JsonSchemaResponse.ProtoReflect.Descriptor instead.
 func (*JsonSchemaResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{67}
+	return file_cells_idm_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *JsonSchemaResponse) GetJsonSchema() *structpb.Struct {
@@ -4478,7 +4826,7 @@ type GetNamespaceSchemaRequest struct {
 
 func (x *GetNamespaceSchemaRequest) Reset() {
 	*x = GetNamespaceSchemaRequest{}
-	mi := &file_cells_idm_proto_msgTypes[68]
+	mi := &file_cells_idm_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4490,7 +4838,7 @@ func (x *GetNamespaceSchemaRequest) String() string {
 func (*GetNamespaceSchemaRequest) ProtoMessage() {}
 
 func (x *GetNamespaceSchemaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[68]
+	mi := &file_cells_idm_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4503,7 +4851,7 @@ func (x *GetNamespaceSchemaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNamespaceSchemaRequest.ProtoReflect.Descriptor instead.
 func (*GetNamespaceSchemaRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{68}
+	return file_cells_idm_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *GetNamespaceSchemaRequest) GetFieldType() string {
@@ -4527,6 +4875,86 @@ func (x *GetNamespaceSchemaRequest) GetFormat() string {
 	return ""
 }
 
+type GetEntitiesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetEntitiesRequest) Reset() {
+	*x = GetEntitiesRequest{}
+	mi := &file_cells_idm_proto_msgTypes[76]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetEntitiesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetEntitiesRequest) ProtoMessage() {}
+
+func (x *GetEntitiesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[76]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetEntitiesRequest.ProtoReflect.Descriptor instead.
+func (*GetEntitiesRequest) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{76}
+}
+
+type GetEntitiesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entities      []*MetaEntity          `protobuf:"bytes,1,rep,name=Entities,proto3" json:"Entities,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetEntitiesResponse) Reset() {
+	*x = GetEntitiesResponse{}
+	mi := &file_cells_idm_proto_msgTypes[77]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetEntitiesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetEntitiesResponse) ProtoMessage() {}
+
+func (x *GetEntitiesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cells_idm_proto_msgTypes[77]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetEntitiesResponse.ProtoReflect.Descriptor instead.
+func (*GetEntitiesResponse) Descriptor() ([]byte, []int) {
+	return file_cells_idm_proto_rawDescGZIP(), []int{77}
+}
+
+func (x *GetEntitiesResponse) GetEntities() []*MetaEntity {
+	if x != nil {
+		return x.Entities
+	}
+	return nil
+}
+
 // Global Event message for IDM
 type ChangeEvent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -4544,7 +4972,7 @@ type ChangeEvent struct {
 
 func (x *ChangeEvent) Reset() {
 	*x = ChangeEvent{}
-	mi := &file_cells_idm_proto_msgTypes[69]
+	mi := &file_cells_idm_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4556,7 +4984,7 @@ func (x *ChangeEvent) String() string {
 func (*ChangeEvent) ProtoMessage() {}
 
 func (x *ChangeEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[69]
+	mi := &file_cells_idm_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4569,7 +4997,7 @@ func (x *ChangeEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeEvent.ProtoReflect.Descriptor instead.
 func (*ChangeEvent) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{69}
+	return file_cells_idm_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *ChangeEvent) GetJsonType() string {
@@ -4643,7 +5071,7 @@ type PolicyEngineRequest struct {
 
 func (x *PolicyEngineRequest) Reset() {
 	*x = PolicyEngineRequest{}
-	mi := &file_cells_idm_proto_msgTypes[70]
+	mi := &file_cells_idm_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4655,7 +5083,7 @@ func (x *PolicyEngineRequest) String() string {
 func (*PolicyEngineRequest) ProtoMessage() {}
 
 func (x *PolicyEngineRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[70]
+	mi := &file_cells_idm_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4668,7 +5096,7 @@ func (x *PolicyEngineRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyEngineRequest.ProtoReflect.Descriptor instead.
 func (*PolicyEngineRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{70}
+	return file_cells_idm_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *PolicyEngineRequest) GetResource() string {
@@ -4710,7 +5138,7 @@ type PolicyEngineResponse struct {
 
 func (x *PolicyEngineResponse) Reset() {
 	*x = PolicyEngineResponse{}
-	mi := &file_cells_idm_proto_msgTypes[71]
+	mi := &file_cells_idm_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4722,7 +5150,7 @@ func (x *PolicyEngineResponse) String() string {
 func (*PolicyEngineResponse) ProtoMessage() {}
 
 func (x *PolicyEngineResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[71]
+	mi := &file_cells_idm_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4735,7 +5163,7 @@ func (x *PolicyEngineResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyEngineResponse.ProtoReflect.Descriptor instead.
 func (*PolicyEngineResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{71}
+	return file_cells_idm_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *PolicyEngineResponse) GetAllowed() bool {
@@ -4769,7 +5197,7 @@ type PolicyCondition struct {
 
 func (x *PolicyCondition) Reset() {
 	*x = PolicyCondition{}
-	mi := &file_cells_idm_proto_msgTypes[72]
+	mi := &file_cells_idm_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4781,7 +5209,7 @@ func (x *PolicyCondition) String() string {
 func (*PolicyCondition) ProtoMessage() {}
 
 func (x *PolicyCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[72]
+	mi := &file_cells_idm_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4794,7 +5222,7 @@ func (x *PolicyCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyCondition.ProtoReflect.Descriptor instead.
 func (*PolicyCondition) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{72}
+	return file_cells_idm_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *PolicyCondition) GetType() string {
@@ -4829,7 +5257,7 @@ type Policy struct {
 
 func (x *Policy) Reset() {
 	*x = Policy{}
-	mi := &file_cells_idm_proto_msgTypes[73]
+	mi := &file_cells_idm_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4841,7 +5269,7 @@ func (x *Policy) String() string {
 func (*Policy) ProtoMessage() {}
 
 func (x *Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[73]
+	mi := &file_cells_idm_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4854,7 +5282,7 @@ func (x *Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy.ProtoReflect.Descriptor instead.
 func (*Policy) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{73}
+	return file_cells_idm_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *Policy) GetID() string {
@@ -4939,7 +5367,7 @@ type PolicySubject struct {
 
 func (x *PolicySubject) Reset() {
 	*x = PolicySubject{}
-	mi := &file_cells_idm_proto_msgTypes[74]
+	mi := &file_cells_idm_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4951,7 +5379,7 @@ func (x *PolicySubject) String() string {
 func (*PolicySubject) ProtoMessage() {}
 
 func (x *PolicySubject) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[74]
+	mi := &file_cells_idm_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4964,7 +5392,7 @@ func (x *PolicySubject) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySubject.ProtoReflect.Descriptor instead.
 func (*PolicySubject) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{74}
+	return file_cells_idm_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *PolicySubject) GetID() string {
@@ -5007,7 +5435,7 @@ type PolicyResource struct {
 
 func (x *PolicyResource) Reset() {
 	*x = PolicyResource{}
-	mi := &file_cells_idm_proto_msgTypes[75]
+	mi := &file_cells_idm_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5019,7 +5447,7 @@ func (x *PolicyResource) String() string {
 func (*PolicyResource) ProtoMessage() {}
 
 func (x *PolicyResource) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[75]
+	mi := &file_cells_idm_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5032,7 +5460,7 @@ func (x *PolicyResource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyResource.ProtoReflect.Descriptor instead.
 func (*PolicyResource) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{75}
+	return file_cells_idm_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *PolicyResource) GetID() string {
@@ -5075,7 +5503,7 @@ type PolicyAction struct {
 
 func (x *PolicyAction) Reset() {
 	*x = PolicyAction{}
-	mi := &file_cells_idm_proto_msgTypes[76]
+	mi := &file_cells_idm_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5087,7 +5515,7 @@ func (x *PolicyAction) String() string {
 func (*PolicyAction) ProtoMessage() {}
 
 func (x *PolicyAction) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[76]
+	mi := &file_cells_idm_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5100,7 +5528,7 @@ func (x *PolicyAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyAction.ProtoReflect.Descriptor instead.
 func (*PolicyAction) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{76}
+	return file_cells_idm_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *PolicyAction) GetID() string {
@@ -5141,7 +5569,7 @@ type PolicyResourceRel struct {
 
 func (x *PolicyResourceRel) Reset() {
 	*x = PolicyResourceRel{}
-	mi := &file_cells_idm_proto_msgTypes[77]
+	mi := &file_cells_idm_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5153,7 +5581,7 @@ func (x *PolicyResourceRel) String() string {
 func (*PolicyResourceRel) ProtoMessage() {}
 
 func (x *PolicyResourceRel) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[77]
+	mi := &file_cells_idm_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5166,7 +5594,7 @@ func (x *PolicyResourceRel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyResourceRel.ProtoReflect.Descriptor instead.
 func (*PolicyResourceRel) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{77}
+	return file_cells_idm_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *PolicyResourceRel) GetPolicy() string {
@@ -5193,7 +5621,7 @@ type PolicySubjectRel struct {
 
 func (x *PolicySubjectRel) Reset() {
 	*x = PolicySubjectRel{}
-	mi := &file_cells_idm_proto_msgTypes[78]
+	mi := &file_cells_idm_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5205,7 +5633,7 @@ func (x *PolicySubjectRel) String() string {
 func (*PolicySubjectRel) ProtoMessage() {}
 
 func (x *PolicySubjectRel) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[78]
+	mi := &file_cells_idm_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5218,7 +5646,7 @@ func (x *PolicySubjectRel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySubjectRel.ProtoReflect.Descriptor instead.
 func (*PolicySubjectRel) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{78}
+	return file_cells_idm_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *PolicySubjectRel) GetPolicy() string {
@@ -5245,7 +5673,7 @@ type PolicyActionRel struct {
 
 func (x *PolicyActionRel) Reset() {
 	*x = PolicyActionRel{}
-	mi := &file_cells_idm_proto_msgTypes[79]
+	mi := &file_cells_idm_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5257,7 +5685,7 @@ func (x *PolicyActionRel) String() string {
 func (*PolicyActionRel) ProtoMessage() {}
 
 func (x *PolicyActionRel) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[79]
+	mi := &file_cells_idm_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5270,7 +5698,7 @@ func (x *PolicyActionRel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyActionRel.ProtoReflect.Descriptor instead.
 func (*PolicyActionRel) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{79}
+	return file_cells_idm_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *PolicyActionRel) GetPolicy() string {
@@ -5298,7 +5726,7 @@ type PolicyRel struct {
 
 func (x *PolicyRel) Reset() {
 	*x = PolicyRel{}
-	mi := &file_cells_idm_proto_msgTypes[80]
+	mi := &file_cells_idm_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5310,7 +5738,7 @@ func (x *PolicyRel) String() string {
 func (*PolicyRel) ProtoMessage() {}
 
 func (x *PolicyRel) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[80]
+	mi := &file_cells_idm_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5323,7 +5751,7 @@ func (x *PolicyRel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyRel.ProtoReflect.Descriptor instead.
 func (*PolicyRel) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{80}
+	return file_cells_idm_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *PolicyRel) GetID() int64 {
@@ -5362,7 +5790,7 @@ type PolicyGroup struct {
 
 func (x *PolicyGroup) Reset() {
 	*x = PolicyGroup{}
-	mi := &file_cells_idm_proto_msgTypes[81]
+	mi := &file_cells_idm_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5374,7 +5802,7 @@ func (x *PolicyGroup) String() string {
 func (*PolicyGroup) ProtoMessage() {}
 
 func (x *PolicyGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[81]
+	mi := &file_cells_idm_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5387,7 +5815,7 @@ func (x *PolicyGroup) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyGroup.ProtoReflect.Descriptor instead.
 func (*PolicyGroup) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{81}
+	return file_cells_idm_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *PolicyGroup) GetUuid() string {
@@ -5449,7 +5877,7 @@ type StorePolicyGroupRequest struct {
 
 func (x *StorePolicyGroupRequest) Reset() {
 	*x = StorePolicyGroupRequest{}
-	mi := &file_cells_idm_proto_msgTypes[82]
+	mi := &file_cells_idm_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5461,7 +5889,7 @@ func (x *StorePolicyGroupRequest) String() string {
 func (*StorePolicyGroupRequest) ProtoMessage() {}
 
 func (x *StorePolicyGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[82]
+	mi := &file_cells_idm_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5474,7 +5902,7 @@ func (x *StorePolicyGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorePolicyGroupRequest.ProtoReflect.Descriptor instead.
 func (*StorePolicyGroupRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{82}
+	return file_cells_idm_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *StorePolicyGroupRequest) GetPolicyGroup() *PolicyGroup {
@@ -5493,7 +5921,7 @@ type StorePolicyGroupResponse struct {
 
 func (x *StorePolicyGroupResponse) Reset() {
 	*x = StorePolicyGroupResponse{}
-	mi := &file_cells_idm_proto_msgTypes[83]
+	mi := &file_cells_idm_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5505,7 +5933,7 @@ func (x *StorePolicyGroupResponse) String() string {
 func (*StorePolicyGroupResponse) ProtoMessage() {}
 
 func (x *StorePolicyGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[83]
+	mi := &file_cells_idm_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5518,7 +5946,7 @@ func (x *StorePolicyGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StorePolicyGroupResponse.ProtoReflect.Descriptor instead.
 func (*StorePolicyGroupResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{83}
+	return file_cells_idm_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *StorePolicyGroupResponse) GetPolicyGroup() *PolicyGroup {
@@ -5537,7 +5965,7 @@ type DeletePolicyGroupRequest struct {
 
 func (x *DeletePolicyGroupRequest) Reset() {
 	*x = DeletePolicyGroupRequest{}
-	mi := &file_cells_idm_proto_msgTypes[84]
+	mi := &file_cells_idm_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5549,7 +5977,7 @@ func (x *DeletePolicyGroupRequest) String() string {
 func (*DeletePolicyGroupRequest) ProtoMessage() {}
 
 func (x *DeletePolicyGroupRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[84]
+	mi := &file_cells_idm_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5562,7 +5990,7 @@ func (x *DeletePolicyGroupRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeletePolicyGroupRequest.ProtoReflect.Descriptor instead.
 func (*DeletePolicyGroupRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{84}
+	return file_cells_idm_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *DeletePolicyGroupRequest) GetPolicyGroup() *PolicyGroup {
@@ -5581,7 +6009,7 @@ type DeletePolicyGroupResponse struct {
 
 func (x *DeletePolicyGroupResponse) Reset() {
 	*x = DeletePolicyGroupResponse{}
-	mi := &file_cells_idm_proto_msgTypes[85]
+	mi := &file_cells_idm_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5593,7 +6021,7 @@ func (x *DeletePolicyGroupResponse) String() string {
 func (*DeletePolicyGroupResponse) ProtoMessage() {}
 
 func (x *DeletePolicyGroupResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[85]
+	mi := &file_cells_idm_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5606,7 +6034,7 @@ func (x *DeletePolicyGroupResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeletePolicyGroupResponse.ProtoReflect.Descriptor instead.
 func (*DeletePolicyGroupResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{85}
+	return file_cells_idm_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *DeletePolicyGroupResponse) GetSuccess() bool {
@@ -5628,7 +6056,7 @@ type ListPolicyGroupsRequest struct {
 
 func (x *ListPolicyGroupsRequest) Reset() {
 	*x = ListPolicyGroupsRequest{}
-	mi := &file_cells_idm_proto_msgTypes[86]
+	mi := &file_cells_idm_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5640,7 +6068,7 @@ func (x *ListPolicyGroupsRequest) String() string {
 func (*ListPolicyGroupsRequest) ProtoMessage() {}
 
 func (x *ListPolicyGroupsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[86]
+	mi := &file_cells_idm_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5653,7 +6081,7 @@ func (x *ListPolicyGroupsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPolicyGroupsRequest.ProtoReflect.Descriptor instead.
 func (*ListPolicyGroupsRequest) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{86}
+	return file_cells_idm_proto_rawDescGZIP(), []int{95}
 }
 
 // Deprecated: Marked as deprecated in cells-idm.proto.
@@ -5681,7 +6109,7 @@ type ListPolicyGroupsResponse struct {
 
 func (x *ListPolicyGroupsResponse) Reset() {
 	*x = ListPolicyGroupsResponse{}
-	mi := &file_cells_idm_proto_msgTypes[87]
+	mi := &file_cells_idm_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5693,7 +6121,7 @@ func (x *ListPolicyGroupsResponse) String() string {
 func (*ListPolicyGroupsResponse) ProtoMessage() {}
 
 func (x *ListPolicyGroupsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[87]
+	mi := &file_cells_idm_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5706,7 +6134,7 @@ func (x *ListPolicyGroupsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPolicyGroupsResponse.ProtoReflect.Descriptor instead.
 func (*ListPolicyGroupsResponse) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{87}
+	return file_cells_idm_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *ListPolicyGroupsResponse) GetPolicyGroups() []*PolicyGroup {
@@ -5742,7 +6170,7 @@ type PolicyGroupSingleQuery struct {
 
 func (x *PolicyGroupSingleQuery) Reset() {
 	*x = PolicyGroupSingleQuery{}
-	mi := &file_cells_idm_proto_msgTypes[88]
+	mi := &file_cells_idm_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5754,7 +6182,7 @@ func (x *PolicyGroupSingleQuery) String() string {
 func (*PolicyGroupSingleQuery) ProtoMessage() {}
 
 func (x *PolicyGroupSingleQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_cells_idm_proto_msgTypes[88]
+	mi := &file_cells_idm_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5767,7 +6195,7 @@ func (x *PolicyGroupSingleQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyGroupSingleQuery.ProtoReflect.Descriptor instead.
 func (*PolicyGroupSingleQuery) Descriptor() ([]byte, []int) {
-	return file_cells_idm_proto_rawDescGZIP(), []int{88}
+	return file_cells_idm_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *PolicyGroupSingleQuery) GetResourceGroup() string {
@@ -6069,8 +6497,24 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\x13CreateEntityRequest\x12'\n" +
 	"\x06Entity\x18\x01 \x01(\v2\x0f.idm.MetaEntityR\x06Entity\"?\n" +
 	"\x14CreateEntityResponse\x12'\n" +
-	"\x06Entity\x18\x01 \x01(\v2\x0f.idm.MetaEntityR\x06Entity\">\n" +
-	"\x1aDeleteEntityValuesResponse\x12 \n" +
+	"\x06Entity\x18\x01 \x01(\v2\x0f.idm.MetaEntityR\x06Entity\"1\n" +
+	"\x13DeleteEntityRequest\x12\x1a\n" +
+	"\bEntityId\x18\x01 \x01(\tR\bEntityId\"8\n" +
+	"\x14DeleteEntityResponse\x12 \n" +
+	"\vRowsDeleted\x18\x01 \x01(\x03R\vRowsDeleted\"1\n" +
+	"\x13ListEntitiesRequest\x12\x1a\n" +
+	"\bEntityId\x18\x01 \x01(\tR\bEntityId\"?\n" +
+	"\x14ListEntitiesResponse\x12'\n" +
+	"\x06Entity\x18\x01 \x03(\v2\x0f.idm.MetaEntityR\x06Entity\"2\n" +
+	"\x10GetEntityRequest\x12\x1e\n" +
+	"\n" +
+	"EntityUuid\x18\x01 \x01(\tR\n" +
+	"EntityUuid\"<\n" +
+	"\x11GetEntityResponse\x12'\n" +
+	"\x06Entity\x18\x01 \x01(\v2\x0f.idm.MetaEntityR\x06Entity\"D\n" +
+	"\x18DeleteEntityValueRequest\x12(\n" +
+	"\x0fEntityValueUuid\x18\x01 \x01(\tR\x0fEntityValueUuid\"=\n" +
+	"\x19DeleteEntityValueResponse\x12 \n" +
 	"\vRowsDeleted\x18\x01 \x01(\x03R\vRowsDeleted\"<\n" +
 	"\x1aGetMetaEntityValuesRequest\x12\x1e\n" +
 	"\n" +
@@ -6107,19 +6551,24 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\x0eEnforceDefault\x18\n" +
 	" \x01(\bR\x0eEnforceDefault\x12 \n" +
 	"\vDescription\x18\v \x01(\tR\vDescription\x12\x1c\n" +
-	"\tFieldType\x18\f \x01(\tR\tFieldType\"X\n" +
+	"\tFieldType\x18\f \x01(\tR\tFieldType\"\xc7\x01\n" +
 	"\n" +
 	"MetaEntity\x12\x12\n" +
 	"\x04Uuid\x18\x01 \x01(\tR\x04Uuid\x12\x14\n" +
 	"\x05Label\x18\x02 \x01(\tR\x05Label\x12 \n" +
-	"\vDescription\x18\x03 \x01(\tR\vDescription\"y\n" +
+	"\vDescription\x18\x03 \x01(\tR\vDescription\x123\n" +
+	"\bPolicies\x18\x04 \x03(\v2\x17.service.ResourcePolicyR\bPolicies\x128\n" +
+	"\x17PoliciesContextEditable\x18\x05 \x01(\bR\x17PoliciesContextEditable\"\x84\x02\n" +
 	"\vEntityValue\x12\x12\n" +
 	"\x04Uuid\x18\x01 \x01(\tR\x04Uuid\x12\x14\n" +
 	"\x05Label\x18\x02 \x01(\tR\x05Label\x12\x1e\n" +
 	"\n" +
 	"EntityUuid\x18\x03 \x01(\tR\n" +
 	"EntityUuid\x12 \n" +
-	"\vDisplayJSON\x18\x04 \x01(\tR\vDisplayJSON\"\xac\x01\n" +
+	"\vDisplayJSON\x18\x04 \x01(\tR\vDisplayJSON\x123\n" +
+	"\bPolicies\x18\x05 \x03(\v2\x17.service.ResourcePolicyR\bPolicies\x128\n" +
+	"\x17PoliciesContextEditable\x18\x06 \x01(\bR\x17PoliciesContextEditable\x12\x1a\n" +
+	"\bMetaUuid\x18\a \x01(\tR\bMetaUuid\"\xac\x01\n" +
 	"\x15UpdateUserMetaRequest\x12C\n" +
 	"\tOperation\x18\x01 \x01(\x0e2%.idm.UpdateUserMetaRequest.UserMetaOpR\tOperation\x12+\n" +
 	"\tMetaDatas\x18\x03 \x03(\v2\r.idm.UserMetaR\tMetaDatas\"!\n" +
@@ -6174,7 +6623,10 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\x19GetNamespaceSchemaRequest\x12\x1c\n" +
 	"\tFieldType\x18\x01 \x01(\tR\tFieldType\x12\x1c\n" +
 	"\tNamespace\x18\x02 \x01(\tR\tNamespace\x12\x16\n" +
-	"\x06Format\x18\x03 \x01(\tR\x06Format\"\x97\x03\n" +
+	"\x06Format\x18\x03 \x01(\tR\x06Format\"\x14\n" +
+	"\x12GetEntitiesRequest\"B\n" +
+	"\x13GetEntitiesResponse\x12+\n" +
+	"\bEntities\x18\x01 \x03(\v2\x0f.idm.MetaEntityR\bEntities\"\x97\x03\n" +
 	"\vChangeEvent\x12\x17\n" +
 	"\bjsonType\x18\x01 \x01(\tR\x05@type\x12(\n" +
 	"\x04Type\x18\x02 \x01(\x0e2\x14.idm.ChangeEventTypeR\x04Type\x12\x1d\n" +
@@ -6422,7 +6874,8 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\tSearchACL\x12\x15.idm.SearchACLRequest\x1a\x16.idm.SearchACLResponse\"\x000\x01\x12@\n" +
 	"\tStreamACL\x12\x15.idm.SearchACLRequest\x1a\x16.idm.SearchACLResponse\"\x00(\x010\x01\x12?\n" +
 	"\n" +
-	"RestoreACL\x12\x16.idm.RestoreACLRequest\x1a\x17.idm.RestoreACLResponse\"\x002\xca\b\n" +
+	"RestoreACL\x12\x16.idm.RestoreACLRequest\x1a\x17.idm.RestoreACLResponse\"\x002\x98\n" +
+	"\n" +
 	"\x0fUserMetaService\x12K\n" +
 	"\x0eUpdateUserMeta\x12\x1a.idm.UpdateUserMetaRequest\x1a\x1b.idm.UpdateUserMetaResponse\"\x00\x12M\n" +
 	"\x0eSearchUserMeta\x12\x1a.idm.SearchUserMetaRequest\x1a\x1b.idm.SearchUserMetaResponse\"\x000\x01\x12f\n" +
@@ -6430,13 +6883,16 @@ const file_cells_idm_proto_rawDesc = "" +
 	"\x15ListUserMetaNamespace\x12!.idm.ListUserMetaNamespaceRequest\x1a\".idm.ListUserMetaNamespaceResponse\"\x000\x01\x12G\n" +
 	"\x0eGetFieldSchema\x12\x1a.idm.GetFieldSchemaRequest\x1a\x17.idm.JsonSchemaResponse\"\x00\x12O\n" +
 	"\x12GetNamespaceSchema\x12\x1e.idm.GetNamespaceSchemaRequest\x1a\x17.idm.JsonSchemaResponse\"\x00\x12R\n" +
-	"\x0fGetEntityValues\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1c.idm.MetaEntityValueResponse\"\x00\x12R\n" +
-	"\fDeleteEntity\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1f.idm.DeleteEntityValuesResponse\"\x00\x12E\n" +
+	"\x0fGetEntityValues\x12\x1f.idm.GetMetaEntityValuesRequest\x1a\x1c.idm.MetaEntityValueResponse\"\x00\x12E\n" +
+	"\fDeleteEntity\x12\x18.idm.DeleteEntityRequest\x1a\x19.idm.DeleteEntityResponse\"\x00\x12<\n" +
+	"\tGetEntity\x12\x15.idm.GetEntityRequest\x1a\x16.idm.GetEntityResponse\"\x00\x12E\n" +
+	"\fListEntities\x12\x18.idm.ListEntitiesRequest\x1a\x19.idm.ListEntitiesResponse\"\x00\x12E\n" +
 	"\fCreateEntity\x12\x18.idm.CreateEntityRequest\x1a\x19.idm.CreateEntityResponse\"\x00\x12U\n" +
 	"\x12CreateEntityValues\x12\x1d.idm.CreateEntityValueRequest\x1a\x1e.idm.CreateEntityValueResponse\"\x00\x12X\n" +
 	"\x15LinkMetaToEntityValue\x12\x1d.idm.MetaToEntityValueRequest\x1a\x1e.idm.MetaToEntityValueResponse\"\x00\x12\\\n" +
 	"\x19UnlinkMetaFromEntityValue\x12\x1d.idm.MetaToEntityValueRequest\x1a\x1e.idm.MetaToEntityValueResponse\"\x00\x127\n" +
-	"\vGetMetadata\x12\x17.idm.GetMetadataRequest\x1a\r.idm.UserMeta\"\x002\x9f\x03\n" +
+	"\vGetMetadata\x12\x17.idm.GetMetadataRequest\x1a\r.idm.UserMeta\"\x00\x12T\n" +
+	"\x11DeleteEntityValue\x12\x1d.idm.DeleteEntityValueRequest\x1a\x1e.idm.DeleteEntityValueResponse\"\x002\x9f\x03\n" +
 	"\x13PolicyEngineService\x12B\n" +
 	"\tIsAllowed\x12\x18.idm.PolicyEngineRequest\x1a\x19.idm.PolicyEngineResponse\"\x00\x12Q\n" +
 	"\x10StorePolicyGroup\x12\x1c.idm.StorePolicyGroupRequest\x1a\x1d.idm.StorePolicyGroupResponse\"\x00\x12Q\n" +
@@ -6457,7 +6913,7 @@ func file_cells_idm_proto_rawDescGZIP() []byte {
 }
 
 var file_cells_idm_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_cells_idm_proto_msgTypes = make([]protoimpl.MessageInfo, 95)
+var file_cells_idm_proto_msgTypes = make([]protoimpl.MessageInfo, 104)
 var file_cells_idm_proto_goTypes = []any{
 	(NodeType)(0),                                    // 0: idm.NodeType
 	(WorkspaceScope)(0),                              // 1: idm.WorkspaceScope
@@ -6515,228 +6971,248 @@ var file_cells_idm_proto_goTypes = []any{
 	(*CreateEntityValueResponse)(nil),                // 53: idm.CreateEntityValueResponse
 	(*CreateEntityRequest)(nil),                      // 54: idm.CreateEntityRequest
 	(*CreateEntityResponse)(nil),                     // 55: idm.CreateEntityResponse
-	(*DeleteEntityValuesResponse)(nil),               // 56: idm.DeleteEntityValuesResponse
-	(*GetMetaEntityValuesRequest)(nil),               // 57: idm.GetMetaEntityValuesRequest
-	(*MetaEntityValueResponse)(nil),                  // 58: idm.MetaEntityValueResponse
-	(*MetaToEntityValueRequest)(nil),                 // 59: idm.MetaToEntityValueRequest
-	(*MetaToEntityValueResponse)(nil),                // 60: idm.MetaToEntityValueResponse
-	(*UserMeta)(nil),                                 // 61: idm.UserMeta
-	(*UserMetaNamespace)(nil),                        // 62: idm.UserMetaNamespace
-	(*MetaEntity)(nil),                               // 63: idm.MetaEntity
-	(*EntityValue)(nil),                              // 64: idm.EntityValue
-	(*UpdateUserMetaRequest)(nil),                    // 65: idm.UpdateUserMetaRequest
-	(*UpdateUserMetaResponse)(nil),                   // 66: idm.UpdateUserMetaResponse
-	(*UpdateUserMetaEvent)(nil),                      // 67: idm.UpdateUserMetaEvent
-	(*SearchUserMetaRequest)(nil),                    // 68: idm.SearchUserMetaRequest
-	(*SearchUserMetaResponse)(nil),                   // 69: idm.SearchUserMetaResponse
-	(*UpdateUserMetaNamespaceRequest)(nil),           // 70: idm.UpdateUserMetaNamespaceRequest
-	(*UpdateUserMetaNamespaceResponse)(nil),          // 71: idm.UpdateUserMetaNamespaceResponse
-	(*ListUserMetaNamespaceRequest)(nil),             // 72: idm.ListUserMetaNamespaceRequest
-	(*ListUserMetaNamespaceResponse)(nil),            // 73: idm.ListUserMetaNamespaceResponse
-	(*GetFieldSchemaRequest)(nil),                    // 74: idm.GetFieldSchemaRequest
-	(*JsonSchemaResponse)(nil),                       // 75: idm.JsonSchemaResponse
-	(*GetNamespaceSchemaRequest)(nil),                // 76: idm.GetNamespaceSchemaRequest
-	(*ChangeEvent)(nil),                              // 77: idm.ChangeEvent
-	(*PolicyEngineRequest)(nil),                      // 78: idm.PolicyEngineRequest
-	(*PolicyEngineResponse)(nil),                     // 79: idm.PolicyEngineResponse
-	(*PolicyCondition)(nil),                          // 80: idm.PolicyCondition
-	(*Policy)(nil),                                   // 81: idm.Policy
-	(*PolicySubject)(nil),                            // 82: idm.PolicySubject
-	(*PolicyResource)(nil),                           // 83: idm.PolicyResource
-	(*PolicyAction)(nil),                             // 84: idm.PolicyAction
-	(*PolicyResourceRel)(nil),                        // 85: idm.PolicyResourceRel
-	(*PolicySubjectRel)(nil),                         // 86: idm.PolicySubjectRel
-	(*PolicyActionRel)(nil),                          // 87: idm.PolicyActionRel
-	(*PolicyRel)(nil),                                // 88: idm.PolicyRel
-	(*PolicyGroup)(nil),                              // 89: idm.PolicyGroup
-	(*StorePolicyGroupRequest)(nil),                  // 90: idm.StorePolicyGroupRequest
-	(*StorePolicyGroupResponse)(nil),                 // 91: idm.StorePolicyGroupResponse
-	(*DeletePolicyGroupRequest)(nil),                 // 92: idm.DeletePolicyGroupRequest
-	(*DeletePolicyGroupResponse)(nil),                // 93: idm.DeletePolicyGroupResponse
-	(*ListPolicyGroupsRequest)(nil),                  // 94: idm.ListPolicyGroupsRequest
-	(*ListPolicyGroupsResponse)(nil),                 // 95: idm.ListPolicyGroupsResponse
-	(*PolicyGroupSingleQuery)(nil),                   // 96: idm.PolicyGroupSingleQuery
-	nil,                                              // 97: idm.User.AttributesEntry
-	nil,                                              // 98: idm.Workspace.RootNodesEntry
-	nil,                                              // 99: idm.UpdateUserMetaEvent.EventMetadataEntry
-	nil,                                              // 100: idm.ChangeEvent.AttributesEntry
-	nil,                                              // 101: idm.PolicyEngineRequest.ContextEntry
-	nil,                                              // 102: idm.Policy.ConditionsEntry
-	(*service.Query)(nil),                            // 103: service.Query
-	(*service.ResourcePolicy)(nil),                   // 104: service.ResourcePolicy
-	(*tree.TreeNode)(nil),                            // 105: tree.TreeNode
-	(*tree.Node)(nil),                                // 106: tree.Node
-	(*structpb.Struct)(nil),                          // 107: google.protobuf.Struct
-	(*service.ResourcePolicyQuery)(nil),              // 108: service.ResourcePolicyQuery
+	(*DeleteEntityRequest)(nil),                      // 56: idm.DeleteEntityRequest
+	(*DeleteEntityResponse)(nil),                     // 57: idm.DeleteEntityResponse
+	(*ListEntitiesRequest)(nil),                      // 58: idm.ListEntitiesRequest
+	(*ListEntitiesResponse)(nil),                     // 59: idm.ListEntitiesResponse
+	(*GetEntityRequest)(nil),                         // 60: idm.GetEntityRequest
+	(*GetEntityResponse)(nil),                        // 61: idm.GetEntityResponse
+	(*DeleteEntityValueRequest)(nil),                 // 62: idm.DeleteEntityValueRequest
+	(*DeleteEntityValueResponse)(nil),                // 63: idm.DeleteEntityValueResponse
+	(*GetMetaEntityValuesRequest)(nil),               // 64: idm.GetMetaEntityValuesRequest
+	(*MetaEntityValueResponse)(nil),                  // 65: idm.MetaEntityValueResponse
+	(*MetaToEntityValueRequest)(nil),                 // 66: idm.MetaToEntityValueRequest
+	(*MetaToEntityValueResponse)(nil),                // 67: idm.MetaToEntityValueResponse
+	(*UserMeta)(nil),                                 // 68: idm.UserMeta
+	(*UserMetaNamespace)(nil),                        // 69: idm.UserMetaNamespace
+	(*MetaEntity)(nil),                               // 70: idm.MetaEntity
+	(*EntityValue)(nil),                              // 71: idm.EntityValue
+	(*UpdateUserMetaRequest)(nil),                    // 72: idm.UpdateUserMetaRequest
+	(*UpdateUserMetaResponse)(nil),                   // 73: idm.UpdateUserMetaResponse
+	(*UpdateUserMetaEvent)(nil),                      // 74: idm.UpdateUserMetaEvent
+	(*SearchUserMetaRequest)(nil),                    // 75: idm.SearchUserMetaRequest
+	(*SearchUserMetaResponse)(nil),                   // 76: idm.SearchUserMetaResponse
+	(*UpdateUserMetaNamespaceRequest)(nil),           // 77: idm.UpdateUserMetaNamespaceRequest
+	(*UpdateUserMetaNamespaceResponse)(nil),          // 78: idm.UpdateUserMetaNamespaceResponse
+	(*ListUserMetaNamespaceRequest)(nil),             // 79: idm.ListUserMetaNamespaceRequest
+	(*ListUserMetaNamespaceResponse)(nil),            // 80: idm.ListUserMetaNamespaceResponse
+	(*GetFieldSchemaRequest)(nil),                    // 81: idm.GetFieldSchemaRequest
+	(*JsonSchemaResponse)(nil),                       // 82: idm.JsonSchemaResponse
+	(*GetNamespaceSchemaRequest)(nil),                // 83: idm.GetNamespaceSchemaRequest
+	(*GetEntitiesRequest)(nil),                       // 84: idm.GetEntitiesRequest
+	(*GetEntitiesResponse)(nil),                      // 85: idm.GetEntitiesResponse
+	(*ChangeEvent)(nil),                              // 86: idm.ChangeEvent
+	(*PolicyEngineRequest)(nil),                      // 87: idm.PolicyEngineRequest
+	(*PolicyEngineResponse)(nil),                     // 88: idm.PolicyEngineResponse
+	(*PolicyCondition)(nil),                          // 89: idm.PolicyCondition
+	(*Policy)(nil),                                   // 90: idm.Policy
+	(*PolicySubject)(nil),                            // 91: idm.PolicySubject
+	(*PolicyResource)(nil),                           // 92: idm.PolicyResource
+	(*PolicyAction)(nil),                             // 93: idm.PolicyAction
+	(*PolicyResourceRel)(nil),                        // 94: idm.PolicyResourceRel
+	(*PolicySubjectRel)(nil),                         // 95: idm.PolicySubjectRel
+	(*PolicyActionRel)(nil),                          // 96: idm.PolicyActionRel
+	(*PolicyRel)(nil),                                // 97: idm.PolicyRel
+	(*PolicyGroup)(nil),                              // 98: idm.PolicyGroup
+	(*StorePolicyGroupRequest)(nil),                  // 99: idm.StorePolicyGroupRequest
+	(*StorePolicyGroupResponse)(nil),                 // 100: idm.StorePolicyGroupResponse
+	(*DeletePolicyGroupRequest)(nil),                 // 101: idm.DeletePolicyGroupRequest
+	(*DeletePolicyGroupResponse)(nil),                // 102: idm.DeletePolicyGroupResponse
+	(*ListPolicyGroupsRequest)(nil),                  // 103: idm.ListPolicyGroupsRequest
+	(*ListPolicyGroupsResponse)(nil),                 // 104: idm.ListPolicyGroupsResponse
+	(*PolicyGroupSingleQuery)(nil),                   // 105: idm.PolicyGroupSingleQuery
+	nil,                                              // 106: idm.User.AttributesEntry
+	nil,                                              // 107: idm.Workspace.RootNodesEntry
+	nil,                                              // 108: idm.UpdateUserMetaEvent.EventMetadataEntry
+	nil,                                              // 109: idm.ChangeEvent.AttributesEntry
+	nil,                                              // 110: idm.PolicyEngineRequest.ContextEntry
+	nil,                                              // 111: idm.Policy.ConditionsEntry
+	(*service.Query)(nil),                            // 112: service.Query
+	(*service.ResourcePolicy)(nil),                   // 113: service.ResourcePolicy
+	(*tree.TreeNode)(nil),                            // 114: tree.TreeNode
+	(*tree.Node)(nil),                                // 115: tree.Node
+	(*structpb.Struct)(nil),                          // 116: google.protobuf.Struct
+	(*service.ResourcePolicyQuery)(nil),              // 117: service.ResourcePolicyQuery
 }
 var file_cells_idm_proto_depIdxs = []int32{
 	15,  // 0: idm.CreateRoleRequest.Role:type_name -> idm.Role
 	15,  // 1: idm.CreateRoleResponse.Role:type_name -> idm.Role
-	103, // 2: idm.DeleteRoleRequest.Query:type_name -> service.Query
-	103, // 3: idm.SearchRoleRequest.Query:type_name -> service.Query
+	112, // 2: idm.DeleteRoleRequest.Query:type_name -> service.Query
+	112, // 3: idm.SearchRoleRequest.Query:type_name -> service.Query
 	15,  // 4: idm.SearchRoleResponse.Role:type_name -> idm.Role
-	104, // 5: idm.Role.Policies:type_name -> service.ResourcePolicy
+	113, // 5: idm.Role.Policies:type_name -> service.ResourcePolicy
 	27,  // 6: idm.CreateUserRequest.User:type_name -> idm.User
 	27,  // 7: idm.CreateUserResponse.User:type_name -> idm.User
 	27,  // 8: idm.BindUserResponse.User:type_name -> idm.User
-	103, // 9: idm.DeleteUserRequest.Query:type_name -> service.Query
-	103, // 10: idm.SearchUserRequest.Query:type_name -> service.Query
+	112, // 9: idm.DeleteUserRequest.Query:type_name -> service.Query
+	112, // 10: idm.SearchUserRequest.Query:type_name -> service.Query
 	27,  // 11: idm.SearchUserResponse.User:type_name -> idm.User
-	105, // 12: idm.TreeUser.node:type_name -> tree.TreeNode
+	114, // 12: idm.TreeUser.node:type_name -> tree.TreeNode
 	27,  // 13: idm.TreeUser.user:type_name -> idm.User
-	97,  // 14: idm.User.Attributes:type_name -> idm.User.AttributesEntry
+	106, // 14: idm.User.Attributes:type_name -> idm.User.AttributesEntry
 	15,  // 15: idm.User.Roles:type_name -> idm.Role
-	104, // 16: idm.User.Policies:type_name -> service.ResourcePolicy
+	113, // 16: idm.User.Policies:type_name -> service.ResourcePolicy
 	0,   // 17: idm.UserSingleQuery.NodeType:type_name -> idm.NodeType
 	35,  // 18: idm.CreateWorkspaceRequest.Workspace:type_name -> idm.Workspace
 	35,  // 19: idm.CreateWorkspaceResponse.Workspace:type_name -> idm.Workspace
-	103, // 20: idm.DeleteWorkspaceRequest.Query:type_name -> service.Query
-	103, // 21: idm.SearchWorkspaceRequest.Query:type_name -> service.Query
+	112, // 20: idm.DeleteWorkspaceRequest.Query:type_name -> service.Query
+	112, // 21: idm.SearchWorkspaceRequest.Query:type_name -> service.Query
 	35,  // 22: idm.SearchWorkspaceResponse.Workspace:type_name -> idm.Workspace
 	1,   // 23: idm.Workspace.Scope:type_name -> idm.WorkspaceScope
-	104, // 24: idm.Workspace.Policies:type_name -> service.ResourcePolicy
-	98,  // 25: idm.Workspace.RootNodes:type_name -> idm.Workspace.RootNodesEntry
+	113, // 24: idm.Workspace.Policies:type_name -> service.ResourcePolicy
+	107, // 25: idm.Workspace.RootNodes:type_name -> idm.Workspace.RootNodesEntry
 	1,   // 26: idm.WorkspaceSingleQuery.scope:type_name -> idm.WorkspaceScope
 	48,  // 27: idm.CreateACLRequest.ACL:type_name -> idm.ACL
 	48,  // 28: idm.CreateACLRequest.Batch:type_name -> idm.ACL
 	48,  // 29: idm.CreateACLResponse.ACL:type_name -> idm.ACL
 	48,  // 30: idm.CreateACLResponse.Batch:type_name -> idm.ACL
-	103, // 31: idm.ExpireACLRequest.Query:type_name -> service.Query
-	103, // 32: idm.DeleteACLRequest.Query:type_name -> service.Query
-	103, // 33: idm.SearchACLRequest.Query:type_name -> service.Query
+	112, // 31: idm.ExpireACLRequest.Query:type_name -> service.Query
+	112, // 32: idm.DeleteACLRequest.Query:type_name -> service.Query
+	112, // 33: idm.SearchACLRequest.Query:type_name -> service.Query
 	48,  // 34: idm.SearchACLResponse.ACL:type_name -> idm.ACL
-	103, // 35: idm.RestoreACLRequest.Query:type_name -> service.Query
+	112, // 35: idm.RestoreACLRequest.Query:type_name -> service.Query
 	47,  // 36: idm.ACL.Action:type_name -> idm.ACLAction
 	47,  // 37: idm.ACLSingleQuery.Actions:type_name -> idm.ACLAction
-	64,  // 38: idm.CreateEntityValueRequest.EntityValue:type_name -> idm.EntityValue
-	64,  // 39: idm.CreateEntityValueResponse.EntityValue:type_name -> idm.EntityValue
-	63,  // 40: idm.CreateEntityRequest.Entity:type_name -> idm.MetaEntity
-	63,  // 41: idm.CreateEntityResponse.Entity:type_name -> idm.MetaEntity
-	64,  // 42: idm.MetaEntityValueResponse.EntityValue:type_name -> idm.EntityValue
-	104, // 43: idm.UserMeta.Policies:type_name -> service.ResourcePolicy
-	106, // 44: idm.UserMeta.ResolvedNode:type_name -> tree.Node
-	104, // 45: idm.UserMetaNamespace.Policies:type_name -> service.ResourcePolicy
-	107, // 46: idm.UserMetaNamespace.JsonSchema:type_name -> google.protobuf.Struct
-	5,   // 47: idm.UpdateUserMetaRequest.Operation:type_name -> idm.UpdateUserMetaRequest.UserMetaOp
-	61,  // 48: idm.UpdateUserMetaRequest.MetaDatas:type_name -> idm.UserMeta
-	61,  // 49: idm.UpdateUserMetaResponse.MetaDatas:type_name -> idm.UserMeta
-	99,  // 50: idm.UpdateUserMetaEvent.EventMetadata:type_name -> idm.UpdateUserMetaEvent.EventMetadataEntry
-	6,   // 51: idm.UpdateUserMetaEvent.Operation:type_name -> idm.UpdateUserMetaEvent.UserMetaOpEvent
-	61,  // 52: idm.UpdateUserMetaEvent.UserMeta:type_name -> idm.UserMeta
-	108, // 53: idm.SearchUserMetaRequest.ResourceQuery:type_name -> service.ResourcePolicyQuery
-	61,  // 54: idm.SearchUserMetaResponse.UserMeta:type_name -> idm.UserMeta
-	7,   // 55: idm.UpdateUserMetaNamespaceRequest.Operation:type_name -> idm.UpdateUserMetaNamespaceRequest.UserMetaNsOp
-	62,  // 56: idm.UpdateUserMetaNamespaceRequest.Namespaces:type_name -> idm.UserMetaNamespace
-	62,  // 57: idm.UpdateUserMetaNamespaceResponse.Namespaces:type_name -> idm.UserMetaNamespace
-	62,  // 58: idm.ListUserMetaNamespaceResponse.UserMetaNamespace:type_name -> idm.UserMetaNamespace
-	107, // 59: idm.JsonSchemaResponse.JsonSchema:type_name -> google.protobuf.Struct
-	2,   // 60: idm.ChangeEvent.Type:type_name -> idm.ChangeEventType
-	27,  // 61: idm.ChangeEvent.User:type_name -> idm.User
-	15,  // 62: idm.ChangeEvent.Role:type_name -> idm.Role
-	35,  // 63: idm.ChangeEvent.Workspace:type_name -> idm.Workspace
-	48,  // 64: idm.ChangeEvent.Acl:type_name -> idm.ACL
-	62,  // 65: idm.ChangeEvent.MetaNamespace:type_name -> idm.UserMetaNamespace
-	100, // 66: idm.ChangeEvent.Attributes:type_name -> idm.ChangeEvent.AttributesEntry
-	101, // 67: idm.PolicyEngineRequest.Context:type_name -> idm.PolicyEngineRequest.ContextEntry
-	82,  // 68: idm.Policy.OrmSubjects:type_name -> idm.PolicySubject
-	83,  // 69: idm.Policy.OrmResources:type_name -> idm.PolicyResource
-	84,  // 70: idm.Policy.OrmActions:type_name -> idm.PolicyAction
-	3,   // 71: idm.Policy.Effect:type_name -> idm.PolicyEffect
-	102, // 72: idm.Policy.Conditions:type_name -> idm.Policy.ConditionsEntry
-	4,   // 73: idm.PolicyGroup.ResourceGroup:type_name -> idm.PolicyResourceGroup
-	81,  // 74: idm.PolicyGroup.Policies:type_name -> idm.Policy
-	89,  // 75: idm.StorePolicyGroupRequest.PolicyGroup:type_name -> idm.PolicyGroup
-	89,  // 76: idm.StorePolicyGroupResponse.PolicyGroup:type_name -> idm.PolicyGroup
-	89,  // 77: idm.DeletePolicyGroupRequest.PolicyGroup:type_name -> idm.PolicyGroup
-	103, // 78: idm.ListPolicyGroupsRequest.Query:type_name -> service.Query
-	89,  // 79: idm.ListPolicyGroupsResponse.PolicyGroups:type_name -> idm.PolicyGroup
-	106, // 80: idm.Workspace.RootNodesEntry.value:type_name -> tree.Node
-	80,  // 81: idm.Policy.ConditionsEntry.value:type_name -> idm.PolicyCondition
-	8,   // 82: idm.RoleService.CreateRole:input_type -> idm.CreateRoleRequest
-	10,  // 83: idm.RoleService.DeleteRole:input_type -> idm.DeleteRoleRequest
-	12,  // 84: idm.RoleService.SearchRole:input_type -> idm.SearchRoleRequest
-	12,  // 85: idm.RoleService.StreamRole:input_type -> idm.SearchRoleRequest
-	12,  // 86: idm.RoleService.CountRole:input_type -> idm.SearchRoleRequest
-	17,  // 87: idm.UserService.CreateUser:input_type -> idm.CreateUserRequest
-	21,  // 88: idm.UserService.DeleteUser:input_type -> idm.DeleteUserRequest
-	19,  // 89: idm.UserService.BindUser:input_type -> idm.BindUserRequest
-	23,  // 90: idm.UserService.CountUser:input_type -> idm.SearchUserRequest
-	23,  // 91: idm.UserService.SearchOne:input_type -> idm.SearchUserRequest
-	23,  // 92: idm.UserService.SearchUser:input_type -> idm.SearchUserRequest
-	23,  // 93: idm.UserService.StreamUser:input_type -> idm.SearchUserRequest
-	29,  // 94: idm.WorkspaceService.CreateWorkspace:input_type -> idm.CreateWorkspaceRequest
-	31,  // 95: idm.WorkspaceService.DeleteWorkspace:input_type -> idm.DeleteWorkspaceRequest
-	33,  // 96: idm.WorkspaceService.SearchWorkspace:input_type -> idm.SearchWorkspaceRequest
-	33,  // 97: idm.WorkspaceService.StreamWorkspace:input_type -> idm.SearchWorkspaceRequest
-	37,  // 98: idm.ACLService.CreateACL:input_type -> idm.CreateACLRequest
-	39,  // 99: idm.ACLService.ExpireACL:input_type -> idm.ExpireACLRequest
-	41,  // 100: idm.ACLService.DeleteACL:input_type -> idm.DeleteACLRequest
-	43,  // 101: idm.ACLService.SearchACL:input_type -> idm.SearchACLRequest
-	43,  // 102: idm.ACLService.StreamACL:input_type -> idm.SearchACLRequest
-	45,  // 103: idm.ACLService.RestoreACL:input_type -> idm.RestoreACLRequest
-	65,  // 104: idm.UserMetaService.UpdateUserMeta:input_type -> idm.UpdateUserMetaRequest
-	68,  // 105: idm.UserMetaService.SearchUserMeta:input_type -> idm.SearchUserMetaRequest
-	70,  // 106: idm.UserMetaService.UpdateUserMetaNamespace:input_type -> idm.UpdateUserMetaNamespaceRequest
-	72,  // 107: idm.UserMetaService.ListUserMetaNamespace:input_type -> idm.ListUserMetaNamespaceRequest
-	74,  // 108: idm.UserMetaService.GetFieldSchema:input_type -> idm.GetFieldSchemaRequest
-	76,  // 109: idm.UserMetaService.GetNamespaceSchema:input_type -> idm.GetNamespaceSchemaRequest
-	57,  // 110: idm.UserMetaService.GetEntityValues:input_type -> idm.GetMetaEntityValuesRequest
-	57,  // 111: idm.UserMetaService.DeleteEntity:input_type -> idm.GetMetaEntityValuesRequest
-	54,  // 112: idm.UserMetaService.CreateEntity:input_type -> idm.CreateEntityRequest
-	52,  // 113: idm.UserMetaService.CreateEntityValues:input_type -> idm.CreateEntityValueRequest
-	59,  // 114: idm.UserMetaService.LinkMetaToEntityValue:input_type -> idm.MetaToEntityValueRequest
-	59,  // 115: idm.UserMetaService.UnlinkMetaFromEntityValue:input_type -> idm.MetaToEntityValueRequest
-	51,  // 116: idm.UserMetaService.GetMetadata:input_type -> idm.GetMetadataRequest
-	78,  // 117: idm.PolicyEngineService.IsAllowed:input_type -> idm.PolicyEngineRequest
-	90,  // 118: idm.PolicyEngineService.StorePolicyGroup:input_type -> idm.StorePolicyGroupRequest
-	94,  // 119: idm.PolicyEngineService.ListPolicyGroups:input_type -> idm.ListPolicyGroupsRequest
-	94,  // 120: idm.PolicyEngineService.StreamPolicyGroups:input_type -> idm.ListPolicyGroupsRequest
-	92,  // 121: idm.PolicyEngineService.DeletePolicyGroup:input_type -> idm.DeletePolicyGroupRequest
-	9,   // 122: idm.RoleService.CreateRole:output_type -> idm.CreateRoleResponse
-	11,  // 123: idm.RoleService.DeleteRole:output_type -> idm.DeleteRoleResponse
-	13,  // 124: idm.RoleService.SearchRole:output_type -> idm.SearchRoleResponse
-	13,  // 125: idm.RoleService.StreamRole:output_type -> idm.SearchRoleResponse
-	14,  // 126: idm.RoleService.CountRole:output_type -> idm.CountRoleResponse
-	18,  // 127: idm.UserService.CreateUser:output_type -> idm.CreateUserResponse
-	22,  // 128: idm.UserService.DeleteUser:output_type -> idm.DeleteUserResponse
-	20,  // 129: idm.UserService.BindUser:output_type -> idm.BindUserResponse
-	25,  // 130: idm.UserService.CountUser:output_type -> idm.CountUserResponse
-	24,  // 131: idm.UserService.SearchOne:output_type -> idm.SearchUserResponse
-	24,  // 132: idm.UserService.SearchUser:output_type -> idm.SearchUserResponse
-	24,  // 133: idm.UserService.StreamUser:output_type -> idm.SearchUserResponse
-	30,  // 134: idm.WorkspaceService.CreateWorkspace:output_type -> idm.CreateWorkspaceResponse
-	32,  // 135: idm.WorkspaceService.DeleteWorkspace:output_type -> idm.DeleteWorkspaceResponse
-	34,  // 136: idm.WorkspaceService.SearchWorkspace:output_type -> idm.SearchWorkspaceResponse
-	34,  // 137: idm.WorkspaceService.StreamWorkspace:output_type -> idm.SearchWorkspaceResponse
-	38,  // 138: idm.ACLService.CreateACL:output_type -> idm.CreateACLResponse
-	40,  // 139: idm.ACLService.ExpireACL:output_type -> idm.ExpireACLResponse
-	42,  // 140: idm.ACLService.DeleteACL:output_type -> idm.DeleteACLResponse
-	44,  // 141: idm.ACLService.SearchACL:output_type -> idm.SearchACLResponse
-	44,  // 142: idm.ACLService.StreamACL:output_type -> idm.SearchACLResponse
-	46,  // 143: idm.ACLService.RestoreACL:output_type -> idm.RestoreACLResponse
-	66,  // 144: idm.UserMetaService.UpdateUserMeta:output_type -> idm.UpdateUserMetaResponse
-	69,  // 145: idm.UserMetaService.SearchUserMeta:output_type -> idm.SearchUserMetaResponse
-	71,  // 146: idm.UserMetaService.UpdateUserMetaNamespace:output_type -> idm.UpdateUserMetaNamespaceResponse
-	73,  // 147: idm.UserMetaService.ListUserMetaNamespace:output_type -> idm.ListUserMetaNamespaceResponse
-	75,  // 148: idm.UserMetaService.GetFieldSchema:output_type -> idm.JsonSchemaResponse
-	75,  // 149: idm.UserMetaService.GetNamespaceSchema:output_type -> idm.JsonSchemaResponse
-	58,  // 150: idm.UserMetaService.GetEntityValues:output_type -> idm.MetaEntityValueResponse
-	56,  // 151: idm.UserMetaService.DeleteEntity:output_type -> idm.DeleteEntityValuesResponse
-	55,  // 152: idm.UserMetaService.CreateEntity:output_type -> idm.CreateEntityResponse
-	53,  // 153: idm.UserMetaService.CreateEntityValues:output_type -> idm.CreateEntityValueResponse
-	60,  // 154: idm.UserMetaService.LinkMetaToEntityValue:output_type -> idm.MetaToEntityValueResponse
-	60,  // 155: idm.UserMetaService.UnlinkMetaFromEntityValue:output_type -> idm.MetaToEntityValueResponse
-	61,  // 156: idm.UserMetaService.GetMetadata:output_type -> idm.UserMeta
-	79,  // 157: idm.PolicyEngineService.IsAllowed:output_type -> idm.PolicyEngineResponse
-	91,  // 158: idm.PolicyEngineService.StorePolicyGroup:output_type -> idm.StorePolicyGroupResponse
-	95,  // 159: idm.PolicyEngineService.ListPolicyGroups:output_type -> idm.ListPolicyGroupsResponse
-	89,  // 160: idm.PolicyEngineService.StreamPolicyGroups:output_type -> idm.PolicyGroup
-	93,  // 161: idm.PolicyEngineService.DeletePolicyGroup:output_type -> idm.DeletePolicyGroupResponse
-	122, // [122:162] is the sub-list for method output_type
-	82,  // [82:122] is the sub-list for method input_type
-	82,  // [82:82] is the sub-list for extension type_name
-	82,  // [82:82] is the sub-list for extension extendee
-	0,   // [0:82] is the sub-list for field type_name
+	71,  // 38: idm.CreateEntityValueRequest.EntityValue:type_name -> idm.EntityValue
+	71,  // 39: idm.CreateEntityValueResponse.EntityValue:type_name -> idm.EntityValue
+	70,  // 40: idm.CreateEntityRequest.Entity:type_name -> idm.MetaEntity
+	70,  // 41: idm.CreateEntityResponse.Entity:type_name -> idm.MetaEntity
+	70,  // 42: idm.ListEntitiesResponse.Entity:type_name -> idm.MetaEntity
+	70,  // 43: idm.GetEntityResponse.Entity:type_name -> idm.MetaEntity
+	71,  // 44: idm.MetaEntityValueResponse.EntityValue:type_name -> idm.EntityValue
+	113, // 45: idm.UserMeta.Policies:type_name -> service.ResourcePolicy
+	115, // 46: idm.UserMeta.ResolvedNode:type_name -> tree.Node
+	113, // 47: idm.UserMetaNamespace.Policies:type_name -> service.ResourcePolicy
+	116, // 48: idm.UserMetaNamespace.JsonSchema:type_name -> google.protobuf.Struct
+	113, // 49: idm.MetaEntity.Policies:type_name -> service.ResourcePolicy
+	113, // 50: idm.EntityValue.Policies:type_name -> service.ResourcePolicy
+	5,   // 51: idm.UpdateUserMetaRequest.Operation:type_name -> idm.UpdateUserMetaRequest.UserMetaOp
+	68,  // 52: idm.UpdateUserMetaRequest.MetaDatas:type_name -> idm.UserMeta
+	68,  // 53: idm.UpdateUserMetaResponse.MetaDatas:type_name -> idm.UserMeta
+	108, // 54: idm.UpdateUserMetaEvent.EventMetadata:type_name -> idm.UpdateUserMetaEvent.EventMetadataEntry
+	6,   // 55: idm.UpdateUserMetaEvent.Operation:type_name -> idm.UpdateUserMetaEvent.UserMetaOpEvent
+	68,  // 56: idm.UpdateUserMetaEvent.UserMeta:type_name -> idm.UserMeta
+	117, // 57: idm.SearchUserMetaRequest.ResourceQuery:type_name -> service.ResourcePolicyQuery
+	68,  // 58: idm.SearchUserMetaResponse.UserMeta:type_name -> idm.UserMeta
+	7,   // 59: idm.UpdateUserMetaNamespaceRequest.Operation:type_name -> idm.UpdateUserMetaNamespaceRequest.UserMetaNsOp
+	69,  // 60: idm.UpdateUserMetaNamespaceRequest.Namespaces:type_name -> idm.UserMetaNamespace
+	69,  // 61: idm.UpdateUserMetaNamespaceResponse.Namespaces:type_name -> idm.UserMetaNamespace
+	69,  // 62: idm.ListUserMetaNamespaceResponse.UserMetaNamespace:type_name -> idm.UserMetaNamespace
+	116, // 63: idm.JsonSchemaResponse.JsonSchema:type_name -> google.protobuf.Struct
+	70,  // 64: idm.GetEntitiesResponse.Entities:type_name -> idm.MetaEntity
+	2,   // 65: idm.ChangeEvent.Type:type_name -> idm.ChangeEventType
+	27,  // 66: idm.ChangeEvent.User:type_name -> idm.User
+	15,  // 67: idm.ChangeEvent.Role:type_name -> idm.Role
+	35,  // 68: idm.ChangeEvent.Workspace:type_name -> idm.Workspace
+	48,  // 69: idm.ChangeEvent.Acl:type_name -> idm.ACL
+	69,  // 70: idm.ChangeEvent.MetaNamespace:type_name -> idm.UserMetaNamespace
+	109, // 71: idm.ChangeEvent.Attributes:type_name -> idm.ChangeEvent.AttributesEntry
+	110, // 72: idm.PolicyEngineRequest.Context:type_name -> idm.PolicyEngineRequest.ContextEntry
+	91,  // 73: idm.Policy.OrmSubjects:type_name -> idm.PolicySubject
+	92,  // 74: idm.Policy.OrmResources:type_name -> idm.PolicyResource
+	93,  // 75: idm.Policy.OrmActions:type_name -> idm.PolicyAction
+	3,   // 76: idm.Policy.Effect:type_name -> idm.PolicyEffect
+	111, // 77: idm.Policy.Conditions:type_name -> idm.Policy.ConditionsEntry
+	4,   // 78: idm.PolicyGroup.ResourceGroup:type_name -> idm.PolicyResourceGroup
+	90,  // 79: idm.PolicyGroup.Policies:type_name -> idm.Policy
+	98,  // 80: idm.StorePolicyGroupRequest.PolicyGroup:type_name -> idm.PolicyGroup
+	98,  // 81: idm.StorePolicyGroupResponse.PolicyGroup:type_name -> idm.PolicyGroup
+	98,  // 82: idm.DeletePolicyGroupRequest.PolicyGroup:type_name -> idm.PolicyGroup
+	112, // 83: idm.ListPolicyGroupsRequest.Query:type_name -> service.Query
+	98,  // 84: idm.ListPolicyGroupsResponse.PolicyGroups:type_name -> idm.PolicyGroup
+	115, // 85: idm.Workspace.RootNodesEntry.value:type_name -> tree.Node
+	89,  // 86: idm.Policy.ConditionsEntry.value:type_name -> idm.PolicyCondition
+	8,   // 87: idm.RoleService.CreateRole:input_type -> idm.CreateRoleRequest
+	10,  // 88: idm.RoleService.DeleteRole:input_type -> idm.DeleteRoleRequest
+	12,  // 89: idm.RoleService.SearchRole:input_type -> idm.SearchRoleRequest
+	12,  // 90: idm.RoleService.StreamRole:input_type -> idm.SearchRoleRequest
+	12,  // 91: idm.RoleService.CountRole:input_type -> idm.SearchRoleRequest
+	17,  // 92: idm.UserService.CreateUser:input_type -> idm.CreateUserRequest
+	21,  // 93: idm.UserService.DeleteUser:input_type -> idm.DeleteUserRequest
+	19,  // 94: idm.UserService.BindUser:input_type -> idm.BindUserRequest
+	23,  // 95: idm.UserService.CountUser:input_type -> idm.SearchUserRequest
+	23,  // 96: idm.UserService.SearchOne:input_type -> idm.SearchUserRequest
+	23,  // 97: idm.UserService.SearchUser:input_type -> idm.SearchUserRequest
+	23,  // 98: idm.UserService.StreamUser:input_type -> idm.SearchUserRequest
+	29,  // 99: idm.WorkspaceService.CreateWorkspace:input_type -> idm.CreateWorkspaceRequest
+	31,  // 100: idm.WorkspaceService.DeleteWorkspace:input_type -> idm.DeleteWorkspaceRequest
+	33,  // 101: idm.WorkspaceService.SearchWorkspace:input_type -> idm.SearchWorkspaceRequest
+	33,  // 102: idm.WorkspaceService.StreamWorkspace:input_type -> idm.SearchWorkspaceRequest
+	37,  // 103: idm.ACLService.CreateACL:input_type -> idm.CreateACLRequest
+	39,  // 104: idm.ACLService.ExpireACL:input_type -> idm.ExpireACLRequest
+	41,  // 105: idm.ACLService.DeleteACL:input_type -> idm.DeleteACLRequest
+	43,  // 106: idm.ACLService.SearchACL:input_type -> idm.SearchACLRequest
+	43,  // 107: idm.ACLService.StreamACL:input_type -> idm.SearchACLRequest
+	45,  // 108: idm.ACLService.RestoreACL:input_type -> idm.RestoreACLRequest
+	72,  // 109: idm.UserMetaService.UpdateUserMeta:input_type -> idm.UpdateUserMetaRequest
+	75,  // 110: idm.UserMetaService.SearchUserMeta:input_type -> idm.SearchUserMetaRequest
+	77,  // 111: idm.UserMetaService.UpdateUserMetaNamespace:input_type -> idm.UpdateUserMetaNamespaceRequest
+	79,  // 112: idm.UserMetaService.ListUserMetaNamespace:input_type -> idm.ListUserMetaNamespaceRequest
+	81,  // 113: idm.UserMetaService.GetFieldSchema:input_type -> idm.GetFieldSchemaRequest
+	83,  // 114: idm.UserMetaService.GetNamespaceSchema:input_type -> idm.GetNamespaceSchemaRequest
+	64,  // 115: idm.UserMetaService.GetEntityValues:input_type -> idm.GetMetaEntityValuesRequest
+	56,  // 116: idm.UserMetaService.DeleteEntity:input_type -> idm.DeleteEntityRequest
+	60,  // 117: idm.UserMetaService.GetEntity:input_type -> idm.GetEntityRequest
+	58,  // 118: idm.UserMetaService.ListEntities:input_type -> idm.ListEntitiesRequest
+	54,  // 119: idm.UserMetaService.CreateEntity:input_type -> idm.CreateEntityRequest
+	52,  // 120: idm.UserMetaService.CreateEntityValues:input_type -> idm.CreateEntityValueRequest
+	66,  // 121: idm.UserMetaService.LinkMetaToEntityValue:input_type -> idm.MetaToEntityValueRequest
+	66,  // 122: idm.UserMetaService.UnlinkMetaFromEntityValue:input_type -> idm.MetaToEntityValueRequest
+	51,  // 123: idm.UserMetaService.GetMetadata:input_type -> idm.GetMetadataRequest
+	62,  // 124: idm.UserMetaService.DeleteEntityValue:input_type -> idm.DeleteEntityValueRequest
+	87,  // 125: idm.PolicyEngineService.IsAllowed:input_type -> idm.PolicyEngineRequest
+	99,  // 126: idm.PolicyEngineService.StorePolicyGroup:input_type -> idm.StorePolicyGroupRequest
+	103, // 127: idm.PolicyEngineService.ListPolicyGroups:input_type -> idm.ListPolicyGroupsRequest
+	103, // 128: idm.PolicyEngineService.StreamPolicyGroups:input_type -> idm.ListPolicyGroupsRequest
+	101, // 129: idm.PolicyEngineService.DeletePolicyGroup:input_type -> idm.DeletePolicyGroupRequest
+	9,   // 130: idm.RoleService.CreateRole:output_type -> idm.CreateRoleResponse
+	11,  // 131: idm.RoleService.DeleteRole:output_type -> idm.DeleteRoleResponse
+	13,  // 132: idm.RoleService.SearchRole:output_type -> idm.SearchRoleResponse
+	13,  // 133: idm.RoleService.StreamRole:output_type -> idm.SearchRoleResponse
+	14,  // 134: idm.RoleService.CountRole:output_type -> idm.CountRoleResponse
+	18,  // 135: idm.UserService.CreateUser:output_type -> idm.CreateUserResponse
+	22,  // 136: idm.UserService.DeleteUser:output_type -> idm.DeleteUserResponse
+	20,  // 137: idm.UserService.BindUser:output_type -> idm.BindUserResponse
+	25,  // 138: idm.UserService.CountUser:output_type -> idm.CountUserResponse
+	24,  // 139: idm.UserService.SearchOne:output_type -> idm.SearchUserResponse
+	24,  // 140: idm.UserService.SearchUser:output_type -> idm.SearchUserResponse
+	24,  // 141: idm.UserService.StreamUser:output_type -> idm.SearchUserResponse
+	30,  // 142: idm.WorkspaceService.CreateWorkspace:output_type -> idm.CreateWorkspaceResponse
+	32,  // 143: idm.WorkspaceService.DeleteWorkspace:output_type -> idm.DeleteWorkspaceResponse
+	34,  // 144: idm.WorkspaceService.SearchWorkspace:output_type -> idm.SearchWorkspaceResponse
+	34,  // 145: idm.WorkspaceService.StreamWorkspace:output_type -> idm.SearchWorkspaceResponse
+	38,  // 146: idm.ACLService.CreateACL:output_type -> idm.CreateACLResponse
+	40,  // 147: idm.ACLService.ExpireACL:output_type -> idm.ExpireACLResponse
+	42,  // 148: idm.ACLService.DeleteACL:output_type -> idm.DeleteACLResponse
+	44,  // 149: idm.ACLService.SearchACL:output_type -> idm.SearchACLResponse
+	44,  // 150: idm.ACLService.StreamACL:output_type -> idm.SearchACLResponse
+	46,  // 151: idm.ACLService.RestoreACL:output_type -> idm.RestoreACLResponse
+	73,  // 152: idm.UserMetaService.UpdateUserMeta:output_type -> idm.UpdateUserMetaResponse
+	76,  // 153: idm.UserMetaService.SearchUserMeta:output_type -> idm.SearchUserMetaResponse
+	78,  // 154: idm.UserMetaService.UpdateUserMetaNamespace:output_type -> idm.UpdateUserMetaNamespaceResponse
+	80,  // 155: idm.UserMetaService.ListUserMetaNamespace:output_type -> idm.ListUserMetaNamespaceResponse
+	82,  // 156: idm.UserMetaService.GetFieldSchema:output_type -> idm.JsonSchemaResponse
+	82,  // 157: idm.UserMetaService.GetNamespaceSchema:output_type -> idm.JsonSchemaResponse
+	65,  // 158: idm.UserMetaService.GetEntityValues:output_type -> idm.MetaEntityValueResponse
+	57,  // 159: idm.UserMetaService.DeleteEntity:output_type -> idm.DeleteEntityResponse
+	61,  // 160: idm.UserMetaService.GetEntity:output_type -> idm.GetEntityResponse
+	59,  // 161: idm.UserMetaService.ListEntities:output_type -> idm.ListEntitiesResponse
+	55,  // 162: idm.UserMetaService.CreateEntity:output_type -> idm.CreateEntityResponse
+	53,  // 163: idm.UserMetaService.CreateEntityValues:output_type -> idm.CreateEntityValueResponse
+	67,  // 164: idm.UserMetaService.LinkMetaToEntityValue:output_type -> idm.MetaToEntityValueResponse
+	67,  // 165: idm.UserMetaService.UnlinkMetaFromEntityValue:output_type -> idm.MetaToEntityValueResponse
+	68,  // 166: idm.UserMetaService.GetMetadata:output_type -> idm.UserMeta
+	63,  // 167: idm.UserMetaService.DeleteEntityValue:output_type -> idm.DeleteEntityValueResponse
+	88,  // 168: idm.PolicyEngineService.IsAllowed:output_type -> idm.PolicyEngineResponse
+	100, // 169: idm.PolicyEngineService.StorePolicyGroup:output_type -> idm.StorePolicyGroupResponse
+	104, // 170: idm.PolicyEngineService.ListPolicyGroups:output_type -> idm.ListPolicyGroupsResponse
+	98,  // 171: idm.PolicyEngineService.StreamPolicyGroups:output_type -> idm.PolicyGroup
+	102, // 172: idm.PolicyEngineService.DeletePolicyGroup:output_type -> idm.DeletePolicyGroupResponse
+	130, // [130:173] is the sub-list for method output_type
+	87,  // [87:130] is the sub-list for method input_type
+	87,  // [87:87] is the sub-list for extension type_name
+	87,  // [87:87] is the sub-list for extension extendee
+	0,   // [0:87] is the sub-list for field type_name
 }
 
 func init() { file_cells_idm_proto_init() }
@@ -6750,7 +7226,7 @@ func file_cells_idm_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cells_idm_proto_rawDesc), len(file_cells_idm_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   95,
+			NumMessages:   104,
 			NumExtensions: 0,
 			NumServices:   6,
 		},

--- a/common/proto/idm/cells-idm.proto
+++ b/common/proto/idm/cells-idm.proto
@@ -448,12 +448,15 @@ service UserMetaService {
     rpc GetFieldSchema(GetFieldSchemaRequest) returns (JsonSchemaResponse) {}
     rpc GetNamespaceSchema(GetNamespaceSchemaRequest) returns (JsonSchemaResponse) {}
     rpc GetEntityValues(GetMetaEntityValuesRequest) returns (MetaEntityValueResponse) {}
-    rpc DeleteEntity(GetMetaEntityValuesRequest) returns (DeleteEntityValuesResponse) {}
+    rpc DeleteEntity(DeleteEntityRequest) returns (DeleteEntityResponse) {}
+    rpc GetEntity(GetEntityRequest) returns (GetEntityResponse) {}
+    rpc ListEntities(ListEntitiesRequest) returns (ListEntitiesResponse) {}
     rpc CreateEntity(CreateEntityRequest) returns (CreateEntityResponse) {}
     rpc CreateEntityValues(CreateEntityValueRequest) returns (CreateEntityValueResponse) {}
     rpc LinkMetaToEntityValue(MetaToEntityValueRequest) returns (MetaToEntityValueResponse) {}
     rpc UnlinkMetaFromEntityValue(MetaToEntityValueRequest) returns (MetaToEntityValueResponse) {}
     rpc GetMetadata(GetMetadataRequest) returns (UserMeta) {}
+    rpc DeleteEntityValue(DeleteEntityValueRequest) returns (DeleteEntityValueResponse) {}
 }
 
 message LinkMetaToEntityValueRequest {
@@ -487,8 +490,37 @@ message CreateEntityResponse {
     MetaEntity Entity = 1;
 }
 
+message DeleteEntityRequest {
+    string EntityId = 1;
+}
+
+message DeleteEntityResponse {
+    int64 RowsDeleted = 1;
+}
+
+message ListEntitiesRequest {
+    string EntityId = 1;
+}
+
+message ListEntitiesResponse {
+    repeated MetaEntity Entity = 1;
+}
+
+message GetEntityRequest {
+    string EntityUuid = 1;
+}
+
+message GetEntityResponse {
+    MetaEntity Entity = 1;
+}
+
+
 // Delete EntityValuesRequest, takes the EntityUuid and delete all its values and associations with metas
-message DeleteEntityValuesResponse {
+message DeleteEntityValueRequest {
+    string EntityValueUuid = 1;
+}
+
+message DeleteEntityValueResponse {
     int64 RowsDeleted = 1;
 }
 
@@ -564,6 +596,8 @@ message MetaEntity {
     string Uuid = 1;
     string Label = 2;
     string Description = 3;
+    repeated service.ResourcePolicy Policies = 4;
+    bool PoliciesContextEditable = 5;
 }
 
 // EntityValue represents a value for an entity (e.g., "Engineering", "Sales")
@@ -572,6 +606,17 @@ message EntityValue {
     string Label = 2;
     string EntityUuid = 3;
     string DisplayJSON = 4;
+    repeated service.ResourcePolicy Policies = 5;
+    bool PoliciesContextEditable = 6;
+    string MetaUuid = 7;
+}
+
+
+message UpsertUserMetaValue {
+    string NodeUuid = 1;
+    string Namespace = 2;
+    repeated EntityValue EntityValues = 3;
+    repeated service.ResourcePolicy Policies = 5;
 }
 
 // Request for modifying UserMeta
@@ -655,6 +700,11 @@ message GetNamespaceSchemaRequest{
     string FieldType = 1;
     string Namespace = 2;
     string Format = 3;
+}
+
+message GetEntitiesRequest {}
+message GetEntitiesResponse {
+    repeated MetaEntity Entities = 1;
 }
 
 

--- a/common/proto/idm/cells-idm.proto
+++ b/common/proto/idm/cells-idm.proto
@@ -448,12 +448,15 @@ service UserMetaService {
     rpc GetFieldSchema(GetFieldSchemaRequest) returns (JsonSchemaResponse) {}
     rpc GetNamespaceSchema(GetNamespaceSchemaRequest) returns (JsonSchemaResponse) {}
     rpc GetEntityValues(GetMetaEntityValuesRequest) returns (MetaEntityValueResponse) {}
-    rpc DeleteEntity(GetMetaEntityValuesRequest) returns (DeleteEntityValuesResponse) {}
+    rpc DeleteEntity(DeleteEntityRequest) returns (DeleteEntityResponse) {}
+    rpc GetEntity(GetEntityRequest) returns (GetEntityResponse) {}
+    rpc ListEntities(ListEntitiesRequest) returns (ListEntitiesResponse) {}
     rpc CreateEntity(CreateEntityRequest) returns (CreateEntityResponse) {}
     rpc CreateEntityValues(CreateEntityValueRequest) returns (CreateEntityValueResponse) {}
     rpc LinkMetaToEntityValue(MetaToEntityValueRequest) returns (MetaToEntityValueResponse) {}
     rpc UnlinkMetaFromEntityValue(MetaToEntityValueRequest) returns (MetaToEntityValueResponse) {}
     rpc GetMetadata(GetMetadataRequest) returns (UserMeta) {}
+    rpc DeleteEntityValue(DeleteEntityValueRequest) returns (DeleteEntityValueResponse) {}
 }
 
 message LinkMetaToEntityValueRequest {
@@ -487,8 +490,37 @@ message CreateEntityResponse {
     MetaEntity Entity = 1;
 }
 
+message DeleteEntityRequest {
+    string EntityId = 1;
+}
+
+message DeleteEntityResponse {
+    int64 RowsDeleted = 1;
+}
+
+message ListEntitiesRequest {
+    string EntityId = 1;
+}
+
+message ListEntitiesResponse {
+    repeated MetaEntity Entity = 1;
+}
+
+message GetEntityRequest {
+    string EntityUuid = 1;
+}
+
+message GetEntityResponse {
+    MetaEntity Entity = 1;
+}
+
+
 // Delete EntityValuesRequest, takes the EntityUuid and delete all its values and associations with metas
-message DeleteEntityValuesResponse {
+message DeleteEntityValueRequest {
+    string EntityValueUuid = 1;
+}
+
+message DeleteEntityValueResponse {
     int64 RowsDeleted = 1;
 }
 
@@ -557,6 +589,8 @@ message UserMetaNamespace{
     string Description = 11;
     // Namespace Type  "boolean", "choice", "css_label", "date", "integer", "json", "multi_value", "stars_rate", "string", "tag_cloud", "tags", "textarea", "url"
     string FieldType = 12;
+    // Associated Entity UUID
+    string EntityUUID = 13;
 }
 
 // MetaEntity represents a metadata entity (e.g., "Department", "Project")
@@ -564,6 +598,8 @@ message MetaEntity {
     string Uuid = 1;
     string Label = 2;
     string Description = 3;
+    repeated service.ResourcePolicy Policies = 4;
+    bool PoliciesContextEditable = 5;
 }
 
 // EntityValue represents a value for an entity (e.g., "Engineering", "Sales")
@@ -572,6 +608,17 @@ message EntityValue {
     string Label = 2;
     string EntityUuid = 3;
     string DisplayJSON = 4;
+    repeated service.ResourcePolicy Policies = 5;
+    bool PoliciesContextEditable = 6;
+    string MetaUuid = 7;
+}
+
+
+message UpsertUserMetaValue {
+    string NodeUuid = 1;
+    string Namespace = 2;
+    repeated EntityValue EntityValues = 3;
+    repeated service.ResourcePolicy Policies = 5;
 }
 
 // Request for modifying UserMeta
@@ -655,6 +702,11 @@ message GetNamespaceSchemaRequest{
     string FieldType = 1;
     string Namespace = 2;
     string Format = 3;
+}
+
+message GetEntitiesRequest {}
+message GetEntitiesResponse {
+    repeated MetaEntity Entities = 1;
 }
 
 

--- a/common/proto/idm/cells-idm_grpc.pb.go
+++ b/common/proto/idm/cells-idm_grpc.pb.go
@@ -1171,11 +1171,14 @@ const (
 	UserMetaService_GetNamespaceSchema_FullMethodName        = "/idm.UserMetaService/GetNamespaceSchema"
 	UserMetaService_GetEntityValues_FullMethodName           = "/idm.UserMetaService/GetEntityValues"
 	UserMetaService_DeleteEntity_FullMethodName              = "/idm.UserMetaService/DeleteEntity"
+	UserMetaService_GetEntity_FullMethodName                 = "/idm.UserMetaService/GetEntity"
+	UserMetaService_ListEntities_FullMethodName              = "/idm.UserMetaService/ListEntities"
 	UserMetaService_CreateEntity_FullMethodName              = "/idm.UserMetaService/CreateEntity"
 	UserMetaService_CreateEntityValues_FullMethodName        = "/idm.UserMetaService/CreateEntityValues"
 	UserMetaService_LinkMetaToEntityValue_FullMethodName     = "/idm.UserMetaService/LinkMetaToEntityValue"
 	UserMetaService_UnlinkMetaFromEntityValue_FullMethodName = "/idm.UserMetaService/UnlinkMetaFromEntityValue"
 	UserMetaService_GetMetadata_FullMethodName               = "/idm.UserMetaService/GetMetadata"
+	UserMetaService_DeleteEntityValue_FullMethodName         = "/idm.UserMetaService/DeleteEntityValue"
 )
 
 // UserMetaServiceClient is the client API for UserMetaService service.
@@ -1192,12 +1195,15 @@ type UserMetaServiceClient interface {
 	GetFieldSchema(ctx context.Context, in *GetFieldSchemaRequest, opts ...grpc.CallOption) (*JsonSchemaResponse, error)
 	GetNamespaceSchema(ctx context.Context, in *GetNamespaceSchemaRequest, opts ...grpc.CallOption) (*JsonSchemaResponse, error)
 	GetEntityValues(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*MetaEntityValueResponse, error)
-	DeleteEntity(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*DeleteEntityValuesResponse, error)
+	DeleteEntity(ctx context.Context, in *DeleteEntityRequest, opts ...grpc.CallOption) (*DeleteEntityResponse, error)
+	GetEntity(ctx context.Context, in *GetEntityRequest, opts ...grpc.CallOption) (*GetEntityResponse, error)
+	ListEntities(ctx context.Context, in *ListEntitiesRequest, opts ...grpc.CallOption) (*ListEntitiesResponse, error)
 	CreateEntity(ctx context.Context, in *CreateEntityRequest, opts ...grpc.CallOption) (*CreateEntityResponse, error)
 	CreateEntityValues(ctx context.Context, in *CreateEntityValueRequest, opts ...grpc.CallOption) (*CreateEntityValueResponse, error)
 	LinkMetaToEntityValue(ctx context.Context, in *MetaToEntityValueRequest, opts ...grpc.CallOption) (*MetaToEntityValueResponse, error)
 	UnlinkMetaFromEntityValue(ctx context.Context, in *MetaToEntityValueRequest, opts ...grpc.CallOption) (*MetaToEntityValueResponse, error)
 	GetMetadata(ctx context.Context, in *GetMetadataRequest, opts ...grpc.CallOption) (*UserMeta, error)
+	DeleteEntityValue(ctx context.Context, in *DeleteEntityValueRequest, opts ...grpc.CallOption) (*DeleteEntityValueResponse, error)
 }
 
 type userMetaServiceClient struct {
@@ -1296,10 +1302,30 @@ func (c *userMetaServiceClient) GetEntityValues(ctx context.Context, in *GetMeta
 	return out, nil
 }
 
-func (c *userMetaServiceClient) DeleteEntity(ctx context.Context, in *GetMetaEntityValuesRequest, opts ...grpc.CallOption) (*DeleteEntityValuesResponse, error) {
+func (c *userMetaServiceClient) DeleteEntity(ctx context.Context, in *DeleteEntityRequest, opts ...grpc.CallOption) (*DeleteEntityResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(DeleteEntityValuesResponse)
+	out := new(DeleteEntityResponse)
 	err := c.cc.Invoke(ctx, UserMetaService_DeleteEntity_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *userMetaServiceClient) GetEntity(ctx context.Context, in *GetEntityRequest, opts ...grpc.CallOption) (*GetEntityResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetEntityResponse)
+	err := c.cc.Invoke(ctx, UserMetaService_GetEntity_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *userMetaServiceClient) ListEntities(ctx context.Context, in *ListEntitiesRequest, opts ...grpc.CallOption) (*ListEntitiesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListEntitiesResponse)
+	err := c.cc.Invoke(ctx, UserMetaService_ListEntities_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1356,6 +1382,16 @@ func (c *userMetaServiceClient) GetMetadata(ctx context.Context, in *GetMetadata
 	return out, nil
 }
 
+func (c *userMetaServiceClient) DeleteEntityValue(ctx context.Context, in *DeleteEntityValueRequest, opts ...grpc.CallOption) (*DeleteEntityValueResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteEntityValueResponse)
+	err := c.cc.Invoke(ctx, UserMetaService_DeleteEntityValue_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // UserMetaServiceServer is the server API for UserMetaService service.
 // All implementations must embed UnimplementedUserMetaServiceServer
 // for forward compatibility.
@@ -1370,12 +1406,15 @@ type UserMetaServiceServer interface {
 	GetFieldSchema(context.Context, *GetFieldSchemaRequest) (*JsonSchemaResponse, error)
 	GetNamespaceSchema(context.Context, *GetNamespaceSchemaRequest) (*JsonSchemaResponse, error)
 	GetEntityValues(context.Context, *GetMetaEntityValuesRequest) (*MetaEntityValueResponse, error)
-	DeleteEntity(context.Context, *GetMetaEntityValuesRequest) (*DeleteEntityValuesResponse, error)
+	DeleteEntity(context.Context, *DeleteEntityRequest) (*DeleteEntityResponse, error)
+	GetEntity(context.Context, *GetEntityRequest) (*GetEntityResponse, error)
+	ListEntities(context.Context, *ListEntitiesRequest) (*ListEntitiesResponse, error)
 	CreateEntity(context.Context, *CreateEntityRequest) (*CreateEntityResponse, error)
 	CreateEntityValues(context.Context, *CreateEntityValueRequest) (*CreateEntityValueResponse, error)
 	LinkMetaToEntityValue(context.Context, *MetaToEntityValueRequest) (*MetaToEntityValueResponse, error)
 	UnlinkMetaFromEntityValue(context.Context, *MetaToEntityValueRequest) (*MetaToEntityValueResponse, error)
 	GetMetadata(context.Context, *GetMetadataRequest) (*UserMeta, error)
+	DeleteEntityValue(context.Context, *DeleteEntityValueRequest) (*DeleteEntityValueResponse, error)
 	mustEmbedUnimplementedUserMetaServiceServer()
 }
 
@@ -1407,8 +1446,14 @@ func (UnimplementedUserMetaServiceServer) GetNamespaceSchema(context.Context, *G
 func (UnimplementedUserMetaServiceServer) GetEntityValues(context.Context, *GetMetaEntityValuesRequest) (*MetaEntityValueResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetEntityValues not implemented")
 }
-func (UnimplementedUserMetaServiceServer) DeleteEntity(context.Context, *GetMetaEntityValuesRequest) (*DeleteEntityValuesResponse, error) {
+func (UnimplementedUserMetaServiceServer) DeleteEntity(context.Context, *DeleteEntityRequest) (*DeleteEntityResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteEntity not implemented")
+}
+func (UnimplementedUserMetaServiceServer) GetEntity(context.Context, *GetEntityRequest) (*GetEntityResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetEntity not implemented")
+}
+func (UnimplementedUserMetaServiceServer) ListEntities(context.Context, *ListEntitiesRequest) (*ListEntitiesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListEntities not implemented")
 }
 func (UnimplementedUserMetaServiceServer) CreateEntity(context.Context, *CreateEntityRequest) (*CreateEntityResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateEntity not implemented")
@@ -1424,6 +1469,9 @@ func (UnimplementedUserMetaServiceServer) UnlinkMetaFromEntityValue(context.Cont
 }
 func (UnimplementedUserMetaServiceServer) GetMetadata(context.Context, *GetMetadataRequest) (*UserMeta, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetMetadata not implemented")
+}
+func (UnimplementedUserMetaServiceServer) DeleteEntityValue(context.Context, *DeleteEntityValueRequest) (*DeleteEntityValueResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteEntityValue not implemented")
 }
 func (UnimplementedUserMetaServiceServer) mustEmbedUnimplementedUserMetaServiceServer() {}
 func (UnimplementedUserMetaServiceServer) testEmbeddedByValue()                         {}
@@ -1559,7 +1607,7 @@ func _UserMetaService_GetEntityValues_Handler(srv interface{}, ctx context.Conte
 }
 
 func _UserMetaService_DeleteEntity_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetMetaEntityValuesRequest)
+	in := new(DeleteEntityRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -1571,7 +1619,43 @@ func _UserMetaService_DeleteEntity_Handler(srv interface{}, ctx context.Context,
 		FullMethod: UserMetaService_DeleteEntity_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(UserMetaServiceServer).DeleteEntity(ctx, req.(*GetMetaEntityValuesRequest))
+		return srv.(UserMetaServiceServer).DeleteEntity(ctx, req.(*DeleteEntityRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _UserMetaService_GetEntity_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetEntityRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UserMetaServiceServer).GetEntity(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UserMetaService_GetEntity_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UserMetaServiceServer).GetEntity(ctx, req.(*GetEntityRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _UserMetaService_ListEntities_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListEntitiesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UserMetaServiceServer).ListEntities(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UserMetaService_ListEntities_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UserMetaServiceServer).ListEntities(ctx, req.(*ListEntitiesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1666,6 +1750,24 @@ func _UserMetaService_GetMetadata_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _UserMetaService_DeleteEntityValue_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteEntityValueRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UserMetaServiceServer).DeleteEntityValue(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UserMetaService_DeleteEntityValue_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UserMetaServiceServer).DeleteEntityValue(ctx, req.(*DeleteEntityValueRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // UserMetaService_ServiceDesc is the grpc.ServiceDesc for UserMetaService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -1698,6 +1800,14 @@ var UserMetaService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _UserMetaService_DeleteEntity_Handler,
 		},
 		{
+			MethodName: "GetEntity",
+			Handler:    _UserMetaService_GetEntity_Handler,
+		},
+		{
+			MethodName: "ListEntities",
+			Handler:    _UserMetaService_ListEntities_Handler,
+		},
+		{
 			MethodName: "CreateEntity",
 			Handler:    _UserMetaService_CreateEntity_Handler,
 		},
@@ -1716,6 +1826,10 @@ var UserMetaService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetMetadata",
 			Handler:    _UserMetaService_GetMetadata_Handler,
+		},
+		{
+			MethodName: "DeleteEntityValue",
+			Handler:    _UserMetaService_DeleteEntityValue_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/common/proto/idm/cells-idm_grpc.stub.pb.go
+++ b/common/proto/idm/cells-idm_grpc.stub.pb.go
@@ -419,7 +419,21 @@ func (s *UserMetaServiceStub) Invoke(ctx context.Context, method string, args in
 			e = er
 		}
 	case "/idm.UserMetaService/DeleteEntity":
-		resp, er := s.UserMetaServiceServer.DeleteEntity(ctx, args.(*GetMetaEntityValuesRequest))
+		resp, er := s.UserMetaServiceServer.DeleteEntity(ctx, args.(*DeleteEntityRequest))
+		if er == nil {
+			e = stubs.AssignToInterface(resp, reply)
+		} else {
+			e = er
+		}
+	case "/idm.UserMetaService/GetEntity":
+		resp, er := s.UserMetaServiceServer.GetEntity(ctx, args.(*GetEntityRequest))
+		if er == nil {
+			e = stubs.AssignToInterface(resp, reply)
+		} else {
+			e = er
+		}
+	case "/idm.UserMetaService/ListEntities":
+		resp, er := s.UserMetaServiceServer.ListEntities(ctx, args.(*ListEntitiesRequest))
 		if er == nil {
 			e = stubs.AssignToInterface(resp, reply)
 		} else {
@@ -455,6 +469,13 @@ func (s *UserMetaServiceStub) Invoke(ctx context.Context, method string, args in
 		}
 	case "/idm.UserMetaService/GetMetadata":
 		resp, er := s.UserMetaServiceServer.GetMetadata(ctx, args.(*GetMetadataRequest))
+		if er == nil {
+			e = stubs.AssignToInterface(resp, reply)
+		} else {
+			e = er
+		}
+	case "/idm.UserMetaService/DeleteEntityValue":
+		resp, er := s.UserMetaServiceServer.DeleteEntityValue(ctx, args.(*DeleteEntityValueRequest))
 		if er == nil {
 			e = stubs.AssignToInterface(resp, reply)
 		} else {

--- a/common/proto/idm/meta-ns.go
+++ b/common/proto/idm/meta-ns.go
@@ -21,6 +21,8 @@
 package idm
 
 import (
+	"errors"
+
 	json "github.com/pydio/cells/v5/common/utils/jsonx"
 )
 
@@ -76,6 +78,8 @@ type ChoiceItem struct {
 	Value string `json:"value"`
 	Color string `json:"color,omitempty"`
 }
+
+// Add Applies
 
 // Implement MetaNamespaceDefinition interface for legacy metaNsDef
 func (d *metaNsDef) GetType() string {
@@ -164,14 +168,19 @@ func (d *MetaNsDef) SetEntityId(entityID string) {
 	d.Entity.EntityID = entityID
 }
 
-func (m *UserMetaNamespace) UnmarshallDefinition() (MetaNamespaceDefinition, error) {
+func (m *UserMetaNamespace) UnmarshallEntityDefinition() (MetaNamespaceDefinition, error) {
 	var fullDef MetaNsDef
 	if e := json.Unmarshal([]byte(m.JsonDefinition), &fullDef); e == nil {
 		if fullDef.Entity.EntityID != "" || len(fullDef.Data.Items) > 0 || len(fullDef.Data.EntityItems) > 0 {
 			return &fullDef, nil
 		}
+		return nil, errors.New("not a full definition")
+	} else {
+		return nil, e
 	}
+}
 
+func (m *UserMetaNamespace) UnmarshallDefinition() (MetaNamespaceDefinition, error) {
 	// Default to legacy metaNsDef for backward compatibility
 	var legacyDef metaNsDef
 	if e := json.Unmarshal([]byte(m.JsonDefinition), &legacyDef); e != nil {

--- a/common/proto/rest/cellsapi-rest.pb.go
+++ b/common/proto/rest/cellsapi-rest.pb.go
@@ -339,7 +339,7 @@ const file_cellsapi_rest_proto_rawDesc = "" +
 	"\n" +
 	"DeleteMeta\x12\x1a.rest.MetaNamespaceRequest\x1a\n" +
 	".tree.Node\"\"\x82\xd3\xe4\x93\x02\x1c:\x01*\"\x17/meta/delete/{NodePath}\x12Z\n" +
-	"\vGetBulkMeta\x12\x18.rest.GetBulkMetaRequest\x1a\x16.rest.BulkMetaResponse\"\x19\x82\xd3\xe4\x93\x02\x13:\x01*\"\x0e/meta/bulk/get2\xb7\t\n" +
+	"\vGetBulkMeta\x12\x18.rest.GetBulkMetaRequest\x1a\x16.rest.BulkMetaResponse\"\x19\x82\xd3\xe4\x93\x02\x13:\x01*\"\x0e/meta/bulk/get2\xe5\r\n" +
 	"\x0fUserMetaService\x12g\n" +
 	"\x0eUpdateUserMeta\x12\x1a.idm.UpdateUserMetaRequest\x1a\x1b.idm.UpdateUserMetaResponse\"\x1c\x82\xd3\xe4\x93\x02\x16:\x01*\x1a\x11/user-meta/update\x12d\n" +
 	"\x0eSearchUserMeta\x12\x1a.idm.SearchUserMetaRequest\x1a\x18.rest.UserMetaCollection\"\x1c\x82\xd3\xe4\x93\x02\x16:\x01*\"\x11/user-meta/search\x12d\n" +
@@ -350,7 +350,12 @@ const file_cellsapi_rest_proto_rawDesc = "" +
 	"\x12GetNamespaceSchema\x12\x1e.idm.GetNamespaceSchemaRequest\x1a\x17.idm.JsonSchemaResponse\"'\x82\xd3\xe4\x93\x02!\x12\x1f/user-meta/namespace/jsonschema\x12v\n" +
 	"\x10ListUserMetaTags\x12\x1d.rest.ListUserMetaTagsRequest\x1a\x1e.rest.ListUserMetaTagsResponse\"#\x82\xd3\xe4\x93\x02\x1d\x12\x1b/user-meta/tags/{Namespace}\x12s\n" +
 	"\x0ePutUserMetaTag\x12\x1b.rest.PutUserMetaTagRequest\x1a\x1c.rest.PutUserMetaTagResponse\"&\x82\xd3\xe4\x93\x02 :\x01*\"\x1b/user-meta/tags/{Namespace}\x12\x83\x01\n" +
-	"\x12DeleteUserMetaTags\x12\x1f.rest.DeleteUserMetaTagsRequest\x1a .rest.DeleteUserMetaTagsResponse\"*\x82\xd3\xe4\x93\x02$*\"/user-meta/tags/{Namespace}/{Tags}2\xe1\x03\n" +
+	"\x12DeleteUserMetaTags\x12\x1f.rest.DeleteUserMetaTagsRequest\x1a .rest.DeleteUserMetaTagsResponse\"*\x82\xd3\xe4\x93\x02$*\"/user-meta/tags/{Namespace}/{Tags}\x12^\n" +
+	"\tPutEntity\x12\x18.idm.CreateEntityRequest\x1a\x19.idm.CreateEntityResponse\"\x1c\x82\xd3\xe4\x93\x02\x16:\x01*\x1a\x11/user-meta/entity\x12i\n" +
+	"\fDeleteEntity\x12\x18.idm.DeleteEntityRequest\x1a\x19.idm.DeleteEntityResponse\"$\x82\xd3\xe4\x93\x02\x1e*\x1c/user-meta/entity/{EntityId}\x12^\n" +
+	"\fListEntities\x12\x18.idm.ListEntitiesRequest\x1a\x19.idm.ListEntitiesResponse\"\x19\x82\xd3\xe4\x93\x02\x13\x12\x11/user-meta/entity\x12x\n" +
+	"\x12CreateEntityValues\x12\x1d.idm.CreateEntityValueRequest\x1a\x1e.idm.CreateEntityValueResponse\"#\x82\xd3\xe4\x93\x02\x1d:\x01*\x1a\x18/user-meta/entity/values\x12\x86\x01\n" +
+	"\x11DeleteEntityValue\x12\x1d.idm.DeleteEntityValueRequest\x1a\x1e.idm.DeleteEntityValueResponse\"2\x82\xd3\xe4\x93\x02,**/user-meta/entity/values/{EntityValueUuid}2\xe1\x03\n" +
 	"\vJobsService\x12]\n" +
 	"\rUserCreateJob\x12\x14.rest.UserJobRequest\x1a\x15.rest.UserJobResponse\"\x1f\x82\xd3\xe4\x93\x02\x19:\x01*\x1a\x14/jobs/user/{JobName}\x12V\n" +
 	"\fUserListJobs\x12\x15.jobs.ListJobsRequest\x1a\x18.rest.UserJobsCollection\"\x15\x82\xd3\xe4\x93\x02\x0f:\x01*\"\n" +
@@ -492,118 +497,128 @@ var file_cellsapi_rest_proto_goTypes = []any{
 	(*ListUserMetaTagsRequest)(nil),             // 65: rest.ListUserMetaTagsRequest
 	(*PutUserMetaTagRequest)(nil),               // 66: rest.PutUserMetaTagRequest
 	(*DeleteUserMetaTagsRequest)(nil),           // 67: rest.DeleteUserMetaTagsRequest
-	(*UserJobRequest)(nil),                      // 68: rest.UserJobRequest
-	(*jobs.ListJobsRequest)(nil),                // 69: jobs.ListJobsRequest
-	(*jobs.CtrlCommand)(nil),                    // 70: jobs.CtrlCommand
-	(*jobs.DeleteTasksRequest)(nil),             // 71: jobs.DeleteTasksRequest
-	(*tree.ListNodesRequest)(nil),               // 72: tree.ListNodesRequest
-	(*tree.ReadNodeRequest)(nil),                // 73: tree.ReadNodeRequest
-	(*UserStateRequest)(nil),                    // 74: rest.UserStateRequest
-	(*RelationRequest)(nil),                     // 75: rest.RelationRequest
-	(*RecommendRequest)(nil),                    // 76: rest.RecommendRequest
-	(*PutCellRequest)(nil),                      // 77: rest.PutCellRequest
-	(*GetCellRequest)(nil),                      // 78: rest.GetCellRequest
-	(*DeleteCellRequest)(nil),                   // 79: rest.DeleteCellRequest
-	(*PutShareLinkRequest)(nil),                 // 80: rest.PutShareLinkRequest
-	(*GetShareLinkRequest)(nil),                 // 81: rest.GetShareLinkRequest
-	(*DeleteShareLinkRequest)(nil),              // 82: rest.DeleteShareLinkRequest
-	(*ListSharedResourcesRequest)(nil),          // 83: rest.ListSharedResourcesRequest
-	(*UpdateSharePoliciesRequest)(nil),          // 84: rest.UpdateSharePoliciesRequest
-	(*install.GetDefaultsRequest)(nil),          // 85: install.GetDefaultsRequest
-	(*install.InstallRequest)(nil),              // 86: install.InstallRequest
-	(*install.PerformCheckRequest)(nil),         // 87: install.PerformCheckRequest
-	(*install.GetAgreementRequest)(nil),         // 88: install.GetAgreementRequest
-	(*install.InstallEventsRequest)(nil),        // 89: install.InstallEventsRequest
-	(*update.UpdateRequest)(nil),                // 90: update.UpdateRequest
-	(*update.ApplyUpdateRequest)(nil),           // 91: update.ApplyUpdateRequest
-	(*FrontStateRequest)(nil),                   // 92: rest.FrontStateRequest
-	(*FrontBootConfRequest)(nil),                // 93: rest.FrontBootConfRequest
-	(*FrontMessagesRequest)(nil),                // 94: rest.FrontMessagesRequest
-	(*FrontPluginsRequest)(nil),                 // 95: rest.FrontPluginsRequest
-	(*FrontSessionRequest)(nil),                 // 96: rest.FrontSessionRequest
-	(*FrontEnrollAuthRequest)(nil),              // 97: rest.FrontEnrollAuthRequest
-	(*FrontBinaryRequest)(nil),                  // 98: rest.FrontBinaryRequest
-	(*SettingsMenuRequest)(nil),                 // 99: rest.SettingsMenuRequest
-	(*DeleteDataSourceResponse)(nil),            // 100: rest.DeleteDataSourceResponse
-	(*DataSourceCollection)(nil),                // 101: rest.DataSourceCollection
-	(*VersioningPolicyCollection)(nil),          // 102: rest.VersioningPolicyCollection
-	(*NodesCollection)(nil),                     // 103: rest.NodesCollection
-	(*ServiceCollection)(nil),                   // 104: rest.ServiceCollection
-	(*ctl.Service)(nil),                         // 105: ctl.Service
-	(*registry.ListResponse)(nil),               // 106: registry.ListResponse
-	(*ListPeersAddressesResponse)(nil),          // 107: rest.ListPeersAddressesResponse
-	(*CreatePeerFolderResponse)(nil),            // 108: rest.CreatePeerFolderResponse
-	(*CreateStorageBucketResponse)(nil),         // 109: rest.CreateStorageBucketResponse
-	(*ListProcessesResponse)(nil),               // 110: rest.ListProcessesResponse
-	(*encryption.AdminListKeysResponse)(nil),    // 111: encryption.AdminListKeysResponse
-	(*encryption.AdminCreateKeyResponse)(nil),   // 112: encryption.AdminCreateKeyResponse
-	(*encryption.AdminDeleteKeyResponse)(nil),   // 113: encryption.AdminDeleteKeyResponse
-	(*encryption.AdminExportKeyResponse)(nil),   // 114: encryption.AdminExportKeyResponse
-	(*encryption.AdminImportKeyResponse)(nil),   // 115: encryption.AdminImportKeyResponse
-	(*DiscoveryResponse)(nil),                   // 116: rest.DiscoveryResponse
-	(*OpenApiResponse)(nil),                     // 117: rest.OpenApiResponse
-	(*SchedulerActionsResponse)(nil),            // 118: rest.SchedulerActionsResponse
-	(*SchedulerActionFormResponse)(nil),         // 119: rest.SchedulerActionFormResponse
-	(*ListSitesResponse)(nil),                   // 120: rest.ListSitesResponse
-	(*RolesCollection)(nil),                     // 121: rest.RolesCollection
-	(*DeleteResponse)(nil),                      // 122: rest.DeleteResponse
-	(*UsersCollection)(nil),                     // 123: rest.UsersCollection
-	(*ACLCollection)(nil),                       // 124: rest.ACLCollection
-	(*idm.ListPolicyGroupsResponse)(nil),        // 125: idm.ListPolicyGroupsResponse
-	(*WorkspaceCollection)(nil),                 // 126: rest.WorkspaceCollection
-	(*activity.Object)(nil),                     // 127: activity.Object
-	(*SubscriptionsCollection)(nil),             // 128: rest.SubscriptionsCollection
-	(*LogMessageCollection)(nil),                // 129: rest.LogMessageCollection
-	(*RevokeResponse)(nil),                      // 130: rest.RevokeResponse
-	(*ResetPasswordTokenResponse)(nil),          // 131: rest.ResetPasswordTokenResponse
-	(*ResetPasswordResponse)(nil),               // 132: rest.ResetPasswordResponse
-	(*DocumentAccessTokenResponse)(nil),         // 133: rest.DocumentAccessTokenResponse
-	(*mailer.SendMailResponse)(nil),             // 134: mailer.SendMailResponse
-	(*SearchResults)(nil),                       // 135: rest.SearchResults
-	(*BulkMetaResponse)(nil),                    // 136: rest.BulkMetaResponse
-	(*HeadNodeResponse)(nil),                    // 137: rest.HeadNodeResponse
-	(*DeleteNodesResponse)(nil),                 // 138: rest.DeleteNodesResponse
-	(*RestoreNodesResponse)(nil),                // 139: rest.RestoreNodesResponse
-	(*CreateSelectionResponse)(nil),             // 140: rest.CreateSelectionResponse
-	(*ListTemplatesResponse)(nil),               // 141: rest.ListTemplatesResponse
-	(*tree.Node)(nil),                           // 142: tree.Node
-	(*idm.UpdateUserMetaResponse)(nil),          // 143: idm.UpdateUserMetaResponse
-	(*UserMetaCollection)(nil),                  // 144: rest.UserMetaCollection
-	(*idm.UpdateUserMetaNamespaceResponse)(nil), // 145: idm.UpdateUserMetaNamespaceResponse
-	(*UserMetaNamespaceCollection)(nil),         // 146: rest.UserMetaNamespaceCollection
-	(*idm.JsonSchemaResponse)(nil),              // 147: idm.JsonSchemaResponse
-	(*ListUserMetaTagsResponse)(nil),            // 148: rest.ListUserMetaTagsResponse
-	(*PutUserMetaTagResponse)(nil),              // 149: rest.PutUserMetaTagResponse
-	(*DeleteUserMetaTagsResponse)(nil),          // 150: rest.DeleteUserMetaTagsResponse
-	(*UserJobResponse)(nil),                     // 151: rest.UserJobResponse
-	(*UserJobsCollection)(nil),                  // 152: rest.UserJobsCollection
-	(*jobs.CtrlCommandResponse)(nil),            // 153: jobs.CtrlCommandResponse
-	(*jobs.DeleteTasksResponse)(nil),            // 154: jobs.DeleteTasksResponse
-	(*tree.ReadNodeResponse)(nil),               // 155: tree.ReadNodeResponse
-	(*UserStateResponse)(nil),                   // 156: rest.UserStateResponse
-	(*RelationResponse)(nil),                    // 157: rest.RelationResponse
-	(*RecommendResponse)(nil),                   // 158: rest.RecommendResponse
-	(*Cell)(nil),                                // 159: rest.Cell
-	(*DeleteCellResponse)(nil),                  // 160: rest.DeleteCellResponse
-	(*ShareLink)(nil),                           // 161: rest.ShareLink
-	(*DeleteShareLinkResponse)(nil),             // 162: rest.DeleteShareLinkResponse
-	(*ListSharedResourcesResponse)(nil),         // 163: rest.ListSharedResourcesResponse
-	(*UpdateSharePoliciesResponse)(nil),         // 164: rest.UpdateSharePoliciesResponse
-	(*install.GetDefaultsResponse)(nil),         // 165: install.GetDefaultsResponse
-	(*install.InstallResponse)(nil),             // 166: install.InstallResponse
-	(*install.PerformCheckResponse)(nil),        // 167: install.PerformCheckResponse
-	(*install.GetAgreementResponse)(nil),        // 168: install.GetAgreementResponse
-	(*install.InstallEventsResponse)(nil),       // 169: install.InstallEventsResponse
-	(*update.UpdateResponse)(nil),               // 170: update.UpdateResponse
-	(*update.ApplyUpdateResponse)(nil),          // 171: update.ApplyUpdateResponse
-	(*FrontStateResponse)(nil),                  // 172: rest.FrontStateResponse
-	(*FrontBootConfResponse)(nil),               // 173: rest.FrontBootConfResponse
-	(*FrontMessagesResponse)(nil),               // 174: rest.FrontMessagesResponse
-	(*FrontPluginsResponse)(nil),                // 175: rest.FrontPluginsResponse
-	(*FrontSessionResponse)(nil),                // 176: rest.FrontSessionResponse
-	(*FrontEnrollAuthResponse)(nil),             // 177: rest.FrontEnrollAuthResponse
-	(*FrontBinaryResponse)(nil),                 // 178: rest.FrontBinaryResponse
-	(*SettingsMenuResponse)(nil),                // 179: rest.SettingsMenuResponse
+	(*idm.CreateEntityRequest)(nil),             // 68: idm.CreateEntityRequest
+	(*idm.DeleteEntityRequest)(nil),             // 69: idm.DeleteEntityRequest
+	(*idm.ListEntitiesRequest)(nil),             // 70: idm.ListEntitiesRequest
+	(*idm.CreateEntityValueRequest)(nil),        // 71: idm.CreateEntityValueRequest
+	(*idm.DeleteEntityValueRequest)(nil),        // 72: idm.DeleteEntityValueRequest
+	(*UserJobRequest)(nil),                      // 73: rest.UserJobRequest
+	(*jobs.ListJobsRequest)(nil),                // 74: jobs.ListJobsRequest
+	(*jobs.CtrlCommand)(nil),                    // 75: jobs.CtrlCommand
+	(*jobs.DeleteTasksRequest)(nil),             // 76: jobs.DeleteTasksRequest
+	(*tree.ListNodesRequest)(nil),               // 77: tree.ListNodesRequest
+	(*tree.ReadNodeRequest)(nil),                // 78: tree.ReadNodeRequest
+	(*UserStateRequest)(nil),                    // 79: rest.UserStateRequest
+	(*RelationRequest)(nil),                     // 80: rest.RelationRequest
+	(*RecommendRequest)(nil),                    // 81: rest.RecommendRequest
+	(*PutCellRequest)(nil),                      // 82: rest.PutCellRequest
+	(*GetCellRequest)(nil),                      // 83: rest.GetCellRequest
+	(*DeleteCellRequest)(nil),                   // 84: rest.DeleteCellRequest
+	(*PutShareLinkRequest)(nil),                 // 85: rest.PutShareLinkRequest
+	(*GetShareLinkRequest)(nil),                 // 86: rest.GetShareLinkRequest
+	(*DeleteShareLinkRequest)(nil),              // 87: rest.DeleteShareLinkRequest
+	(*ListSharedResourcesRequest)(nil),          // 88: rest.ListSharedResourcesRequest
+	(*UpdateSharePoliciesRequest)(nil),          // 89: rest.UpdateSharePoliciesRequest
+	(*install.GetDefaultsRequest)(nil),          // 90: install.GetDefaultsRequest
+	(*install.InstallRequest)(nil),              // 91: install.InstallRequest
+	(*install.PerformCheckRequest)(nil),         // 92: install.PerformCheckRequest
+	(*install.GetAgreementRequest)(nil),         // 93: install.GetAgreementRequest
+	(*install.InstallEventsRequest)(nil),        // 94: install.InstallEventsRequest
+	(*update.UpdateRequest)(nil),                // 95: update.UpdateRequest
+	(*update.ApplyUpdateRequest)(nil),           // 96: update.ApplyUpdateRequest
+	(*FrontStateRequest)(nil),                   // 97: rest.FrontStateRequest
+	(*FrontBootConfRequest)(nil),                // 98: rest.FrontBootConfRequest
+	(*FrontMessagesRequest)(nil),                // 99: rest.FrontMessagesRequest
+	(*FrontPluginsRequest)(nil),                 // 100: rest.FrontPluginsRequest
+	(*FrontSessionRequest)(nil),                 // 101: rest.FrontSessionRequest
+	(*FrontEnrollAuthRequest)(nil),              // 102: rest.FrontEnrollAuthRequest
+	(*FrontBinaryRequest)(nil),                  // 103: rest.FrontBinaryRequest
+	(*SettingsMenuRequest)(nil),                 // 104: rest.SettingsMenuRequest
+	(*DeleteDataSourceResponse)(nil),            // 105: rest.DeleteDataSourceResponse
+	(*DataSourceCollection)(nil),                // 106: rest.DataSourceCollection
+	(*VersioningPolicyCollection)(nil),          // 107: rest.VersioningPolicyCollection
+	(*NodesCollection)(nil),                     // 108: rest.NodesCollection
+	(*ServiceCollection)(nil),                   // 109: rest.ServiceCollection
+	(*ctl.Service)(nil),                         // 110: ctl.Service
+	(*registry.ListResponse)(nil),               // 111: registry.ListResponse
+	(*ListPeersAddressesResponse)(nil),          // 112: rest.ListPeersAddressesResponse
+	(*CreatePeerFolderResponse)(nil),            // 113: rest.CreatePeerFolderResponse
+	(*CreateStorageBucketResponse)(nil),         // 114: rest.CreateStorageBucketResponse
+	(*ListProcessesResponse)(nil),               // 115: rest.ListProcessesResponse
+	(*encryption.AdminListKeysResponse)(nil),    // 116: encryption.AdminListKeysResponse
+	(*encryption.AdminCreateKeyResponse)(nil),   // 117: encryption.AdminCreateKeyResponse
+	(*encryption.AdminDeleteKeyResponse)(nil),   // 118: encryption.AdminDeleteKeyResponse
+	(*encryption.AdminExportKeyResponse)(nil),   // 119: encryption.AdminExportKeyResponse
+	(*encryption.AdminImportKeyResponse)(nil),   // 120: encryption.AdminImportKeyResponse
+	(*DiscoveryResponse)(nil),                   // 121: rest.DiscoveryResponse
+	(*OpenApiResponse)(nil),                     // 122: rest.OpenApiResponse
+	(*SchedulerActionsResponse)(nil),            // 123: rest.SchedulerActionsResponse
+	(*SchedulerActionFormResponse)(nil),         // 124: rest.SchedulerActionFormResponse
+	(*ListSitesResponse)(nil),                   // 125: rest.ListSitesResponse
+	(*RolesCollection)(nil),                     // 126: rest.RolesCollection
+	(*DeleteResponse)(nil),                      // 127: rest.DeleteResponse
+	(*UsersCollection)(nil),                     // 128: rest.UsersCollection
+	(*ACLCollection)(nil),                       // 129: rest.ACLCollection
+	(*idm.ListPolicyGroupsResponse)(nil),        // 130: idm.ListPolicyGroupsResponse
+	(*WorkspaceCollection)(nil),                 // 131: rest.WorkspaceCollection
+	(*activity.Object)(nil),                     // 132: activity.Object
+	(*SubscriptionsCollection)(nil),             // 133: rest.SubscriptionsCollection
+	(*LogMessageCollection)(nil),                // 134: rest.LogMessageCollection
+	(*RevokeResponse)(nil),                      // 135: rest.RevokeResponse
+	(*ResetPasswordTokenResponse)(nil),          // 136: rest.ResetPasswordTokenResponse
+	(*ResetPasswordResponse)(nil),               // 137: rest.ResetPasswordResponse
+	(*DocumentAccessTokenResponse)(nil),         // 138: rest.DocumentAccessTokenResponse
+	(*mailer.SendMailResponse)(nil),             // 139: mailer.SendMailResponse
+	(*SearchResults)(nil),                       // 140: rest.SearchResults
+	(*BulkMetaResponse)(nil),                    // 141: rest.BulkMetaResponse
+	(*HeadNodeResponse)(nil),                    // 142: rest.HeadNodeResponse
+	(*DeleteNodesResponse)(nil),                 // 143: rest.DeleteNodesResponse
+	(*RestoreNodesResponse)(nil),                // 144: rest.RestoreNodesResponse
+	(*CreateSelectionResponse)(nil),             // 145: rest.CreateSelectionResponse
+	(*ListTemplatesResponse)(nil),               // 146: rest.ListTemplatesResponse
+	(*tree.Node)(nil),                           // 147: tree.Node
+	(*idm.UpdateUserMetaResponse)(nil),          // 148: idm.UpdateUserMetaResponse
+	(*UserMetaCollection)(nil),                  // 149: rest.UserMetaCollection
+	(*idm.UpdateUserMetaNamespaceResponse)(nil), // 150: idm.UpdateUserMetaNamespaceResponse
+	(*UserMetaNamespaceCollection)(nil),         // 151: rest.UserMetaNamespaceCollection
+	(*idm.JsonSchemaResponse)(nil),              // 152: idm.JsonSchemaResponse
+	(*ListUserMetaTagsResponse)(nil),            // 153: rest.ListUserMetaTagsResponse
+	(*PutUserMetaTagResponse)(nil),              // 154: rest.PutUserMetaTagResponse
+	(*DeleteUserMetaTagsResponse)(nil),          // 155: rest.DeleteUserMetaTagsResponse
+	(*idm.CreateEntityResponse)(nil),            // 156: idm.CreateEntityResponse
+	(*idm.DeleteEntityResponse)(nil),            // 157: idm.DeleteEntityResponse
+	(*idm.ListEntitiesResponse)(nil),            // 158: idm.ListEntitiesResponse
+	(*idm.CreateEntityValueResponse)(nil),       // 159: idm.CreateEntityValueResponse
+	(*idm.DeleteEntityValueResponse)(nil),       // 160: idm.DeleteEntityValueResponse
+	(*UserJobResponse)(nil),                     // 161: rest.UserJobResponse
+	(*UserJobsCollection)(nil),                  // 162: rest.UserJobsCollection
+	(*jobs.CtrlCommandResponse)(nil),            // 163: jobs.CtrlCommandResponse
+	(*jobs.DeleteTasksResponse)(nil),            // 164: jobs.DeleteTasksResponse
+	(*tree.ReadNodeResponse)(nil),               // 165: tree.ReadNodeResponse
+	(*UserStateResponse)(nil),                   // 166: rest.UserStateResponse
+	(*RelationResponse)(nil),                    // 167: rest.RelationResponse
+	(*RecommendResponse)(nil),                   // 168: rest.RecommendResponse
+	(*Cell)(nil),                                // 169: rest.Cell
+	(*DeleteCellResponse)(nil),                  // 170: rest.DeleteCellResponse
+	(*ShareLink)(nil),                           // 171: rest.ShareLink
+	(*DeleteShareLinkResponse)(nil),             // 172: rest.DeleteShareLinkResponse
+	(*ListSharedResourcesResponse)(nil),         // 173: rest.ListSharedResourcesResponse
+	(*UpdateSharePoliciesResponse)(nil),         // 174: rest.UpdateSharePoliciesResponse
+	(*install.GetDefaultsResponse)(nil),         // 175: install.GetDefaultsResponse
+	(*install.InstallResponse)(nil),             // 176: install.InstallResponse
+	(*install.PerformCheckResponse)(nil),        // 177: install.PerformCheckResponse
+	(*install.GetAgreementResponse)(nil),        // 178: install.GetAgreementResponse
+	(*install.InstallEventsResponse)(nil),       // 179: install.InstallEventsResponse
+	(*update.UpdateResponse)(nil),               // 180: update.UpdateResponse
+	(*update.ApplyUpdateResponse)(nil),          // 181: update.ApplyUpdateResponse
+	(*FrontStateResponse)(nil),                  // 182: rest.FrontStateResponse
+	(*FrontBootConfResponse)(nil),               // 183: rest.FrontBootConfResponse
+	(*FrontMessagesResponse)(nil),               // 184: rest.FrontMessagesResponse
+	(*FrontPluginsResponse)(nil),                // 185: rest.FrontPluginsResponse
+	(*FrontSessionResponse)(nil),                // 186: rest.FrontSessionResponse
+	(*FrontEnrollAuthResponse)(nil),             // 187: rest.FrontEnrollAuthResponse
+	(*FrontBinaryResponse)(nil),                 // 188: rest.FrontBinaryResponse
+	(*SettingsMenuResponse)(nil),                // 189: rest.SettingsMenuResponse
 }
 var file_cellsapi_rest_proto_depIdxs = []int32{
 	4,   // 0: rest.HealthServiceResponse.Components:type_name -> rest.HealthServiceResponse.ComponentsEntry
@@ -684,162 +699,172 @@ var file_cellsapi_rest_proto_depIdxs = []int32{
 	65,  // 75: rest.UserMetaService.ListUserMetaTags:input_type -> rest.ListUserMetaTagsRequest
 	66,  // 76: rest.UserMetaService.PutUserMetaTag:input_type -> rest.PutUserMetaTagRequest
 	67,  // 77: rest.UserMetaService.DeleteUserMetaTags:input_type -> rest.DeleteUserMetaTagsRequest
-	68,  // 78: rest.JobsService.UserCreateJob:input_type -> rest.UserJobRequest
-	69,  // 79: rest.JobsService.UserListJobs:input_type -> jobs.ListJobsRequest
-	70,  // 80: rest.JobsService.UserControlJob:input_type -> jobs.CtrlCommand
-	71,  // 81: rest.JobsService.UserDeleteTasks:input_type -> jobs.DeleteTasksRequest
-	42,  // 82: rest.JobsService.ListTasksLogs:input_type -> log.ListLogRequest
-	72,  // 83: rest.AdminTreeService.ListAdminTree:input_type -> tree.ListNodesRequest
-	73,  // 84: rest.AdminTreeService.StatAdminTree:input_type -> tree.ReadNodeRequest
-	74,  // 85: rest.GraphService.UserState:input_type -> rest.UserStateRequest
-	75,  // 86: rest.GraphService.Relation:input_type -> rest.RelationRequest
-	76,  // 87: rest.GraphService.Recommend:input_type -> rest.RecommendRequest
-	77,  // 88: rest.ShareService.PutCell:input_type -> rest.PutCellRequest
-	78,  // 89: rest.ShareService.GetCell:input_type -> rest.GetCellRequest
-	79,  // 90: rest.ShareService.DeleteCell:input_type -> rest.DeleteCellRequest
-	80,  // 91: rest.ShareService.PutShareLink:input_type -> rest.PutShareLinkRequest
-	81,  // 92: rest.ShareService.GetShareLink:input_type -> rest.GetShareLinkRequest
-	82,  // 93: rest.ShareService.DeleteShareLink:input_type -> rest.DeleteShareLinkRequest
-	83,  // 94: rest.ShareService.ListSharedResources:input_type -> rest.ListSharedResourcesRequest
-	84,  // 95: rest.ShareService.UpdateSharePolicies:input_type -> rest.UpdateSharePoliciesRequest
-	85,  // 96: rest.InstallService.GetInstall:input_type -> install.GetDefaultsRequest
-	86,  // 97: rest.InstallService.PostInstall:input_type -> install.InstallRequest
-	87,  // 98: rest.InstallService.PerformInstallCheck:input_type -> install.PerformCheckRequest
-	88,  // 99: rest.InstallService.GetAgreement:input_type -> install.GetAgreementRequest
-	89,  // 100: rest.InstallService.InstallEvents:input_type -> install.InstallEventsRequest
-	90,  // 101: rest.UpdateService.UpdateRequired:input_type -> update.UpdateRequest
-	91,  // 102: rest.UpdateService.ApplyUpdate:input_type -> update.ApplyUpdateRequest
-	92,  // 103: rest.FrontendService.FrontState:input_type -> rest.FrontStateRequest
-	93,  // 104: rest.FrontendService.FrontBootConf:input_type -> rest.FrontBootConfRequest
-	94,  // 105: rest.FrontendService.FrontMessages:input_type -> rest.FrontMessagesRequest
-	95,  // 106: rest.FrontendService.FrontPlugins:input_type -> rest.FrontPluginsRequest
-	96,  // 107: rest.FrontendService.FrontSession:input_type -> rest.FrontSessionRequest
-	97,  // 108: rest.FrontendService.FrontEnrollAuth:input_type -> rest.FrontEnrollAuthRequest
-	98,  // 109: rest.FrontendService.FrontServeBinary:input_type -> rest.FrontBinaryRequest
-	98,  // 110: rest.FrontendService.FrontPutBinary:input_type -> rest.FrontBinaryRequest
-	99,  // 111: rest.FrontendService.SettingsMenu:input_type -> rest.SettingsMenuRequest
-	1,   // 112: rest.HealthService.ApiPing:input_type -> rest.HealthServiceRequest
-	1,   // 113: rest.HealthService.ApiLive:input_type -> rest.HealthServiceRequest
-	1,   // 114: rest.HealthService.ApiReady:input_type -> rest.HealthServiceRequest
-	1,   // 115: rest.HealthService.ServiceLive:input_type -> rest.HealthServiceRequest
-	1,   // 116: rest.HealthService.ServiceReady:input_type -> rest.HealthServiceRequest
-	5,   // 117: rest.ConfigService.PutConfig:output_type -> rest.Configuration
-	5,   // 118: rest.ConfigService.GetConfig:output_type -> rest.Configuration
-	6,   // 119: rest.ConfigService.PutDataSource:output_type -> object.DataSource
-	6,   // 120: rest.ConfigService.GetDataSource:output_type -> object.DataSource
-	100, // 121: rest.ConfigService.DeleteDataSource:output_type -> rest.DeleteDataSourceResponse
-	101, // 122: rest.ConfigService.ListDataSources:output_type -> rest.DataSourceCollection
-	102, // 123: rest.ConfigService.ListVersioningPolicies:output_type -> rest.VersioningPolicyCollection
-	9,   // 124: rest.ConfigService.GetVersioningPolicy:output_type -> tree.VersioningPolicy
-	103, // 125: rest.ConfigService.ListVirtualNodes:output_type -> rest.NodesCollection
-	104, // 126: rest.ConfigService.ListServices:output_type -> rest.ServiceCollection
-	105, // 127: rest.ConfigService.ControlService:output_type -> ctl.Service
-	106, // 128: rest.ConfigService.ListRegistry:output_type -> registry.ListResponse
-	107, // 129: rest.ConfigService.ListPeersAddresses:output_type -> rest.ListPeersAddressesResponse
-	103, // 130: rest.ConfigService.ListPeerFolders:output_type -> rest.NodesCollection
-	108, // 131: rest.ConfigService.CreatePeerFolder:output_type -> rest.CreatePeerFolderResponse
-	103, // 132: rest.ConfigService.ListStorageBuckets:output_type -> rest.NodesCollection
-	109, // 133: rest.ConfigService.CreateStorageBucket:output_type -> rest.CreateStorageBucketResponse
-	110, // 134: rest.ConfigService.ListProcesses:output_type -> rest.ListProcessesResponse
-	111, // 135: rest.ConfigService.ListEncryptionKeys:output_type -> encryption.AdminListKeysResponse
-	112, // 136: rest.ConfigService.CreateEncryptionKey:output_type -> encryption.AdminCreateKeyResponse
-	113, // 137: rest.ConfigService.DeleteEncryptionKey:output_type -> encryption.AdminDeleteKeyResponse
-	114, // 138: rest.ConfigService.ExportEncryptionKey:output_type -> encryption.AdminExportKeyResponse
-	115, // 139: rest.ConfigService.ImportEncryptionKey:output_type -> encryption.AdminImportKeyResponse
-	116, // 140: rest.ConfigService.EndpointsDiscovery:output_type -> rest.DiscoveryResponse
-	117, // 141: rest.ConfigService.OpenApiDiscovery:output_type -> rest.OpenApiResponse
-	116, // 142: rest.ConfigService.ConfigFormsDiscovery:output_type -> rest.DiscoveryResponse
-	118, // 143: rest.ConfigService.SchedulerActionsDiscovery:output_type -> rest.SchedulerActionsResponse
-	119, // 144: rest.ConfigService.SchedulerActionFormDiscovery:output_type -> rest.SchedulerActionFormResponse
-	120, // 145: rest.ConfigService.ListSites:output_type -> rest.ListSitesResponse
-	30,  // 146: rest.RoleService.SetRole:output_type -> idm.Role
-	30,  // 147: rest.RoleService.DeleteRole:output_type -> idm.Role
-	30,  // 148: rest.RoleService.GetRole:output_type -> idm.Role
-	121, // 149: rest.RoleService.SearchRoles:output_type -> rest.RolesCollection
-	32,  // 150: rest.UserService.PutUser:output_type -> idm.User
-	122, // 151: rest.UserService.DeleteUser:output_type -> rest.DeleteResponse
-	32,  // 152: rest.UserService.GetUser:output_type -> idm.User
-	123, // 153: rest.UserService.SearchUsers:output_type -> rest.UsersCollection
-	32,  // 154: rest.UserService.PutRoles:output_type -> idm.User
-	34,  // 155: rest.ACLService.PutAcl:output_type -> idm.ACL
-	122, // 156: rest.ACLService.DeleteAcl:output_type -> rest.DeleteResponse
-	124, // 157: rest.ACLService.SearchAcls:output_type -> rest.ACLCollection
-	125, // 158: rest.PolicyService.ListPolicies:output_type -> idm.ListPolicyGroupsResponse
-	37,  // 159: rest.WorkspaceService.PutWorkspace:output_type -> idm.Workspace
-	122, // 160: rest.WorkspaceService.DeleteWorkspace:output_type -> rest.DeleteResponse
-	126, // 161: rest.WorkspaceService.SearchWorkspaces:output_type -> rest.WorkspaceCollection
-	127, // 162: rest.ActivityService.Stream:output_type -> activity.Object
-	40,  // 163: rest.ActivityService.Subscribe:output_type -> activity.Subscription
-	128, // 164: rest.ActivityService.SearchSubscriptions:output_type -> rest.SubscriptionsCollection
-	129, // 165: rest.LogService.Syslog:output_type -> rest.LogMessageCollection
-	130, // 166: rest.TokenService.Revoke:output_type -> rest.RevokeResponse
-	131, // 167: rest.TokenService.ResetPasswordToken:output_type -> rest.ResetPasswordTokenResponse
-	132, // 168: rest.TokenService.ResetPassword:output_type -> rest.ResetPasswordResponse
-	133, // 169: rest.TokenService.GenerateDocumentAccessToken:output_type -> rest.DocumentAccessTokenResponse
-	134, // 170: rest.MailerService.Send:output_type -> mailer.SendMailResponse
-	135, // 171: rest.SearchService.Nodes:output_type -> rest.SearchResults
-	136, // 172: rest.TreeService.BulkStatNodes:output_type -> rest.BulkMetaResponse
-	103, // 173: rest.TreeService.CreateNodes:output_type -> rest.NodesCollection
-	137, // 174: rest.TreeService.HeadNode:output_type -> rest.HeadNodeResponse
-	138, // 175: rest.TreeService.DeleteNodes:output_type -> rest.DeleteNodesResponse
-	139, // 176: rest.TreeService.RestoreNodes:output_type -> rest.RestoreNodesResponse
-	140, // 177: rest.TreeService.CreateSelection:output_type -> rest.CreateSelectionResponse
-	141, // 178: rest.TemplatesService.ListTemplates:output_type -> rest.ListTemplatesResponse
-	142, // 179: rest.MetaService.GetMeta:output_type -> tree.Node
-	142, // 180: rest.MetaService.SetMeta:output_type -> tree.Node
-	142, // 181: rest.MetaService.DeleteMeta:output_type -> tree.Node
-	136, // 182: rest.MetaService.GetBulkMeta:output_type -> rest.BulkMetaResponse
-	143, // 183: rest.UserMetaService.UpdateUserMeta:output_type -> idm.UpdateUserMetaResponse
-	144, // 184: rest.UserMetaService.SearchUserMeta:output_type -> rest.UserMetaCollection
-	136, // 185: rest.UserMetaService.UserBookmarks:output_type -> rest.BulkMetaResponse
-	145, // 186: rest.UserMetaService.UpdateUserMetaNamespace:output_type -> idm.UpdateUserMetaNamespaceResponse
-	146, // 187: rest.UserMetaService.ListUserMetaNamespace:output_type -> rest.UserMetaNamespaceCollection
-	147, // 188: rest.UserMetaService.GetFieldSchema:output_type -> idm.JsonSchemaResponse
-	147, // 189: rest.UserMetaService.GetNamespaceSchema:output_type -> idm.JsonSchemaResponse
-	148, // 190: rest.UserMetaService.ListUserMetaTags:output_type -> rest.ListUserMetaTagsResponse
-	149, // 191: rest.UserMetaService.PutUserMetaTag:output_type -> rest.PutUserMetaTagResponse
-	150, // 192: rest.UserMetaService.DeleteUserMetaTags:output_type -> rest.DeleteUserMetaTagsResponse
-	151, // 193: rest.JobsService.UserCreateJob:output_type -> rest.UserJobResponse
-	152, // 194: rest.JobsService.UserListJobs:output_type -> rest.UserJobsCollection
-	153, // 195: rest.JobsService.UserControlJob:output_type -> jobs.CtrlCommandResponse
-	154, // 196: rest.JobsService.UserDeleteTasks:output_type -> jobs.DeleteTasksResponse
-	129, // 197: rest.JobsService.ListTasksLogs:output_type -> rest.LogMessageCollection
-	103, // 198: rest.AdminTreeService.ListAdminTree:output_type -> rest.NodesCollection
-	155, // 199: rest.AdminTreeService.StatAdminTree:output_type -> tree.ReadNodeResponse
-	156, // 200: rest.GraphService.UserState:output_type -> rest.UserStateResponse
-	157, // 201: rest.GraphService.Relation:output_type -> rest.RelationResponse
-	158, // 202: rest.GraphService.Recommend:output_type -> rest.RecommendResponse
-	159, // 203: rest.ShareService.PutCell:output_type -> rest.Cell
-	159, // 204: rest.ShareService.GetCell:output_type -> rest.Cell
-	160, // 205: rest.ShareService.DeleteCell:output_type -> rest.DeleteCellResponse
-	161, // 206: rest.ShareService.PutShareLink:output_type -> rest.ShareLink
-	161, // 207: rest.ShareService.GetShareLink:output_type -> rest.ShareLink
-	162, // 208: rest.ShareService.DeleteShareLink:output_type -> rest.DeleteShareLinkResponse
-	163, // 209: rest.ShareService.ListSharedResources:output_type -> rest.ListSharedResourcesResponse
-	164, // 210: rest.ShareService.UpdateSharePolicies:output_type -> rest.UpdateSharePoliciesResponse
-	165, // 211: rest.InstallService.GetInstall:output_type -> install.GetDefaultsResponse
-	166, // 212: rest.InstallService.PostInstall:output_type -> install.InstallResponse
-	167, // 213: rest.InstallService.PerformInstallCheck:output_type -> install.PerformCheckResponse
-	168, // 214: rest.InstallService.GetAgreement:output_type -> install.GetAgreementResponse
-	169, // 215: rest.InstallService.InstallEvents:output_type -> install.InstallEventsResponse
-	170, // 216: rest.UpdateService.UpdateRequired:output_type -> update.UpdateResponse
-	171, // 217: rest.UpdateService.ApplyUpdate:output_type -> update.ApplyUpdateResponse
-	172, // 218: rest.FrontendService.FrontState:output_type -> rest.FrontStateResponse
-	173, // 219: rest.FrontendService.FrontBootConf:output_type -> rest.FrontBootConfResponse
-	174, // 220: rest.FrontendService.FrontMessages:output_type -> rest.FrontMessagesResponse
-	175, // 221: rest.FrontendService.FrontPlugins:output_type -> rest.FrontPluginsResponse
-	176, // 222: rest.FrontendService.FrontSession:output_type -> rest.FrontSessionResponse
-	177, // 223: rest.FrontendService.FrontEnrollAuth:output_type -> rest.FrontEnrollAuthResponse
-	178, // 224: rest.FrontendService.FrontServeBinary:output_type -> rest.FrontBinaryResponse
-	178, // 225: rest.FrontendService.FrontPutBinary:output_type -> rest.FrontBinaryResponse
-	179, // 226: rest.FrontendService.SettingsMenu:output_type -> rest.SettingsMenuResponse
-	3,   // 227: rest.HealthService.ApiPing:output_type -> rest.HealthServiceResponse
-	3,   // 228: rest.HealthService.ApiLive:output_type -> rest.HealthServiceResponse
-	3,   // 229: rest.HealthService.ApiReady:output_type -> rest.HealthServiceResponse
-	3,   // 230: rest.HealthService.ServiceLive:output_type -> rest.HealthServiceResponse
-	3,   // 231: rest.HealthService.ServiceReady:output_type -> rest.HealthServiceResponse
-	117, // [117:232] is the sub-list for method output_type
-	2,   // [2:117] is the sub-list for method input_type
+	68,  // 78: rest.UserMetaService.PutEntity:input_type -> idm.CreateEntityRequest
+	69,  // 79: rest.UserMetaService.DeleteEntity:input_type -> idm.DeleteEntityRequest
+	70,  // 80: rest.UserMetaService.ListEntities:input_type -> idm.ListEntitiesRequest
+	71,  // 81: rest.UserMetaService.CreateEntityValues:input_type -> idm.CreateEntityValueRequest
+	72,  // 82: rest.UserMetaService.DeleteEntityValue:input_type -> idm.DeleteEntityValueRequest
+	73,  // 83: rest.JobsService.UserCreateJob:input_type -> rest.UserJobRequest
+	74,  // 84: rest.JobsService.UserListJobs:input_type -> jobs.ListJobsRequest
+	75,  // 85: rest.JobsService.UserControlJob:input_type -> jobs.CtrlCommand
+	76,  // 86: rest.JobsService.UserDeleteTasks:input_type -> jobs.DeleteTasksRequest
+	42,  // 87: rest.JobsService.ListTasksLogs:input_type -> log.ListLogRequest
+	77,  // 88: rest.AdminTreeService.ListAdminTree:input_type -> tree.ListNodesRequest
+	78,  // 89: rest.AdminTreeService.StatAdminTree:input_type -> tree.ReadNodeRequest
+	79,  // 90: rest.GraphService.UserState:input_type -> rest.UserStateRequest
+	80,  // 91: rest.GraphService.Relation:input_type -> rest.RelationRequest
+	81,  // 92: rest.GraphService.Recommend:input_type -> rest.RecommendRequest
+	82,  // 93: rest.ShareService.PutCell:input_type -> rest.PutCellRequest
+	83,  // 94: rest.ShareService.GetCell:input_type -> rest.GetCellRequest
+	84,  // 95: rest.ShareService.DeleteCell:input_type -> rest.DeleteCellRequest
+	85,  // 96: rest.ShareService.PutShareLink:input_type -> rest.PutShareLinkRequest
+	86,  // 97: rest.ShareService.GetShareLink:input_type -> rest.GetShareLinkRequest
+	87,  // 98: rest.ShareService.DeleteShareLink:input_type -> rest.DeleteShareLinkRequest
+	88,  // 99: rest.ShareService.ListSharedResources:input_type -> rest.ListSharedResourcesRequest
+	89,  // 100: rest.ShareService.UpdateSharePolicies:input_type -> rest.UpdateSharePoliciesRequest
+	90,  // 101: rest.InstallService.GetInstall:input_type -> install.GetDefaultsRequest
+	91,  // 102: rest.InstallService.PostInstall:input_type -> install.InstallRequest
+	92,  // 103: rest.InstallService.PerformInstallCheck:input_type -> install.PerformCheckRequest
+	93,  // 104: rest.InstallService.GetAgreement:input_type -> install.GetAgreementRequest
+	94,  // 105: rest.InstallService.InstallEvents:input_type -> install.InstallEventsRequest
+	95,  // 106: rest.UpdateService.UpdateRequired:input_type -> update.UpdateRequest
+	96,  // 107: rest.UpdateService.ApplyUpdate:input_type -> update.ApplyUpdateRequest
+	97,  // 108: rest.FrontendService.FrontState:input_type -> rest.FrontStateRequest
+	98,  // 109: rest.FrontendService.FrontBootConf:input_type -> rest.FrontBootConfRequest
+	99,  // 110: rest.FrontendService.FrontMessages:input_type -> rest.FrontMessagesRequest
+	100, // 111: rest.FrontendService.FrontPlugins:input_type -> rest.FrontPluginsRequest
+	101, // 112: rest.FrontendService.FrontSession:input_type -> rest.FrontSessionRequest
+	102, // 113: rest.FrontendService.FrontEnrollAuth:input_type -> rest.FrontEnrollAuthRequest
+	103, // 114: rest.FrontendService.FrontServeBinary:input_type -> rest.FrontBinaryRequest
+	103, // 115: rest.FrontendService.FrontPutBinary:input_type -> rest.FrontBinaryRequest
+	104, // 116: rest.FrontendService.SettingsMenu:input_type -> rest.SettingsMenuRequest
+	1,   // 117: rest.HealthService.ApiPing:input_type -> rest.HealthServiceRequest
+	1,   // 118: rest.HealthService.ApiLive:input_type -> rest.HealthServiceRequest
+	1,   // 119: rest.HealthService.ApiReady:input_type -> rest.HealthServiceRequest
+	1,   // 120: rest.HealthService.ServiceLive:input_type -> rest.HealthServiceRequest
+	1,   // 121: rest.HealthService.ServiceReady:input_type -> rest.HealthServiceRequest
+	5,   // 122: rest.ConfigService.PutConfig:output_type -> rest.Configuration
+	5,   // 123: rest.ConfigService.GetConfig:output_type -> rest.Configuration
+	6,   // 124: rest.ConfigService.PutDataSource:output_type -> object.DataSource
+	6,   // 125: rest.ConfigService.GetDataSource:output_type -> object.DataSource
+	105, // 126: rest.ConfigService.DeleteDataSource:output_type -> rest.DeleteDataSourceResponse
+	106, // 127: rest.ConfigService.ListDataSources:output_type -> rest.DataSourceCollection
+	107, // 128: rest.ConfigService.ListVersioningPolicies:output_type -> rest.VersioningPolicyCollection
+	9,   // 129: rest.ConfigService.GetVersioningPolicy:output_type -> tree.VersioningPolicy
+	108, // 130: rest.ConfigService.ListVirtualNodes:output_type -> rest.NodesCollection
+	109, // 131: rest.ConfigService.ListServices:output_type -> rest.ServiceCollection
+	110, // 132: rest.ConfigService.ControlService:output_type -> ctl.Service
+	111, // 133: rest.ConfigService.ListRegistry:output_type -> registry.ListResponse
+	112, // 134: rest.ConfigService.ListPeersAddresses:output_type -> rest.ListPeersAddressesResponse
+	108, // 135: rest.ConfigService.ListPeerFolders:output_type -> rest.NodesCollection
+	113, // 136: rest.ConfigService.CreatePeerFolder:output_type -> rest.CreatePeerFolderResponse
+	108, // 137: rest.ConfigService.ListStorageBuckets:output_type -> rest.NodesCollection
+	114, // 138: rest.ConfigService.CreateStorageBucket:output_type -> rest.CreateStorageBucketResponse
+	115, // 139: rest.ConfigService.ListProcesses:output_type -> rest.ListProcessesResponse
+	116, // 140: rest.ConfigService.ListEncryptionKeys:output_type -> encryption.AdminListKeysResponse
+	117, // 141: rest.ConfigService.CreateEncryptionKey:output_type -> encryption.AdminCreateKeyResponse
+	118, // 142: rest.ConfigService.DeleteEncryptionKey:output_type -> encryption.AdminDeleteKeyResponse
+	119, // 143: rest.ConfigService.ExportEncryptionKey:output_type -> encryption.AdminExportKeyResponse
+	120, // 144: rest.ConfigService.ImportEncryptionKey:output_type -> encryption.AdminImportKeyResponse
+	121, // 145: rest.ConfigService.EndpointsDiscovery:output_type -> rest.DiscoveryResponse
+	122, // 146: rest.ConfigService.OpenApiDiscovery:output_type -> rest.OpenApiResponse
+	121, // 147: rest.ConfigService.ConfigFormsDiscovery:output_type -> rest.DiscoveryResponse
+	123, // 148: rest.ConfigService.SchedulerActionsDiscovery:output_type -> rest.SchedulerActionsResponse
+	124, // 149: rest.ConfigService.SchedulerActionFormDiscovery:output_type -> rest.SchedulerActionFormResponse
+	125, // 150: rest.ConfigService.ListSites:output_type -> rest.ListSitesResponse
+	30,  // 151: rest.RoleService.SetRole:output_type -> idm.Role
+	30,  // 152: rest.RoleService.DeleteRole:output_type -> idm.Role
+	30,  // 153: rest.RoleService.GetRole:output_type -> idm.Role
+	126, // 154: rest.RoleService.SearchRoles:output_type -> rest.RolesCollection
+	32,  // 155: rest.UserService.PutUser:output_type -> idm.User
+	127, // 156: rest.UserService.DeleteUser:output_type -> rest.DeleteResponse
+	32,  // 157: rest.UserService.GetUser:output_type -> idm.User
+	128, // 158: rest.UserService.SearchUsers:output_type -> rest.UsersCollection
+	32,  // 159: rest.UserService.PutRoles:output_type -> idm.User
+	34,  // 160: rest.ACLService.PutAcl:output_type -> idm.ACL
+	127, // 161: rest.ACLService.DeleteAcl:output_type -> rest.DeleteResponse
+	129, // 162: rest.ACLService.SearchAcls:output_type -> rest.ACLCollection
+	130, // 163: rest.PolicyService.ListPolicies:output_type -> idm.ListPolicyGroupsResponse
+	37,  // 164: rest.WorkspaceService.PutWorkspace:output_type -> idm.Workspace
+	127, // 165: rest.WorkspaceService.DeleteWorkspace:output_type -> rest.DeleteResponse
+	131, // 166: rest.WorkspaceService.SearchWorkspaces:output_type -> rest.WorkspaceCollection
+	132, // 167: rest.ActivityService.Stream:output_type -> activity.Object
+	40,  // 168: rest.ActivityService.Subscribe:output_type -> activity.Subscription
+	133, // 169: rest.ActivityService.SearchSubscriptions:output_type -> rest.SubscriptionsCollection
+	134, // 170: rest.LogService.Syslog:output_type -> rest.LogMessageCollection
+	135, // 171: rest.TokenService.Revoke:output_type -> rest.RevokeResponse
+	136, // 172: rest.TokenService.ResetPasswordToken:output_type -> rest.ResetPasswordTokenResponse
+	137, // 173: rest.TokenService.ResetPassword:output_type -> rest.ResetPasswordResponse
+	138, // 174: rest.TokenService.GenerateDocumentAccessToken:output_type -> rest.DocumentAccessTokenResponse
+	139, // 175: rest.MailerService.Send:output_type -> mailer.SendMailResponse
+	140, // 176: rest.SearchService.Nodes:output_type -> rest.SearchResults
+	141, // 177: rest.TreeService.BulkStatNodes:output_type -> rest.BulkMetaResponse
+	108, // 178: rest.TreeService.CreateNodes:output_type -> rest.NodesCollection
+	142, // 179: rest.TreeService.HeadNode:output_type -> rest.HeadNodeResponse
+	143, // 180: rest.TreeService.DeleteNodes:output_type -> rest.DeleteNodesResponse
+	144, // 181: rest.TreeService.RestoreNodes:output_type -> rest.RestoreNodesResponse
+	145, // 182: rest.TreeService.CreateSelection:output_type -> rest.CreateSelectionResponse
+	146, // 183: rest.TemplatesService.ListTemplates:output_type -> rest.ListTemplatesResponse
+	147, // 184: rest.MetaService.GetMeta:output_type -> tree.Node
+	147, // 185: rest.MetaService.SetMeta:output_type -> tree.Node
+	147, // 186: rest.MetaService.DeleteMeta:output_type -> tree.Node
+	141, // 187: rest.MetaService.GetBulkMeta:output_type -> rest.BulkMetaResponse
+	148, // 188: rest.UserMetaService.UpdateUserMeta:output_type -> idm.UpdateUserMetaResponse
+	149, // 189: rest.UserMetaService.SearchUserMeta:output_type -> rest.UserMetaCollection
+	141, // 190: rest.UserMetaService.UserBookmarks:output_type -> rest.BulkMetaResponse
+	150, // 191: rest.UserMetaService.UpdateUserMetaNamespace:output_type -> idm.UpdateUserMetaNamespaceResponse
+	151, // 192: rest.UserMetaService.ListUserMetaNamespace:output_type -> rest.UserMetaNamespaceCollection
+	152, // 193: rest.UserMetaService.GetFieldSchema:output_type -> idm.JsonSchemaResponse
+	152, // 194: rest.UserMetaService.GetNamespaceSchema:output_type -> idm.JsonSchemaResponse
+	153, // 195: rest.UserMetaService.ListUserMetaTags:output_type -> rest.ListUserMetaTagsResponse
+	154, // 196: rest.UserMetaService.PutUserMetaTag:output_type -> rest.PutUserMetaTagResponse
+	155, // 197: rest.UserMetaService.DeleteUserMetaTags:output_type -> rest.DeleteUserMetaTagsResponse
+	156, // 198: rest.UserMetaService.PutEntity:output_type -> idm.CreateEntityResponse
+	157, // 199: rest.UserMetaService.DeleteEntity:output_type -> idm.DeleteEntityResponse
+	158, // 200: rest.UserMetaService.ListEntities:output_type -> idm.ListEntitiesResponse
+	159, // 201: rest.UserMetaService.CreateEntityValues:output_type -> idm.CreateEntityValueResponse
+	160, // 202: rest.UserMetaService.DeleteEntityValue:output_type -> idm.DeleteEntityValueResponse
+	161, // 203: rest.JobsService.UserCreateJob:output_type -> rest.UserJobResponse
+	162, // 204: rest.JobsService.UserListJobs:output_type -> rest.UserJobsCollection
+	163, // 205: rest.JobsService.UserControlJob:output_type -> jobs.CtrlCommandResponse
+	164, // 206: rest.JobsService.UserDeleteTasks:output_type -> jobs.DeleteTasksResponse
+	134, // 207: rest.JobsService.ListTasksLogs:output_type -> rest.LogMessageCollection
+	108, // 208: rest.AdminTreeService.ListAdminTree:output_type -> rest.NodesCollection
+	165, // 209: rest.AdminTreeService.StatAdminTree:output_type -> tree.ReadNodeResponse
+	166, // 210: rest.GraphService.UserState:output_type -> rest.UserStateResponse
+	167, // 211: rest.GraphService.Relation:output_type -> rest.RelationResponse
+	168, // 212: rest.GraphService.Recommend:output_type -> rest.RecommendResponse
+	169, // 213: rest.ShareService.PutCell:output_type -> rest.Cell
+	169, // 214: rest.ShareService.GetCell:output_type -> rest.Cell
+	170, // 215: rest.ShareService.DeleteCell:output_type -> rest.DeleteCellResponse
+	171, // 216: rest.ShareService.PutShareLink:output_type -> rest.ShareLink
+	171, // 217: rest.ShareService.GetShareLink:output_type -> rest.ShareLink
+	172, // 218: rest.ShareService.DeleteShareLink:output_type -> rest.DeleteShareLinkResponse
+	173, // 219: rest.ShareService.ListSharedResources:output_type -> rest.ListSharedResourcesResponse
+	174, // 220: rest.ShareService.UpdateSharePolicies:output_type -> rest.UpdateSharePoliciesResponse
+	175, // 221: rest.InstallService.GetInstall:output_type -> install.GetDefaultsResponse
+	176, // 222: rest.InstallService.PostInstall:output_type -> install.InstallResponse
+	177, // 223: rest.InstallService.PerformInstallCheck:output_type -> install.PerformCheckResponse
+	178, // 224: rest.InstallService.GetAgreement:output_type -> install.GetAgreementResponse
+	179, // 225: rest.InstallService.InstallEvents:output_type -> install.InstallEventsResponse
+	180, // 226: rest.UpdateService.UpdateRequired:output_type -> update.UpdateResponse
+	181, // 227: rest.UpdateService.ApplyUpdate:output_type -> update.ApplyUpdateResponse
+	182, // 228: rest.FrontendService.FrontState:output_type -> rest.FrontStateResponse
+	183, // 229: rest.FrontendService.FrontBootConf:output_type -> rest.FrontBootConfResponse
+	184, // 230: rest.FrontendService.FrontMessages:output_type -> rest.FrontMessagesResponse
+	185, // 231: rest.FrontendService.FrontPlugins:output_type -> rest.FrontPluginsResponse
+	186, // 232: rest.FrontendService.FrontSession:output_type -> rest.FrontSessionResponse
+	187, // 233: rest.FrontendService.FrontEnrollAuth:output_type -> rest.FrontEnrollAuthResponse
+	188, // 234: rest.FrontendService.FrontServeBinary:output_type -> rest.FrontBinaryResponse
+	188, // 235: rest.FrontendService.FrontPutBinary:output_type -> rest.FrontBinaryResponse
+	189, // 236: rest.FrontendService.SettingsMenu:output_type -> rest.SettingsMenuResponse
+	3,   // 237: rest.HealthService.ApiPing:output_type -> rest.HealthServiceResponse
+	3,   // 238: rest.HealthService.ApiLive:output_type -> rest.HealthServiceResponse
+	3,   // 239: rest.HealthService.ApiReady:output_type -> rest.HealthServiceResponse
+	3,   // 240: rest.HealthService.ServiceLive:output_type -> rest.HealthServiceResponse
+	3,   // 241: rest.HealthService.ServiceReady:output_type -> rest.HealthServiceResponse
+	122, // [122:242] is the sub-list for method output_type
+	2,   // [2:122] is the sub-list for method input_type
 	2,   // [2:2] is the sub-list for extension type_name
 	2,   // [2:2] is the sub-list for extension extendee
 	0,   // [0:2] is the sub-list for field type_name

--- a/common/proto/rest/cellsapi-rest.proto
+++ b/common/proto/rest/cellsapi-rest.proto
@@ -633,6 +633,38 @@ service UserMetaService {
             delete: "/user-meta/tags/{Namespace}/{Tags}"
         };
     }
+
+   rpc PutEntity(idm.CreateEntityRequest) returns (idm.CreateEntityResponse){
+       option (google.api.http) = {
+           put: "/user-meta/entity"
+           body: "*"
+       };
+   }
+
+   rpc DeleteEntity(idm.DeleteEntityRequest) returns (idm.DeleteEntityResponse){
+       option (google.api.http) = {
+           delete: "/user-meta/entity/{EntityId}"
+       };
+   }
+
+   rpc ListEntities(idm.ListEntitiesRequest) returns (idm.ListEntitiesResponse){
+       option (google.api.http) = {
+           get: "/user-meta/entity"
+       };
+   }
+    rpc CreateEntityValues(idm.CreateEntityValueRequest) returns (idm.CreateEntityValueResponse){
+        option (google.api.http) = {
+            put: "/user-meta/entity/values"
+            body: "*"
+       };
+    }
+
+    rpc DeleteEntityValue(idm.DeleteEntityValueRequest) returns (idm.DeleteEntityValueResponse){
+        option (google.api.http) = {
+            delete: "/user-meta/entity/values/{EntityValueUuid}"
+       };
+    }
+    
 }
 
 // User-accessible Jobs service

--- a/common/proto/rest/cellsapi-rest.swagger.json
+++ b/common/proto/rest/cellsapi-rest.swagger.json
@@ -1250,10 +1250,115 @@
       },
       "type": "object"
     },
+    "idmCreateEntityRequest": {
+      "properties": {
+        "Entity": {
+          "$ref": "#/definitions/idmMetaEntity"
+        }
+      },
+      "title": "Creates a new Entity request",
+      "type": "object"
+    },
+    "idmCreateEntityResponse": {
+      "properties": {
+        "Entity": {
+          "$ref": "#/definitions/idmMetaEntity"
+        }
+      },
+      "title": "Response of CreateEntityRequest, returns the created Entity with its UUID",
+      "type": "object"
+    },
+    "idmCreateEntityValueRequest": {
+      "properties": {
+        "EntityValue": {
+          "items": {
+            "$ref": "#/definitions/idmEntityValue",
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "title": "Creates a new Entity representing a metadata field (e.g. \"Department\", \"Project\") and its possible values",
+      "type": "object"
+    },
+    "idmCreateEntityValueResponse": {
+      "properties": {
+        "EntityValue": {
+          "items": {
+            "$ref": "#/definitions/idmEntityValue",
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "title": "Response of CreateEntityValueRequest, returns the list of created EntityValues with their UUIDs",
+      "type": "object"
+    },
+    "idmDeleteEntityResponse": {
+      "properties": {
+        "RowsDeleted": {
+          "format": "int64",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "idmDeleteEntityValueResponse": {
+      "properties": {
+        "RowsDeleted": {
+          "format": "int64",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "idmEntityValue": {
+      "properties": {
+        "DisplayJSON": {
+          "type": "string"
+        },
+        "EntityUuid": {
+          "type": "string"
+        },
+        "Label": {
+          "type": "string"
+        },
+        "MetaUuid": {
+          "type": "string"
+        },
+        "Policies": {
+          "items": {
+            "$ref": "#/definitions/serviceResourcePolicy",
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "PoliciesContextEditable": {
+          "type": "boolean"
+        },
+        "Uuid": {
+          "type": "string"
+        }
+      },
+      "title": "EntityValue represents a value for an entity (e.g., \"Engineering\", \"Sales\")",
+      "type": "object"
+    },
     "idmJsonSchemaResponse": {
       "properties": {
         "JsonSchema": {
           "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "idmListEntitiesResponse": {
+      "properties": {
+        "Entity": {
+          "items": {
+            "$ref": "#/definitions/idmMetaEntity",
+            "type": "object"
+          },
+          "type": "array"
         }
       },
       "type": "object"
@@ -1284,6 +1389,31 @@
           "type": "integer"
         }
       },
+      "type": "object"
+    },
+    "idmMetaEntity": {
+      "properties": {
+        "Description": {
+          "type": "string"
+        },
+        "Label": {
+          "type": "string"
+        },
+        "Policies": {
+          "items": {
+            "$ref": "#/definitions/serviceResourcePolicy",
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "PoliciesContextEditable": {
+          "type": "boolean"
+        },
+        "Uuid": {
+          "type": "string"
+        }
+      },
+      "title": "MetaEntity represents a metadata entity (e.g., \"Department\", \"Project\")",
       "type": "object"
     },
     "idmNodeType": {
@@ -1762,6 +1892,10 @@
         "EnforceDefault": {
           "title": "Use default value from JsonSchema to enforce defaults",
           "type": "boolean"
+        },
+        "EntityUUID": {
+          "title": "Associated Entity UUID",
+          "type": "string"
         },
         "FieldType": {
           "title": "Namespace Type  \"boolean\", \"choice\", \"css_label\", \"date\", \"integer\", \"json\", \"multi_value\", \"stars_rate\", \"string\", \"tag_cloud\", \"tags\", \"textarea\", \"url\"",
@@ -12192,6 +12326,248 @@
           }
         },
         "summary": "Special API for Bookmarks, will load userMeta and the associated nodes, and return\nas a node list",
+        "tags": [
+          "UserMetaService"
+        ]
+      }
+    },
+    "/user-meta/entity": {
+      "get": {
+        "operationId": "ListEntities",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "EntityId",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/idmListEntitiesResponse"
+            }
+          },
+          "401": {
+            "description": "User is not authenticated",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "403": {
+            "description": "User has no permission to access this particular resource",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "404": {
+            "description": "Resource does not exist in the system",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "500": {
+            "description": "An internal error occurred in the backend",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          }
+        },
+        "tags": [
+          "UserMetaService"
+        ]
+      },
+      "put": {
+        "operationId": "PutEntity",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/idmCreateEntityRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/idmCreateEntityResponse"
+            }
+          },
+          "401": {
+            "description": "User is not authenticated",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "403": {
+            "description": "User has no permission to access this particular resource",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "404": {
+            "description": "Resource does not exist in the system",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "500": {
+            "description": "An internal error occurred in the backend",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          }
+        },
+        "tags": [
+          "UserMetaService"
+        ]
+      }
+    },
+    "/user-meta/entity/values": {
+      "put": {
+        "operationId": "CreateEntityValues",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/idmCreateEntityValueRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/idmCreateEntityValueResponse"
+            }
+          },
+          "401": {
+            "description": "User is not authenticated",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "403": {
+            "description": "User has no permission to access this particular resource",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "404": {
+            "description": "Resource does not exist in the system",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "500": {
+            "description": "An internal error occurred in the backend",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          }
+        },
+        "tags": [
+          "UserMetaService"
+        ]
+      }
+    },
+    "/user-meta/entity/values/{EntityValueUuid}": {
+      "delete": {
+        "operationId": "DeleteEntityValue",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "EntityValueUuid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/idmDeleteEntityValueResponse"
+            }
+          },
+          "401": {
+            "description": "User is not authenticated",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "403": {
+            "description": "User has no permission to access this particular resource",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "404": {
+            "description": "Resource does not exist in the system",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "500": {
+            "description": "An internal error occurred in the backend",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          }
+        },
+        "tags": [
+          "UserMetaService"
+        ]
+      }
+    },
+    "/user-meta/entity/{EntityId}": {
+      "delete": {
+        "operationId": "DeleteEntity",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "EntityId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/idmDeleteEntityResponse"
+            }
+          },
+          "401": {
+            "description": "User is not authenticated",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "403": {
+            "description": "User has no permission to access this particular resource",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "404": {
+            "description": "Resource does not exist in the system",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "500": {
+            "description": "An internal error occurred in the backend",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          }
+        },
         "tags": [
           "UserMetaService"
         ]

--- a/common/proto/rest/cellsapi-rest.swagger.json
+++ b/common/proto/rest/cellsapi-rest.swagger.json
@@ -1250,10 +1250,115 @@
       },
       "type": "object"
     },
+    "idmCreateEntityRequest": {
+      "properties": {
+        "Entity": {
+          "$ref": "#/definitions/idmMetaEntity"
+        }
+      },
+      "title": "Creates a new Entity request",
+      "type": "object"
+    },
+    "idmCreateEntityResponse": {
+      "properties": {
+        "Entity": {
+          "$ref": "#/definitions/idmMetaEntity"
+        }
+      },
+      "title": "Response of CreateEntityRequest, returns the created Entity with its UUID",
+      "type": "object"
+    },
+    "idmCreateEntityValueRequest": {
+      "properties": {
+        "EntityValue": {
+          "items": {
+            "$ref": "#/definitions/idmEntityValue",
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "title": "Creates a new Entity representing a metadata field (e.g. \"Department\", \"Project\") and its possible values",
+      "type": "object"
+    },
+    "idmCreateEntityValueResponse": {
+      "properties": {
+        "EntityValue": {
+          "items": {
+            "$ref": "#/definitions/idmEntityValue",
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "title": "Response of CreateEntityValueRequest, returns the list of created EntityValues with their UUIDs",
+      "type": "object"
+    },
+    "idmDeleteEntityResponse": {
+      "properties": {
+        "RowsDeleted": {
+          "format": "int64",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "idmDeleteEntityValueResponse": {
+      "properties": {
+        "RowsDeleted": {
+          "format": "int64",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "idmEntityValue": {
+      "properties": {
+        "DisplayJSON": {
+          "type": "string"
+        },
+        "EntityUuid": {
+          "type": "string"
+        },
+        "Label": {
+          "type": "string"
+        },
+        "MetaUuid": {
+          "type": "string"
+        },
+        "Policies": {
+          "items": {
+            "$ref": "#/definitions/serviceResourcePolicy",
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "PoliciesContextEditable": {
+          "type": "boolean"
+        },
+        "Uuid": {
+          "type": "string"
+        }
+      },
+      "title": "EntityValue represents a value for an entity (e.g., \"Engineering\", \"Sales\")",
+      "type": "object"
+    },
     "idmJsonSchemaResponse": {
       "properties": {
         "JsonSchema": {
           "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "idmListEntitiesResponse": {
+      "properties": {
+        "Entity": {
+          "items": {
+            "$ref": "#/definitions/idmMetaEntity",
+            "type": "object"
+          },
+          "type": "array"
         }
       },
       "type": "object"
@@ -1284,6 +1389,31 @@
           "type": "integer"
         }
       },
+      "type": "object"
+    },
+    "idmMetaEntity": {
+      "properties": {
+        "Description": {
+          "type": "string"
+        },
+        "Label": {
+          "type": "string"
+        },
+        "Policies": {
+          "items": {
+            "$ref": "#/definitions/serviceResourcePolicy",
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "PoliciesContextEditable": {
+          "type": "boolean"
+        },
+        "Uuid": {
+          "type": "string"
+        }
+      },
+      "title": "MetaEntity represents a metadata entity (e.g., \"Department\", \"Project\")",
       "type": "object"
     },
     "idmNodeType": {
@@ -12192,6 +12322,248 @@
           }
         },
         "summary": "Special API for Bookmarks, will load userMeta and the associated nodes, and return\nas a node list",
+        "tags": [
+          "UserMetaService"
+        ]
+      }
+    },
+    "/user-meta/entity": {
+      "get": {
+        "operationId": "ListEntities",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "EntityId",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/idmListEntitiesResponse"
+            }
+          },
+          "401": {
+            "description": "User is not authenticated",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "403": {
+            "description": "User has no permission to access this particular resource",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "404": {
+            "description": "Resource does not exist in the system",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "500": {
+            "description": "An internal error occurred in the backend",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          }
+        },
+        "tags": [
+          "UserMetaService"
+        ]
+      },
+      "put": {
+        "operationId": "PutEntity",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/idmCreateEntityRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/idmCreateEntityResponse"
+            }
+          },
+          "401": {
+            "description": "User is not authenticated",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "403": {
+            "description": "User has no permission to access this particular resource",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "404": {
+            "description": "Resource does not exist in the system",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "500": {
+            "description": "An internal error occurred in the backend",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          }
+        },
+        "tags": [
+          "UserMetaService"
+        ]
+      }
+    },
+    "/user-meta/entity/values": {
+      "put": {
+        "operationId": "CreateEntityValues",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/idmCreateEntityValueRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/idmCreateEntityValueResponse"
+            }
+          },
+          "401": {
+            "description": "User is not authenticated",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "403": {
+            "description": "User has no permission to access this particular resource",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "404": {
+            "description": "Resource does not exist in the system",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "500": {
+            "description": "An internal error occurred in the backend",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          }
+        },
+        "tags": [
+          "UserMetaService"
+        ]
+      }
+    },
+    "/user-meta/entity/values/{EntityValueUuid}": {
+      "delete": {
+        "operationId": "DeleteEntityValue",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "EntityValueUuid",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/idmDeleteEntityValueResponse"
+            }
+          },
+          "401": {
+            "description": "User is not authenticated",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "403": {
+            "description": "User has no permission to access this particular resource",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "404": {
+            "description": "Resource does not exist in the system",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "500": {
+            "description": "An internal error occurred in the backend",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          }
+        },
+        "tags": [
+          "UserMetaService"
+        ]
+      }
+    },
+    "/user-meta/entity/{EntityId}": {
+      "delete": {
+        "operationId": "DeleteEntity",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "EntityId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/idmDeleteEntityResponse"
+            }
+          },
+          "401": {
+            "description": "User is not authenticated",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "403": {
+            "description": "User has no permission to access this particular resource",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "404": {
+            "description": "Resource does not exist in the system",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          },
+          "500": {
+            "description": "An internal error occurred in the backend",
+            "schema": {
+              "$ref": "#/definitions/restError"
+            }
+          }
+        },
         "tags": [
           "UserMetaService"
         ]

--- a/idm/acl/dao/sql/sql_test.go
+++ b/idm/acl/dao/sql/sql_test.go
@@ -413,7 +413,7 @@ func TestQueryBuilder(t *testing.T) {
 
 		})
 
-		Convey(" Reorder user roles", t, func() {
+		Convey("Reorder user roles", t, func() {
 			aa := []*idm.ACL{
 				{NodeID: "n4.0", RoleID: "role1", Action: &idm.ACLAction{Name: "read", Value: "read_val1"}},
 				{NodeID: "n4.1", RoleID: "role2", Action: &idm.ACLAction{Name: "read", Value: "read_val2"}},

--- a/idm/meta/client.go
+++ b/idm/meta/client.go
@@ -24,7 +24,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"slices"
+
 	"strconv"
 	"strings"
 	"text/template"
@@ -89,11 +89,14 @@ type UserMetaClient interface {
 	GetEntityValues(ctx context.Context, entityID string) ([]*idm.EntityValue, error)
 	IsContextEditable(ctx context.Context, resourceId string, policies []*serviceproto.ResourcePolicy) bool
 	MatchPolicies(ctx context.Context, resourceId string, policies []*serviceproto.ResourcePolicy, action serviceproto.ResourcePolicyAction, subjects ...string) bool
-	DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error)
+	Entities(ctx context.Context) (map[string]*idm.MetaEntity, error)
+	DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityResponse, error)
+	GetEntity(ctx context.Context, entityID string) (*idm.MetaEntity, error)
 	CreateEntity(ctx context.Context, input *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error)
 	CreateEntityValues(ctx context.Context, input *idm.CreateEntityValueRequest) (*idm.CreateEntityValueResponse, error)
 	LinkMetaToEntityValue(ctx context.Context, metaUuid string, valueUuid string) (*idm.MetaToEntityValueResponse, error)
 	UnlinkMetaFromEntityValue(ctx context.Context, metaUuid string, valueUuid string) (*idm.MetaToEntityValueResponse, error)
+	DeleteEntityValue(ctx context.Context, entityValueUuid string) (*idm.DeleteEntityValueResponse, error)
 }
 
 type umClient struct {
@@ -147,6 +150,7 @@ func (u *umClient) UpdateMetaResolved(ctx context.Context, input *idm.UpdateUser
 		if !u.MatchPolicies(ctx, meta.Namespace, policies, serviceproto.ResourcePolicyAction_WRITE) {
 			return nil, errors.WithMessagef(errors.NamespaceNotAllowed, "Updating namespace %s is not allowed!", meta.Namespace)
 		}
+		// TODO deny updates to admin only tag values for tag_cloud namespaces with admin only policies
 		if meta.Uuid != "" {
 			loadUuids = append(loadUuids, meta.Uuid)
 		}
@@ -195,129 +199,13 @@ func (u *umClient) UpdateMetaResolved(ctx context.Context, input *idm.UpdateUser
 		}
 	}
 
-	// First persist metadata to get UUIDs assigned
+	// Persist metadata and let server handle entity value reconciliation
 	resp, err := svc.UpdateUserMeta(ctx, input)
 	if err != nil {
 		return nil, err
 	}
 
-	// Now link to entity values using the persisted metadata with valid UUIDs
-	for _, m := range resp.MetaDatas {
-		var metaValue string
-		// Check if namespace is linked to an entity
-		if e := json.Unmarshal([]byte(m.JsonValue), &metaValue); e != nil {
-			// if we cannot unmarshal the value, it means it's not linked to an entity and we can skip it
-			// if this throws an error it breaks the Integration tests, one of the tests was passing with an invalid payload //generate64KJsonString()
-			continue
-		}
-		if len(metaValue) == 0 && !slices.Contains([]string{"tag_cloud", "auto_complete"}, nsList[m.Namespace].FieldType) {
-			continue
-			// if  JsonValue is empty, should we unlink meta from evalue?
-			// get all linked entity values
-
-			// unlink all
-			// continue to next meta
-
-		}
-		if ns, exists := nsList[m.Namespace]; exists {
-			if slices.Contains([]string{"tag_cloud", "auto_complete"}, ns.FieldType) {
-				definition, _ := ns.UnmarshallDefinition()
-				if definition != nil {
-					entityID := definition.GetEntityId()
-					if len(entityID) == 0 {
-						continue // no entity linked to this namespace, nothing to do
-					}
-					evals, err := u.ServiceClient(ctx).GetEntityValues(ctx, &idm.GetMetaEntityValuesRequest{
-						EntityUuid: entityID,
-					})
-					if len(metaValue) == 0 && len(evals.EntityValue) > 0 {
-						meta, _ := u.ServiceClient(ctx).GetMetadata(ctx, &idm.GetMetadataRequest{NodeUuid: m.NodeUuid, Namespace: m.Namespace})
-						for _, val := range evals.EntityValue {
-							// unlink all values
-							_, err = u.ServiceClient(ctx).UnlinkMetaFromEntityValue(ctx, &idm.MetaToEntityValueRequest{
-								MetaUuid:        meta.Uuid,
-								EntityValueUuid: val.Uuid,
-							})
-							if err != nil {
-								return nil, err
-							}
-						}
-						continue
-					} else if len(metaValue) > 0 && len(evals.EntityValue) > 0 {
-						// unlink the diff
-						for _, val := range evals.EntityValue {
-							if !slices.Contains(strings.Split(metaValue, ","), val.Label) {
-								//unlink value
-								meta, _ := u.ServiceClient(ctx).GetMetadata(ctx, &idm.GetMetadataRequest{NodeUuid: m.NodeUuid, Namespace: m.Namespace})
-								_, err = u.ServiceClient(ctx).UnlinkMetaFromEntityValue(ctx, &idm.MetaToEntityValueRequest{
-									MetaUuid:        meta.Uuid,
-									EntityValueUuid: val.Uuid,
-								})
-								if err != nil {
-									return nil, err
-								}
-							}
-						}
-					}
-					if err != nil || len(evals.EntityValue) == 0 && len(metaValue) > 0 {
-						// if no entity values exist for this entity but we have a meta value throw an error
-						return nil, err
-					}
-
-					for _, val := range evals.EntityValue {
-						//string already exists
-						if metaValue == val.Label || slices.Contains(strings.Split(metaValue, ","), val.Label) {
-							meta, _ := u.ServiceClient(ctx).GetMetadata(ctx, &idm.GetMetadataRequest{NodeUuid: m.NodeUuid, Namespace: m.Namespace})
-
-							u.ServiceClient(ctx).LinkMetaToEntityValue(ctx, &idm.MetaToEntityValueRequest{
-								MetaUuid:        meta.Uuid,
-								EntityValueUuid: val.Uuid,
-							})
-						}
-					}
-
-					if ns.FieldType == "tag_cloud" || ns.FieldType == "auto_complete" {
-						// get the diff of labels from metaValue
-						var newLabels []string
-						// combine all EntityValue labels into an array
-						var existingLabels []string
-						for _, val := range evals.EntityValue {
-							existingLabels = append(existingLabels, val.Label)
-						}
-						for _, label := range strings.Split(metaValue, ",") {
-							if !slices.Contains(existingLabels, label) {
-								newLabels = append(newLabels, label)
-							}
-						}
-						// create new EntityValues for the diff
-						entityValues := make([]*idm.EntityValue, 0, len(newLabels))
-
-						meta, _ := u.ServiceClient(ctx).GetMetadata(ctx, &idm.GetMetadataRequest{NodeUuid: m.NodeUuid, Namespace: m.Namespace})
-						for _, label := range newLabels {
-							// append and create many instead of one by one
-							entityValues = append(entityValues, &idm.EntityValue{
-								EntityUuid: entityID,
-								Label:      label,
-							})
-						}
-						if len(entityValues) > 0 {
-							createValResp, err := u.CreateEntityValues(ctx, &idm.CreateEntityValueRequest{EntityValue: entityValues})
-							if err != nil {
-								return nil, err
-							}
-							// Link meta to entity value
-							for _, createVal := range createValResp.EntityValue {
-								_, err = u.LinkMetaToEntityValue(ctx, meta.Uuid, createVal.Uuid)
-								if err != nil {
-									return nil, err
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+	// Server-side EvResolver now handles vocabulary creation, linking, and unlinking
 	return resp, nil
 }
 
@@ -484,6 +372,35 @@ func (u *umClient) PoliciesForMeta(_ context.Context, _ string, _ interface{}) (
 	return
 }
 
+// Entities lists all entities the current context has READ access to.
+// Visibility is gated on READ; editability is indicated separately via PoliciesContextEditable (WRITE check).
+func (u *umClient) Entities(ctx context.Context) (map[string]*idm.MetaEntity, error) {
+	resp, err := u.ServiceClient(ctx).ListEntities(ctx, &idm.ListEntitiesRequest{})
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]*idm.MetaEntity)
+	for _, entity := range resp.Entity {
+		if !u.MatchPolicies(ctx, entity.Uuid, entity.Policies, serviceproto.ResourcePolicyAction_READ) {
+			continue
+		}
+		entity.PoliciesContextEditable = u.IsContextEditable(ctx, entity.Uuid, entity.Policies)
+		result[entity.Uuid] = entity
+	}
+	return result, nil
+}
+
+func (u *umClient) GetEntity(ctx context.Context, entityID string) (*idm.MetaEntity, error) {
+	req := &idm.GetEntityRequest{
+		EntityUuid: entityID,
+	}
+	resp, err := u.ServiceClient(ctx).GetEntity(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Entity, nil
+}
+
 func (u *umClient) GetEntityValues(ctx context.Context, entityID string) ([]*idm.EntityValue, error) {
 	req := &idm.GetMetaEntityValuesRequest{
 		EntityUuid: entityID,
@@ -495,9 +412,9 @@ func (u *umClient) GetEntityValues(ctx context.Context, entityID string) ([]*idm
 	return resp.EntityValue, nil
 }
 
-func (u *umClient) DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
-	req := &idm.GetMetaEntityValuesRequest{
-		EntityUuid: entityID,
+func (u *umClient) DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityResponse, error) {
+	req := &idm.DeleteEntityRequest{
+		EntityId: entityID,
 	}
 	resp, err := u.ServiceClient(ctx).DeleteEntity(ctx, req)
 	if err != nil {
@@ -762,4 +679,9 @@ func (u *umClient) incomingDefaults(ctx context.Context, inputType tree.NodeType
 		}
 	}
 	return
+}
+
+func (u *umClient) DeleteEntityValue(ctx context.Context, entityValueUuid string) (*idm.DeleteEntityValueResponse, error) {
+	// TODO Implement this method to delete an entity value by its UUID
+	return nil, nil
 }

--- a/idm/meta/client.go
+++ b/idm/meta/client.go
@@ -24,7 +24,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"slices"
+
 	"strconv"
 	"strings"
 	"text/template"
@@ -89,11 +89,14 @@ type UserMetaClient interface {
 	GetEntityValues(ctx context.Context, entityID string) ([]*idm.EntityValue, error)
 	IsContextEditable(ctx context.Context, resourceId string, policies []*serviceproto.ResourcePolicy) bool
 	MatchPolicies(ctx context.Context, resourceId string, policies []*serviceproto.ResourcePolicy, action serviceproto.ResourcePolicyAction, subjects ...string) bool
-	DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error)
+	Entities(ctx context.Context) (map[string]*idm.MetaEntity, error)
+	DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityResponse, error)
+	GetEntity(ctx context.Context, entityID string) (*idm.MetaEntity, error)
 	CreateEntity(ctx context.Context, input *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error)
 	CreateEntityValues(ctx context.Context, input *idm.CreateEntityValueRequest) (*idm.CreateEntityValueResponse, error)
 	LinkMetaToEntityValue(ctx context.Context, metaUuid string, valueUuid string) (*idm.MetaToEntityValueResponse, error)
 	UnlinkMetaFromEntityValue(ctx context.Context, metaUuid string, valueUuid string) (*idm.MetaToEntityValueResponse, error)
+	DeleteEntityValue(ctx context.Context, entityValueUuid string) (*idm.DeleteEntityValueResponse, error)
 }
 
 type umClient struct {
@@ -195,129 +198,13 @@ func (u *umClient) UpdateMetaResolved(ctx context.Context, input *idm.UpdateUser
 		}
 	}
 
-	// First persist metadata to get UUIDs assigned
+	// Persist metadata and let server handle entity value reconciliation
 	resp, err := svc.UpdateUserMeta(ctx, input)
 	if err != nil {
 		return nil, err
 	}
 
-	// Now link to entity values using the persisted metadata with valid UUIDs
-	for _, m := range resp.MetaDatas {
-		var metaValue string
-		// Check if namespace is linked to an entity
-		if e := json.Unmarshal([]byte(m.JsonValue), &metaValue); e != nil {
-			// if we cannot unmarshal the value, it means it's not linked to an entity and we can skip it
-			// if this throws an error it breaks the Integration tests, one of the tests was passing with an invalid payload //generate64KJsonString()
-			continue
-		}
-		if len(metaValue) == 0 && !slices.Contains([]string{"tag_cloud", "auto_complete"}, nsList[m.Namespace].FieldType) {
-			continue
-			// if  JsonValue is empty, should we unlink meta from evalue?
-			// get all linked entity values
-
-			// unlink all
-			// continue to next meta
-
-		}
-		if ns, exists := nsList[m.Namespace]; exists {
-			if slices.Contains([]string{"tag_cloud", "auto_complete"}, ns.FieldType) {
-				definition, _ := ns.UnmarshallDefinition()
-				if definition != nil {
-					entityID := definition.GetEntityId()
-					if len(entityID) == 0 {
-						continue // no entity linked to this namespace, nothing to do
-					}
-					evals, err := u.ServiceClient(ctx).GetEntityValues(ctx, &idm.GetMetaEntityValuesRequest{
-						EntityUuid: entityID,
-					})
-					if len(metaValue) == 0 && len(evals.EntityValue) > 0 {
-						meta, _ := u.ServiceClient(ctx).GetMetadata(ctx, &idm.GetMetadataRequest{NodeUuid: m.NodeUuid, Namespace: m.Namespace})
-						for _, val := range evals.EntityValue {
-							// unlink all values
-							_, err = u.ServiceClient(ctx).UnlinkMetaFromEntityValue(ctx, &idm.MetaToEntityValueRequest{
-								MetaUuid:        meta.Uuid,
-								EntityValueUuid: val.Uuid,
-							})
-							if err != nil {
-								return nil, err
-							}
-						}
-						continue
-					} else if len(metaValue) > 0 && len(evals.EntityValue) > 0 {
-						// unlink the diff
-						for _, val := range evals.EntityValue {
-							if !slices.Contains(strings.Split(metaValue, ","), val.Label) {
-								//unlink value
-								meta, _ := u.ServiceClient(ctx).GetMetadata(ctx, &idm.GetMetadataRequest{NodeUuid: m.NodeUuid, Namespace: m.Namespace})
-								_, err = u.ServiceClient(ctx).UnlinkMetaFromEntityValue(ctx, &idm.MetaToEntityValueRequest{
-									MetaUuid:        meta.Uuid,
-									EntityValueUuid: val.Uuid,
-								})
-								if err != nil {
-									return nil, err
-								}
-							}
-						}
-					}
-					if err != nil || len(evals.EntityValue) == 0 && len(metaValue) > 0 {
-						// if no entity values exist for this entity but we have a meta value throw an error
-						return nil, err
-					}
-
-					for _, val := range evals.EntityValue {
-						//string already exists
-						if metaValue == val.Label || slices.Contains(strings.Split(metaValue, ","), val.Label) {
-							meta, _ := u.ServiceClient(ctx).GetMetadata(ctx, &idm.GetMetadataRequest{NodeUuid: m.NodeUuid, Namespace: m.Namespace})
-
-							u.ServiceClient(ctx).LinkMetaToEntityValue(ctx, &idm.MetaToEntityValueRequest{
-								MetaUuid:        meta.Uuid,
-								EntityValueUuid: val.Uuid,
-							})
-						}
-					}
-
-					if ns.FieldType == "tag_cloud" || ns.FieldType == "auto_complete" {
-						// get the diff of labels from metaValue
-						var newLabels []string
-						// combine all EntityValue labels into an array
-						var existingLabels []string
-						for _, val := range evals.EntityValue {
-							existingLabels = append(existingLabels, val.Label)
-						}
-						for _, label := range strings.Split(metaValue, ",") {
-							if !slices.Contains(existingLabels, label) {
-								newLabels = append(newLabels, label)
-							}
-						}
-						// create new EntityValues for the diff
-						entityValues := make([]*idm.EntityValue, 0, len(newLabels))
-
-						meta, _ := u.ServiceClient(ctx).GetMetadata(ctx, &idm.GetMetadataRequest{NodeUuid: m.NodeUuid, Namespace: m.Namespace})
-						for _, label := range newLabels {
-							// append and create many instead of one by one
-							entityValues = append(entityValues, &idm.EntityValue{
-								EntityUuid: entityID,
-								Label:      label,
-							})
-						}
-						if len(entityValues) > 0 {
-							createValResp, err := u.CreateEntityValues(ctx, &idm.CreateEntityValueRequest{EntityValue: entityValues})
-							if err != nil {
-								return nil, err
-							}
-							// Link meta to entity value
-							for _, createVal := range createValResp.EntityValue {
-								_, err = u.LinkMetaToEntityValue(ctx, meta.Uuid, createVal.Uuid)
-								if err != nil {
-									return nil, err
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+	// Server-side EvResolver now handles vocabulary creation, linking, and unlinking
 	return resp, nil
 }
 
@@ -484,6 +371,34 @@ func (u *umClient) PoliciesForMeta(_ context.Context, _ string, _ interface{}) (
 	return
 }
 
+// Entities lists all entities the current context has READ access to
+func (u *umClient) Entities(ctx context.Context) (map[string]*idm.MetaEntity, error) {
+	resp, err := u.ServiceClient(ctx).ListEntities(ctx, &idm.ListEntitiesRequest{})
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]*idm.MetaEntity)
+	for _, entity := range resp.Entity {
+		if !u.MatchPolicies(ctx, entity.Uuid, entity.Policies, serviceproto.ResourcePolicyAction_READ) {
+			continue
+		}
+		entity.PoliciesContextEditable = u.IsContextEditable(ctx, entity.Uuid, entity.Policies)
+		result[entity.Uuid] = entity
+	}
+	return result, nil
+}
+
+func (u *umClient) GetEntity(ctx context.Context, entityID string) (*idm.MetaEntity, error) {
+	req := &idm.GetEntityRequest{
+		EntityUuid: entityID,
+	}
+	resp, err := u.ServiceClient(ctx).GetEntity(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Entity, nil
+}
+
 func (u *umClient) GetEntityValues(ctx context.Context, entityID string) ([]*idm.EntityValue, error) {
 	req := &idm.GetMetaEntityValuesRequest{
 		EntityUuid: entityID,
@@ -495,9 +410,9 @@ func (u *umClient) GetEntityValues(ctx context.Context, entityID string) ([]*idm
 	return resp.EntityValue, nil
 }
 
-func (u *umClient) DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
-	req := &idm.GetMetaEntityValuesRequest{
-		EntityUuid: entityID,
+func (u *umClient) DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityResponse, error) {
+	req := &idm.DeleteEntityRequest{
+		EntityId: entityID,
 	}
 	resp, err := u.ServiceClient(ctx).DeleteEntity(ctx, req)
 	if err != nil {
@@ -762,4 +677,9 @@ func (u *umClient) incomingDefaults(ctx context.Context, inputType tree.NodeType
 		}
 	}
 	return
+}
+
+func (u *umClient) DeleteEntityValue(ctx context.Context, entityValueUuid string) (*idm.DeleteEntityValueResponse, error) {
+
+	return nil, nil
 }

--- a/idm/meta/dao.go
+++ b/idm/meta/dao.go
@@ -40,7 +40,6 @@ var Drivers = service.StorageDrivers{}
 type DAO interface {
 	resources.DAO
 	GetNamespaceDao() NamespaceDAO
-	// GetEntityValueDao() EntityValueDAO
 
 	Migrate(ctx context.Context) error
 	Set(ctx context.Context, meta *idm.UserMeta) (*idm.UserMeta, string, error)

--- a/idm/meta/dao/sql/ev-sql.go
+++ b/idm/meta/dao/sql/ev-sql.go
@@ -33,13 +33,18 @@ import (
 	"github.com/pydio/cells/v5/common/errors"
 	"github.com/pydio/cells/v5/common/proto/idm"
 	"github.com/pydio/cells/v5/common/storage/sql"
-	"github.com/pydio/cells/v5/common/storage/sql/resources"
+	resources2 "github.com/pydio/cells/v5/common/storage/sql/resources"
 	"github.com/pydio/cells/v5/idm/meta"
 )
 
 var (
 	EntityValueErr = errors.RegisterBaseSentinel(errors.SqlDAO, "sql entity values")
 )
+
+func init() {
+	meta.Drivers.Register(NewEntityDAO)
+	meta.Drivers.Register(NewEntityValueDAO)
+}
 
 func evTagError(err error) error {
 	return errors.Tag(err, EntityValueErr)
@@ -72,29 +77,72 @@ func (*EntityValues) TableName(namer schema.Namer) string {
 }
 
 type MetaValuesRel struct {
-	MetaUUID   string `gorm:"primaryKey;column:meta_uuid;type:varchar(255);notNull;index:idx_meta_evalue,composite:meta_evalue"`
-	EValueUUID string `gorm:"primaryKey;column:e_value_uuid;type:varchar(255);notNull;index:idx_meta_evalue,composite:meta_evalue"`
+	MetaUUID   string `gorm:"primaryKey;column:meta_uuid;type:varchar(255);notNull"`
+	EValueUUID string `gorm:"primaryKey;column:e_value_uuid;type:varchar(255);notNull"`
 }
 
 func (*MetaValuesRel) TableName(namer schema.Namer) string {
 	return namer.JoinTableName("meta_values_rel")
 }
 
-func NewEntityValueDAO(db *gorm.DB) meta.EntityValueDAO {
-
-	return &evSqlImpl{
-		Abstract: sql.NewAbstract(db),
-		DAO:      resources.NewDAO(db),
+func (s *evSqlImpl) MigrateEV(ctx context.Context) error {
+	db := s.Session(ctx)
+	if err := db.AutoMigrate(&EntityValues{}); err != nil {
+		return err
 	}
+
+	if err := s.resourcesDAO.Migrate(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Move this to entitySqlImpl
+func (s *entitySqlImpl) MigrateEntity(ctx context.Context) error {
+	if err := s.Session(ctx).AutoMigrate(&Entities{}); err != nil {
+		return err
+	}
+
+	if err := s.resourcesDAO.Migrate(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Add explicit Migrate for entitySqlImpl to resolve ambiguity
+func (s *entitySqlImpl) Migrate(ctx context.Context) error {
+	return s.MigrateEntity(ctx)
+}
+
+// Add explicit Migrate for evSqlImpl to resolve ambiguity
+func (s *evSqlImpl) Migrate(ctx context.Context) error {
+	return s.MigrateEV(ctx)
+}
+
+func NewEntityDAO(db *gorm.DB) meta.MetaEntityDAO {
+	return &entitySqlImpl{
+		Abstract:     sql.NewAbstract(db),
+		resourcesDAO: resources2.NewDAO(db),
+	}
+}
+
+func NewEntityValueDAO(db *gorm.DB) meta.MetaEntityValueDAO {
+	return &evSqlImpl{
+		Abstract:     sql.NewAbstract(db),
+		resourcesDAO: resources2.NewDAO(db),
+	}
+}
+
+type entitySqlImpl struct {
+	*sql.Abstract
+	resourcesDAO
+	// entityDAO meta.MetaEntityDAO
 }
 
 type evSqlImpl struct {
 	*sql.Abstract
-	resources.DAO
-}
-
-func (s *evSqlImpl) Migrate(ctx context.Context) error {
-	return s.Session(ctx).AutoMigrate(&Entities{}, &EntityValues{})
+	resourcesDAO
+	// entityValueDAO meta.MetaEntityValueDAO
 }
 
 func (u *Entities) AsEntity(res *idm.MetaEntity) *idm.MetaEntity {
@@ -116,7 +164,7 @@ func (u *Entities) FromEntity(res *idm.MetaEntity) *Entities {
 }
 
 // CreateEntity creates a new entity
-func (s *evSqlImpl) CreateEntity(ctx context.Context, entity *idm.MetaEntity) (*idm.MetaEntity, error) {
+func (s *entitySqlImpl) CreateEntity(ctx context.Context, entity *idm.MetaEntity) (*idm.MetaEntity, error) {
 	res := (&Entities{}).FromEntity(entity)
 	// //check if entity with the same label exists
 	// var existing Entities
@@ -135,7 +183,7 @@ func (s *evSqlImpl) CreateEntity(ctx context.Context, entity *idm.MetaEntity) (*
 }
 
 // SetEntities creates multiple entities
-func (s *evSqlImpl) SetEntities(ctx context.Context, entities []*idm.MetaEntity) ([]*idm.MetaEntity, error) {
+func (s *entitySqlImpl) SetEntities(ctx context.Context, entities []*idm.MetaEntity) ([]*idm.MetaEntity, error) {
 	createdEntities := make([]*idm.MetaEntity, 0, len(entities))
 
 	for _, entity := range entities {
@@ -150,7 +198,7 @@ func (s *evSqlImpl) SetEntities(ctx context.Context, entities []*idm.MetaEntity)
 }
 
 // GetEntity retrieves an entity by its UUID
-func (s *evSqlImpl) GetEntity(ctx context.Context, entityUuid string) (*idm.MetaEntity, error) {
+func (s *entitySqlImpl) GetEntity(ctx context.Context, entityUuid string) (*idm.MetaEntity, error) {
 	var model Entities
 	tx := s.Session(ctx).Where(&Entities{UUID: entityUuid}).First(&model)
 	if tx.Error != nil {

--- a/idm/meta/dao/sql/ev-sql.go
+++ b/idm/meta/dao/sql/ev-sql.go
@@ -97,7 +97,6 @@ func (s *evSqlImpl) MigrateEV(ctx context.Context) error {
 	return nil
 }
 
-// Move this to entitySqlImpl
 func (s *entitySqlImpl) MigrateEntity(ctx context.Context) error {
 	if err := s.Session(ctx).AutoMigrate(&Entities{}); err != nil {
 		return err
@@ -109,12 +108,12 @@ func (s *entitySqlImpl) MigrateEntity(ctx context.Context) error {
 	return nil
 }
 
-// Add explicit Migrate for entitySqlImpl to resolve ambiguity
+// Migrate Add explicit Migrate for entitySqlImpl to resolve ambiguity
 func (s *entitySqlImpl) Migrate(ctx context.Context) error {
 	return s.MigrateEntity(ctx)
 }
 
-// Add explicit Migrate for evSqlImpl to resolve ambiguity
+// Migrate Add explicit Migrate for evSqlImpl to resolve ambiguity
 func (s *evSqlImpl) Migrate(ctx context.Context) error {
 	return s.MigrateEV(ctx)
 }
@@ -136,15 +135,14 @@ func NewEntityValueDAO(db *gorm.DB) meta.EntityValueDAO {
 type entitySqlImpl struct {
 	*sql.Abstract
 	resourcesDAO
-	// entityDAO meta.MetaEntityDAO
 }
 
 type evSqlImpl struct {
 	*sql.Abstract
 	resourcesDAO
-	// entityValueDAO meta.MetaEntityValueDAO
 }
 
+// AsEntity converts an Entities model to an idm.MetaEntity
 func (u *Entities) AsEntity(res *idm.MetaEntity) *idm.MetaEntity {
 	res.Uuid = u.UUID
 	res.Label = u.Label
@@ -153,6 +151,7 @@ func (u *Entities) AsEntity(res *idm.MetaEntity) *idm.MetaEntity {
 	return res
 }
 
+// FromEntity populates an Entities model from an idm.MetaEntity
 func (u *Entities) FromEntity(res *idm.MetaEntity) *Entities {
 	if u.UUID == "" {
 		u.UUID = uuid.New().String()
@@ -211,6 +210,7 @@ func (s *entitySqlImpl) GetEntity(ctx context.Context, entityUuid string) (*idm.
 	return model.AsEntity(&idm.MetaEntity{}), nil
 }
 
+// AsEntityValue converts an EntityValues model to an idm.EntityValue
 func (u *EntityValues) AsEntityValue(res *idm.EntityValue) *idm.EntityValue {
 	res.Uuid = u.UUID
 	res.Label = u.Label
@@ -222,6 +222,7 @@ func (u *EntityValues) AsEntityValue(res *idm.EntityValue) *idm.EntityValue {
 	return res
 }
 
+// FromEntityValue populates an EntityValues model from an idm.EntityValue
 func (u *EntityValues) FromEntityValue(res *idm.EntityValue) *EntityValues {
 	u.UUID = uuid.New().String()
 	u.Label = res.Label

--- a/idm/meta/dao/sql/ev-sql.go
+++ b/idm/meta/dao/sql/ev-sql.go
@@ -42,8 +42,8 @@ var (
 )
 
 func init() {
-	meta.Drivers.Register(NewEntityDAO)
-	meta.Drivers.Register(NewEntityValueDAO)
+	meta.EntityDrivers.Register(NewEntityDAO)
+	meta.EntityValueDrivers.Register(NewEntityValueDAO)
 }
 
 func evTagError(err error) error {
@@ -119,14 +119,14 @@ func (s *evSqlImpl) Migrate(ctx context.Context) error {
 	return s.MigrateEV(ctx)
 }
 
-func NewEntityDAO(db *gorm.DB) meta.MetaEntityDAO {
+func NewEntityDAO(db *gorm.DB) meta.EntityDAO {
 	return &entitySqlImpl{
 		Abstract:     sql.NewAbstract(db),
 		resourcesDAO: resources2.NewDAO(db),
 	}
 }
 
-func NewEntityValueDAO(db *gorm.DB) meta.MetaEntityValueDAO {
+func NewEntityValueDAO(db *gorm.DB) meta.EntityValueDAO {
 	return &evSqlImpl{
 		Abstract:     sql.NewAbstract(db),
 		resourcesDAO: resources2.NewDAO(db),

--- a/idm/meta/dao/sql/ev-sql.go
+++ b/idm/meta/dao/sql/ev-sql.go
@@ -33,13 +33,18 @@ import (
 	"github.com/pydio/cells/v5/common/errors"
 	"github.com/pydio/cells/v5/common/proto/idm"
 	"github.com/pydio/cells/v5/common/storage/sql"
-	"github.com/pydio/cells/v5/common/storage/sql/resources"
+	resources2 "github.com/pydio/cells/v5/common/storage/sql/resources"
 	"github.com/pydio/cells/v5/idm/meta"
 )
 
 var (
 	EntityValueErr = errors.RegisterBaseSentinel(errors.SqlDAO, "sql entity values")
 )
+
+func init() {
+	meta.EntityDrivers.Register(NewEntityDAO)
+	meta.EntityValueDrivers.Register(NewEntityValueDAO)
+}
 
 func evTagError(err error) error {
 	return errors.Tag(err, EntityValueErr)
@@ -80,17 +85,56 @@ func (*MetaValuesRel) TableName(namer schema.Namer) string {
 	return namer.JoinTableName("meta_values_rel")
 }
 
-func NewEntityValueDAO(db *gorm.DB) meta.EntityValueDAO {
-
-	return &evSqlImpl{
-		Abstract: sql.NewAbstract(db),
-		DAO:      resources.NewDAO(db),
+func (s *evSqlImpl) MigrateEV(ctx context.Context) error {
+	db := s.Session(ctx)
+	if err := db.AutoMigrate(&EntityValues{}); err != nil {
+		return err
 	}
+
+	if err := s.resourcesDAO.Migrate(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *entitySqlImpl) MigrateEntity(ctx context.Context) error {
+	if err := s.Session(ctx).AutoMigrate(&Entities{}); err != nil {
+		return err
+	}
+
+	if err := s.resourcesDAO.Migrate(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Migrate Add explicit Migrate for entitySqlImpl to resolve ambiguity
+func (s *entitySqlImpl) Migrate(ctx context.Context) error {
+	return s.MigrateEntity(ctx)
+}
+
+func NewEntityDAO(db *gorm.DB) meta.EntityDAO {
+	return &entitySqlImpl{
+		Abstract:     sql.NewAbstract(db),
+		resourcesDAO: resources2.NewDAO(db),
+	}
+}
+
+func NewEntityValueDAO(db *gorm.DB) meta.EntityValueDAO {
+	return &evSqlImpl{
+		Abstract:     sql.NewAbstract(db),
+		resourcesDAO: resources2.NewDAO(db),
+	}
+}
+
+type entitySqlImpl struct {
+	*sql.Abstract
+	resourcesDAO
 }
 
 type evSqlImpl struct {
 	*sql.Abstract
-	resources.DAO
+	resourcesDAO
 }
 
 func (s *evSqlImpl) Migrate(ctx context.Context) error {
@@ -101,6 +145,7 @@ func (s *evSqlImpl) Migrate(ctx context.Context) error {
 	return db.AutoMigrate(&Entities{}, &EntityValues{})
 }
 
+// AsEntity converts an Entities model to an idm.MetaEntity
 func (u *Entities) AsEntity(res *idm.MetaEntity) *idm.MetaEntity {
 	res.Uuid = u.UUID
 	res.Label = u.Label
@@ -109,6 +154,7 @@ func (u *Entities) AsEntity(res *idm.MetaEntity) *idm.MetaEntity {
 	return res
 }
 
+// FromEntity populates an Entities model from an idm.MetaEntity
 func (u *Entities) FromEntity(res *idm.MetaEntity) *Entities {
 	if u.UUID == "" {
 		u.UUID = uuid.New().String()
@@ -120,26 +166,27 @@ func (u *Entities) FromEntity(res *idm.MetaEntity) *Entities {
 }
 
 // CreateEntity creates a new entity
-func (s *evSqlImpl) CreateEntity(ctx context.Context, entity *idm.MetaEntity) (*idm.MetaEntity, error) {
+func (s *entitySqlImpl) CreateEntity(ctx context.Context, entity *idm.MetaEntity) (*idm.MetaEntity, error) {
 	res := (&Entities{}).FromEntity(entity)
-	// //check if entity with the same label exists
-	// var existing Entities
-	// tx := s.Session(ctx).Where("label = ?", res.Label).First(&existing)
-	// if tx.Error == nil {
-	// 	// if a row exists with the same label
-	// 	return nil, evTagError(errors.New("entity with the same label already exists"))
-	// }
 
 	tx := s.Session(ctx).Create(res)
 	if tx.Error != nil {
 		return nil, evTagError(tx.Error)
 	}
 
-	return res.AsEntity(&idm.MetaEntity{}), nil
+	out := res.AsEntity(&idm.MetaEntity{})
+	if len(entity.Policies) > 0 {
+		if pols, err := s.AddPolicies(ctx, false, out.Uuid, entity.Policies); err != nil {
+			return nil, evTagError(err)
+		} else {
+			out.Policies = pols
+		}
+	}
+	return out, nil
 }
 
 // SetEntities creates multiple entities
-func (s *evSqlImpl) SetEntities(ctx context.Context, entities []*idm.MetaEntity) ([]*idm.MetaEntity, error) {
+func (s *entitySqlImpl) SetEntities(ctx context.Context, entities []*idm.MetaEntity) ([]*idm.MetaEntity, error) {
 	createdEntities := make([]*idm.MetaEntity, 0, len(entities))
 
 	for _, entity := range entities {
@@ -154,7 +201,7 @@ func (s *evSqlImpl) SetEntities(ctx context.Context, entities []*idm.MetaEntity)
 }
 
 // GetEntity retrieves an entity by its UUID
-func (s *evSqlImpl) GetEntity(ctx context.Context, entityUuid string) (*idm.MetaEntity, error) {
+func (s *entitySqlImpl) GetEntity(ctx context.Context, entityUuid string) (*idm.MetaEntity, error) {
 	var model Entities
 	tx := s.Session(ctx).Where(&Entities{UUID: entityUuid}).First(&model)
 	if tx.Error != nil {
@@ -164,9 +211,33 @@ func (s *evSqlImpl) GetEntity(ctx context.Context, entityUuid string) (*idm.Meta
 		return nil, evTagError(tx.Error)
 	}
 
-	return model.AsEntity(&idm.MetaEntity{}), nil
+	out := model.AsEntity(&idm.MetaEntity{})
+	if pols, err := s.GetPoliciesForResource(ctx, out.Uuid); err == nil {
+		out.Policies = pols
+	}
+	return out, nil
 }
 
+// ListEntities retrieves all entities
+func (s *entitySqlImpl) ListEntities(ctx context.Context) ([]*idm.MetaEntity, error) {
+	var models []*Entities
+	tx := s.Session(ctx).Find(&models)
+	if tx.Error != nil {
+		return nil, evTagError(tx.Error)
+	}
+
+	entities := make([]*idm.MetaEntity, 0, len(models))
+	for _, model := range models {
+		out := model.AsEntity(&idm.MetaEntity{})
+		if pols, err := s.GetPoliciesForResource(ctx, out.Uuid); err == nil {
+			out.Policies = pols
+		}
+		entities = append(entities, out)
+	}
+	return entities, nil
+}
+
+// AsEntityValue converts an EntityValues model to an idm.EntityValue
 func (u *EntityValues) AsEntityValue(res *idm.EntityValue) *idm.EntityValue {
 	res.Uuid = u.UUID
 	res.Label = u.Label
@@ -178,8 +249,13 @@ func (u *EntityValues) AsEntityValue(res *idm.EntityValue) *idm.EntityValue {
 	return res
 }
 
+// FromEntityValue populates an EntityValues model from an idm.EntityValue
 func (u *EntityValues) FromEntityValue(res *idm.EntityValue) *EntityValues {
-	u.UUID = uuid.New().String()
+	if res.Uuid != "" {
+		u.UUID = res.Uuid
+	} else {
+		u.UUID = uuid.New().String()
+	}
 	u.Label = res.Label
 	u.EntityUUID = res.EntityUuid
 	if res.DisplayJSON != "" {
@@ -192,13 +268,41 @@ func (u *EntityValues) FromEntityValue(res *idm.EntityValue) *EntityValues {
 
 // CreateEntityValue creates a new entity value and links it to its entity
 func (s *evSqlImpl) CreateEntityValue(ctx context.Context, value *idm.EntityValue) (*idm.EntityValue, error) {
-	// Check if already exists
+	// Check if already exists by UUID first (if UUID is provided)
 	var existing EntityValues
-	tx := s.Session(ctx).Where("label = ? AND entity_uuid = ?", value.Label, value.EntityUuid).First(&existing)
+	var tx *gorm.DB
+
+	if value.Uuid != "" {
+		// UUID provided, check by UUID
+		tx = s.Session(ctx).Where("uuid = ?", value.Uuid).First(&existing)
+	} else {
+		// No UUID, check by label + entity_uuid
+		tx = s.Session(ctx).Where("label = ? AND entity_uuid = ?", value.Label, value.EntityUuid).First(&existing)
+	}
 
 	if tx.Error == nil {
-		// Found existing, return it
-		return existing.AsEntityValue(&idm.EntityValue{}), nil
+		// Found existing, update it rather than creating a new one
+		if value.Label != "" {
+			existing.Label = value.Label
+		}
+		if value.DisplayJSON != "" {
+			j := datatypes.JSON(value.DisplayJSON)
+			existing.DisplayJSON = &j
+		}
+		tx = s.Session(ctx).Model(&existing).Updates(existing)
+		if tx.Error != nil {
+			return nil, evTagError(tx.Error)
+		}
+
+		out := existing.AsEntityValue(&idm.EntityValue{})
+		if len(value.Policies) > 0 {
+			if pols, err := s.AddPolicies(ctx, false, out.Uuid, value.Policies); err != nil {
+				return nil, evTagError(err)
+			} else {
+				out.Policies = pols
+			}
+		}
+		return out, nil
 	}
 
 	// Return error only if it's not "record not found"
@@ -215,7 +319,15 @@ func (s *evSqlImpl) CreateEntityValue(ctx context.Context, value *idm.EntityValu
 		return nil, evTagError(tx.Error)
 	}
 
-	return model.AsEntityValue(&idm.EntityValue{}), nil
+	out := model.AsEntityValue(&idm.EntityValue{})
+	if len(value.Policies) > 0 {
+		if pols, err := s.AddPolicies(ctx, false, out.Uuid, value.Policies); err != nil {
+			return nil, evTagError(err)
+		} else {
+			out.Policies = pols
+		}
+	}
+	return out, nil
 }
 
 // CreateEntityValues creates multiple entity values
@@ -316,33 +428,55 @@ func (s *evSqlImpl) GetMetaEntityValues(ctx context.Context, metaUuid string) ([
 }
 
 // DeleteEntity deletes an entity and all its values, as well as the links between those values and any meta
-func (s *evSqlImpl) DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
-	if err := s.validateUUIDs(entityID); err != nil {
-		return nil, err
+func (s *entitySqlImpl) DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityResponse, error) {
+
+	// Validate UUID format
+	if entityID == "" {
+		return nil, evTagError(errors.New("entity uuid cannot be empty"))
+	}
+	if _, err := uuid.Parse(entityID); err != nil {
+		return nil, evTagError(errors.New("invalid entity uuid: " + entityID))
 	}
 
+	// Delete related MetaValuesRel entries (cascade)
 	subQuery := s.Session(ctx).Model(&EntityValues{}).Select("uuid").Where("entity_uuid = ?", entityID)
-
 	tx := s.Session(ctx).Where("e_value_uuid IN (?)", subQuery).Delete(&MetaValuesRel{})
 	if tx.Error != nil {
 		return nil, evTagError(tx.Error)
 	}
 
-	EntityValuesModel := &EntityValues{}
-	tx = s.Session(ctx).Where(&EntityValues{EntityUUID: entityID}).Delete(EntityValuesModel)
+	// Delete all entity values for this entity (cascade)
+	tx = s.Session(ctx).Model(&EntityValues{}).Where(&EntityValues{EntityUUID: entityID}).Delete(&EntityValues{})
 	if tx.Error != nil {
 		return nil, evTagError(tx.Error)
 	}
 
+	// Delete policies for the entity
+	if err := s.DeletePoliciesForResource(ctx, entityID); err != nil {
+		return nil, evTagError(err)
+	}
+
+	// Delete the entity itself - only count this for RowsDeleted
 	EntitiesModel := &Entities{}
 	tx = s.Session(ctx).Where(&Entities{UUID: entityID}).Delete(EntitiesModel)
 	if tx.Error != nil {
 		return nil, evTagError(tx.Error)
 	}
 
-	return &idm.DeleteEntityValuesResponse{
+	return &idm.DeleteEntityResponse{
 		RowsDeleted: tx.RowsAffected,
 	}, nil
+}
+
+func (s *evSqlImpl) DeleteEntityValues(ctx context.Context, entityID string) (bool, error) {
+	tx := s.Session(ctx).Model(&EntityValues{}).Where(&EntityValues{EntityUUID: entityID}).Delete(&EntityValues{})
+	if tx.Error != nil {
+		return false, evTagError(tx.Error)
+	}
+	if tx.RowsAffected > 0 {
+		return true, nil
+	}
+	return false, nil
 }
 
 // GetMetaEntityValuesMap retrieves a map of meta UUIDs to their linked entity values for a given list of meta UUIDs

--- a/idm/meta/dao/sql/ev-sql.go
+++ b/idm/meta/dao/sql/ev-sql.go
@@ -165,20 +165,21 @@ func (u *Entities) FromEntity(res *idm.MetaEntity) *Entities {
 // CreateEntity creates a new entity
 func (s *entitySqlImpl) CreateEntity(ctx context.Context, entity *idm.MetaEntity) (*idm.MetaEntity, error) {
 	res := (&Entities{}).FromEntity(entity)
-	// //check if entity with the same label exists
-	// var existing Entities
-	// tx := s.Session(ctx).Where("label = ?", res.Label).First(&existing)
-	// if tx.Error == nil {
-	// 	// if a row exists with the same label
-	// 	return nil, evTagError(errors.New("entity with the same label already exists"))
-	// }
 
 	tx := s.Session(ctx).Create(res)
 	if tx.Error != nil {
 		return nil, evTagError(tx.Error)
 	}
 
-	return res.AsEntity(&idm.MetaEntity{}), nil
+	out := res.AsEntity(&idm.MetaEntity{})
+	if len(entity.Policies) > 0 {
+		if pols, err := s.AddPolicies(ctx, false, out.Uuid, entity.Policies); err != nil {
+			return nil, evTagError(err)
+		} else {
+			out.Policies = pols
+		}
+	}
+	return out, nil
 }
 
 // SetEntities creates multiple entities
@@ -207,7 +208,30 @@ func (s *entitySqlImpl) GetEntity(ctx context.Context, entityUuid string) (*idm.
 		return nil, evTagError(tx.Error)
 	}
 
-	return model.AsEntity(&idm.MetaEntity{}), nil
+	out := model.AsEntity(&idm.MetaEntity{})
+	if pols, err := s.GetPoliciesForResource(ctx, out.Uuid); err == nil {
+		out.Policies = pols
+	}
+	return out, nil
+}
+
+// ListEntities retrieves all entities
+func (s *entitySqlImpl) ListEntities(ctx context.Context) ([]*idm.MetaEntity, error) {
+	var models []*Entities
+	tx := s.Session(ctx).Find(&models)
+	if tx.Error != nil {
+		return nil, evTagError(tx.Error)
+	}
+
+	entities := make([]*idm.MetaEntity, 0, len(models))
+	for _, model := range models {
+		out := model.AsEntity(&idm.MetaEntity{})
+		if pols, err := s.GetPoliciesForResource(ctx, out.Uuid); err == nil {
+			out.Policies = pols
+		}
+		entities = append(entities, out)
+	}
+	return entities, nil
 }
 
 // AsEntityValue converts an EntityValues model to an idm.EntityValue
@@ -224,7 +248,11 @@ func (u *EntityValues) AsEntityValue(res *idm.EntityValue) *idm.EntityValue {
 
 // FromEntityValue populates an EntityValues model from an idm.EntityValue
 func (u *EntityValues) FromEntityValue(res *idm.EntityValue) *EntityValues {
-	u.UUID = uuid.New().String()
+	if res.Uuid != "" {
+		u.UUID = res.Uuid
+	} else {
+		u.UUID = uuid.New().String()
+	}
 	u.Label = res.Label
 	u.EntityUUID = res.EntityUuid
 	if res.DisplayJSON != "" {
@@ -237,13 +265,41 @@ func (u *EntityValues) FromEntityValue(res *idm.EntityValue) *EntityValues {
 
 // CreateEntityValue creates a new entity value and links it to its entity
 func (s *evSqlImpl) CreateEntityValue(ctx context.Context, value *idm.EntityValue) (*idm.EntityValue, error) {
-	// Check if already exists
+	// Check if already exists by UUID first (if UUID is provided)
 	var existing EntityValues
-	tx := s.Session(ctx).Where("label = ? AND entity_uuid = ?", value.Label, value.EntityUuid).First(&existing)
+	var tx *gorm.DB
+
+	if value.Uuid != "" {
+		// UUID provided, check by UUID
+		tx = s.Session(ctx).Where("uuid = ?", value.Uuid).First(&existing)
+	} else {
+		// No UUID, check by label + entity_uuid
+		tx = s.Session(ctx).Where("label = ? AND entity_uuid = ?", value.Label, value.EntityUuid).First(&existing)
+	}
 
 	if tx.Error == nil {
-		// Found existing, return it
-		return existing.AsEntityValue(&idm.EntityValue{}), nil
+		// Found existing, update it rather than creating a new one
+		if value.Label != "" {
+			existing.Label = value.Label
+		}
+		if value.DisplayJSON != "" {
+			j := datatypes.JSON(value.DisplayJSON)
+			existing.DisplayJSON = &j
+		}
+		tx = s.Session(ctx).Model(&existing).Updates(existing)
+		if tx.Error != nil {
+			return nil, evTagError(tx.Error)
+		}
+
+		out := existing.AsEntityValue(&idm.EntityValue{})
+		if len(value.Policies) > 0 {
+			if pols, err := s.AddPolicies(ctx, false, out.Uuid, value.Policies); err != nil {
+				return nil, evTagError(err)
+			} else {
+				out.Policies = pols
+			}
+		}
+		return out, nil
 	}
 
 	// Return error only if it's not "record not found"
@@ -260,7 +316,15 @@ func (s *evSqlImpl) CreateEntityValue(ctx context.Context, value *idm.EntityValu
 		return nil, evTagError(tx.Error)
 	}
 
-	return model.AsEntityValue(&idm.EntityValue{}), nil
+	out := model.AsEntityValue(&idm.EntityValue{})
+	if len(value.Policies) > 0 {
+		if pols, err := s.AddPolicies(ctx, false, out.Uuid, value.Policies); err != nil {
+			return nil, evTagError(err)
+		} else {
+			out.Policies = pols
+		}
+	}
+	return out, nil
 }
 
 // CreateEntityValues creates multiple entity values
@@ -361,33 +425,55 @@ func (s *evSqlImpl) GetMetaEntityValues(ctx context.Context, metaUuid string) ([
 }
 
 // DeleteEntity deletes an entity and all its values, as well as the links between those values and any meta
-func (s *evSqlImpl) DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityValuesResponse, error) {
-	if err := s.validateUUIDs(entityID); err != nil {
-		return nil, err
+func (s *entitySqlImpl) DeleteEntity(ctx context.Context, entityID string) (*idm.DeleteEntityResponse, error) {
+
+	// Validate UUID format
+	if entityID == "" {
+		return nil, evTagError(errors.New("entity uuid cannot be empty"))
+	}
+	if _, err := uuid.Parse(entityID); err != nil {
+		return nil, evTagError(errors.New("invalid entity uuid: " + entityID))
 	}
 
+	// Delete related MetaValuesRel entries (cascade)
 	subQuery := s.Session(ctx).Model(&EntityValues{}).Select("uuid").Where("entity_uuid = ?", entityID)
-
 	tx := s.Session(ctx).Where("e_value_uuid IN (?)", subQuery).Delete(&MetaValuesRel{})
 	if tx.Error != nil {
 		return nil, evTagError(tx.Error)
 	}
 
-	EntityValuesModel := &EntityValues{}
-	tx = s.Session(ctx).Where(&EntityValues{EntityUUID: entityID}).Delete(EntityValuesModel)
+	// Delete all entity values for this entity (cascade)
+	tx = s.Session(ctx).Model(&EntityValues{}).Where(&EntityValues{EntityUUID: entityID}).Delete(&EntityValues{})
 	if tx.Error != nil {
 		return nil, evTagError(tx.Error)
 	}
 
+	// Delete policies for the entity
+	if err := s.DeletePoliciesForResource(ctx, entityID); err != nil {
+		return nil, evTagError(err)
+	}
+
+	// Delete the entity itself - only count this for RowsDeleted
 	EntitiesModel := &Entities{}
 	tx = s.Session(ctx).Where(&Entities{UUID: entityID}).Delete(EntitiesModel)
 	if tx.Error != nil {
 		return nil, evTagError(tx.Error)
 	}
 
-	return &idm.DeleteEntityValuesResponse{
+	return &idm.DeleteEntityResponse{
 		RowsDeleted: tx.RowsAffected,
 	}, nil
+}
+
+func (s *evSqlImpl) DeleteEntityValues(ctx context.Context, entityID string) (bool, error) {
+	tx := s.Session(ctx).Model(&EntityValues{}).Where(&EntityValues{EntityUUID: entityID}).Delete(&EntityValues{})
+	if tx.Error != nil {
+		return false, evTagError(tx.Error)
+	}
+	if tx.RowsAffected > 0 {
+		return true, nil
+	}
+	return false, nil
 }
 
 // GetMetaEntityValuesMap retrieves a map of meta UUIDs to their linked entity values for a given list of meta UUIDs

--- a/idm/meta/dao/sql/ev-sql.go
+++ b/idm/meta/dao/sql/ev-sql.go
@@ -77,8 +77,8 @@ func (*EntityValues) TableName(namer schema.Namer) string {
 }
 
 type MetaValuesRel struct {
-	MetaUUID   string `gorm:"primaryKey;column:meta_uuid;type:varchar(255);notNull"`
-	EValueUUID string `gorm:"primaryKey;column:e_value_uuid;type:varchar(255);notNull"`
+	MetaUUID   string `gorm:"primaryKey;column:meta_uuid;type:varchar(255);notNull;index:idx_meta_evalue,composite:meta_evalue"`
+	EValueUUID string `gorm:"primaryKey;column:e_value_uuid;type:varchar(255);notNull;index:idx_meta_evalue,composite:meta_evalue"`
 }
 
 func (*MetaValuesRel) TableName(namer schema.Namer) string {

--- a/idm/meta/dao/sql/ev-sql_test.go
+++ b/idm/meta/dao/sql/ev-sql_test.go
@@ -121,6 +121,24 @@ func TestEntityCrud(t *testing.T) {
 				So(e.Label, ShouldEqual, entities[i].Label)
 			}
 		})
+
+		Convey("List Entities", t, func() {
+			_, err := entityDAO.CreateEntity(ctx, &idm.MetaEntity{Label: "List 1", Description: "Desc 1"})
+			So(err, ShouldBeNil)
+
+			_, err = entityDAO.CreateEntity(ctx, &idm.MetaEntity{Label: "List 2", Description: "Desc 2"})
+			So(err, ShouldBeNil)
+
+			list, err := entityDAO.ListEntities(ctx)
+			So(err, ShouldBeNil)
+			So(len(list), ShouldBeGreaterThanOrEqualTo, 2)
+		})
+
+		Convey("Get Non-existent Entity Returns Nil", t, func() {
+			retrieved, err := entityDAO.GetEntity(ctx, "00000000-0000-0000-0000-000000000000")
+			So(err, ShouldBeNil)
+			So(retrieved, ShouldBeNil)
+		})
 	})
 }
 
@@ -159,6 +177,86 @@ func TestEntityValueCrud(t *testing.T) {
 			values, err := evDAO.GetEntityValues(ctx, createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(values, ShouldHaveLength, 2)
+		})
+
+		Convey("Create Entity Value with DisplayJSON", t, func() {
+			createdEntity, err := createTestEntity(ctx, entityDAO, "Display JSON Entity")
+			So(err, ShouldBeNil)
+
+			value := &idm.EntityValue{
+				Label:       "JSON Value",
+				EntityUuid:  createdEntity.Uuid,
+				DisplayJSON: `{"color":"red","icon":"star"}`,
+			}
+
+			created, err := evDAO.CreateEntityValue(ctx, value)
+			So(err, ShouldBeNil)
+			So(created.DisplayJSON, ShouldEqual, value.DisplayJSON)
+		})
+
+		Convey("Update Entity Value When Duplicate Label", t, func() {
+			createdEntity, err := createTestEntity(ctx, entityDAO, "Update Entity")
+			So(err, ShouldBeNil)
+
+			value1 := &idm.EntityValue{
+				Label:       "Duplicate Label",
+				EntityUuid:  createdEntity.Uuid,
+				DisplayJSON: `{"version":"1"}`,
+			}
+
+			created, err := evDAO.CreateEntityValue(ctx, value1)
+			So(err, ShouldBeNil)
+			originalUuid := created.Uuid
+
+			// Try creating with same label - should update
+			value2 := &idm.EntityValue{
+				Label:       "Duplicate Label",
+				EntityUuid:  createdEntity.Uuid,
+				DisplayJSON: `{"version":"2"}`,
+			}
+
+			updated, err := evDAO.CreateEntityValue(ctx, value2)
+			So(err, ShouldBeNil)
+			So(updated.Uuid, ShouldEqual, originalUuid)
+			So(updated.DisplayJSON, ShouldEqual, `{"version":"2"}`)
+
+			// Verify only one value exists
+			values, err := evDAO.GetEntityValues(ctx, createdEntity.Uuid)
+			So(err, ShouldBeNil)
+			So(values, ShouldHaveLength, 1)
+		})
+
+		Convey("Update Entity Value When UUID Provided", t, func() {
+			createdEntity, err := createTestEntity(ctx, entityDAO, "UUID Update Entity")
+			So(err, ShouldBeNil)
+
+			value1 := &idm.EntityValue{
+				Label:      "Original",
+				EntityUuid: createdEntity.Uuid,
+			}
+
+			created, err := evDAO.CreateEntityValue(ctx, value1)
+			So(err, ShouldBeNil)
+
+			// Update by providing the UUID
+			value2 := &idm.EntityValue{
+				Uuid:        created.Uuid,
+				Label:       "Updated",
+				EntityUuid:  createdEntity.Uuid,
+				DisplayJSON: `{"updated":true}`,
+			}
+
+			updated, err := evDAO.CreateEntityValue(ctx, value2)
+			So(err, ShouldBeNil)
+			So(updated.Uuid, ShouldEqual, created.Uuid)
+			So(updated.Label, ShouldEqual, "Updated")
+			So(updated.DisplayJSON, ShouldEqual, `{"updated":true}`)
+		})
+
+		Convey("Get Entity Values Returns Empty For Non-existent Entity", t, func() {
+			values, err := evDAO.GetEntityValues(ctx, "00000000-0000-0000-0000-000000000000")
+			So(err, ShouldBeNil)
+			So(values, ShouldHaveLength, 0)
 		})
 	})
 }
@@ -345,7 +443,7 @@ func TestDeleteOperations(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(linkedValuesBefore, ShouldHaveLength, 2)
 
-			deleteResp, err := evDAO.DeleteEntity(ctx, createdEntity.Uuid)
+			deleteResp, err := eDAO.DeleteEntity(ctx, createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(deleteResp, ShouldNotBeNil)
 			So(deleteResp.RowsDeleted, ShouldEqual, 1)
@@ -364,14 +462,14 @@ func TestDeleteOperations(t *testing.T) {
 		})
 
 		Convey("Delete Non-existent Entity", t, func() {
-			deleteResp, err := evDAO.DeleteEntity(ctx, "00000000-0000-0000-0000-000000000000")
+			deleteResp, err := eDAO.DeleteEntity(ctx, "00000000-0000-0000-0000-000000000000")
 			So(err, ShouldBeNil)
 			So(deleteResp, ShouldNotBeNil)
 			So(deleteResp.RowsDeleted, ShouldEqual, 0)
 		})
 
 		Convey("Delete Entity with Invalid UUID", t, func() {
-			_, err := evDAO.DeleteEntity(ctx, "invalid-uuid")
+			_, err := eDAO.DeleteEntity(ctx, "invalid-uuid")
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -403,6 +501,12 @@ func TestValidation(t *testing.T) {
 
 			_, err = evDAO.UnlinkMetaValue(ctx, "00000000-0000-0000-0000-000000000000", "invalid-uuid")
 			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Unlink Non-existent Link Returns False", t, func() {
+			unlinked, err := evDAO.UnlinkMetaValue(ctx, "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002")
+			So(err, ShouldBeNil)
+			So(unlinked, ShouldBeFalse)
 		})
 	})
 }

--- a/idm/meta/dao/sql/ev-sql_test.go
+++ b/idm/meta/dao/sql/ev-sql_test.go
@@ -35,7 +35,9 @@ import (
 )
 
 var (
-	evTestcases = test.TemplateSQL(NewDAO)
+	mainTestcases = test.TemplateSQL(NewDAO)            // Main meta DAO
+	eTestcases    = test.TemplateSQL(NewEntityDAO)      // Entity DAO
+	evTestcases   = test.TemplateSQL(NewEntityValueDAO) // Entity value DAO
 )
 
 // Test fixtures
@@ -52,24 +54,20 @@ var (
 )
 
 // Helper functions
-func createTestEntity(ctx context.Context, mockDAO meta.EntityValueDAO, label string) (*idm.MetaEntity, error) {
+func createTestEntity(ctx context.Context, dao meta.EntityDAO, label string) (*idm.MetaEntity, error) {
 	entity := &idm.MetaEntity{Label: label}
-	return mockDAO.CreateEntity(ctx, entity)
+	return dao.CreateEntity(ctx, entity)
 }
 
-func createTestEntityValue(ctx context.Context, mockDAO meta.EntityValueDAO, label, entityUuid string) (*idm.EntityValue, error) {
+func createTestEntityValue(ctx context.Context, dao meta.EntityValueDAO, label, entityUuid string) (*idm.EntityValue, error) {
 	value := &idm.EntityValue{
 		Label:      label,
 		EntityUuid: entityUuid,
 	}
-	return mockDAO.CreateEntityValue(ctx, value)
+	return dao.CreateEntityValue(ctx, value)
 }
 
-func createTestMeta(ctx context.Context, nodeUuid, namespace string) (*idm.UserMeta, error) {
-	metaDAO, err := manager.Resolve[meta.DAO](ctx)
-	if err != nil {
-		return nil, err
-	}
+func createTestMeta(ctx context.Context, metaDAO meta.DAO, nodeUuid, namespace string) (*idm.UserMeta, error) {
 	metaWithId, _, err := metaDAO.Set(ctx, &idm.UserMeta{
 		NodeUuid:  nodeUuid,
 		Namespace: namespace,
@@ -79,15 +77,17 @@ func createTestMeta(ctx context.Context, nodeUuid, namespace string) (*idm.UserM
 }
 
 func TestEntityCrud(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
+		sqlDAO := mockDAO.(*sqlimpl)
+		entityDAO := sqlDAO.entityDAO
+		// evDAO := sqlDAO.entityValueDAO
 
 		Convey("Create Entity", t, func() {
-			created, err := mockDAO.CreateEntity(ctx, fixtureEntityCity)
+			created, err := entityDAO.CreateEntity(ctx, fixtureEntityCity)
 			So(err, ShouldBeNil)
 			So(created, ShouldNotBeNil)
 			So(created.Uuid, ShouldNotBeEmpty)
@@ -96,10 +96,10 @@ func TestEntityCrud(t *testing.T) {
 		})
 
 		Convey("Get Entity", t, func() {
-			created, err := mockDAO.CreateEntity(ctx, fixtureEntitySimple)
+			created, err := entityDAO.CreateEntity(ctx, fixtureEntitySimple)
 			So(err, ShouldBeNil)
 
-			retrieved, err := mockDAO.GetEntity(ctx, created.Uuid)
+			retrieved, err := entityDAO.GetEntity(ctx, created.Uuid)
 			So(err, ShouldBeNil)
 			So(retrieved, ShouldNotBeNil)
 			So(retrieved.Uuid, ShouldEqual, created.Uuid)
@@ -113,7 +113,7 @@ func TestEntityCrud(t *testing.T) {
 				{Label: "Entity 3", Description: "Description 3"},
 			}
 
-			created, err := mockDAO.SetEntities(ctx, entities)
+			created, err := entityDAO.SetEntities(ctx, entities)
 			So(err, ShouldBeNil)
 			So(created, ShouldHaveLength, 3)
 			for i, e := range created {
@@ -121,22 +121,42 @@ func TestEntityCrud(t *testing.T) {
 				So(e.Label, ShouldEqual, entities[i].Label)
 			}
 		})
+
+		Convey("List Entities", t, func() {
+			_, err := entityDAO.CreateEntity(ctx, &idm.MetaEntity{Label: "List 1", Description: "Desc 1"})
+			So(err, ShouldBeNil)
+
+			_, err = entityDAO.CreateEntity(ctx, &idm.MetaEntity{Label: "List 2", Description: "Desc 2"})
+			So(err, ShouldBeNil)
+
+			list, err := entityDAO.ListEntities(ctx)
+			So(err, ShouldBeNil)
+			So(len(list), ShouldBeGreaterThanOrEqualTo, 2)
+		})
+
+		Convey("Get Non-existent Entity Returns Nil", t, func() {
+			retrieved, err := entityDAO.GetEntity(ctx, "00000000-0000-0000-0000-000000000000")
+			So(err, ShouldBeNil)
+			So(retrieved, ShouldBeNil)
+		})
 	})
 }
 
 func TestEntityValueCrud(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
+		sqlDAO := mockDAO.(*sqlimpl)
+		entityDAO := sqlDAO.entityDAO
+		evDAO := sqlDAO.entityValueDAO
 
 		Convey("Create Entity Value", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Test Entity")
+			createdEntity, err := createTestEntity(ctx, entityDAO, "Test Entity")
 			So(err, ShouldBeNil)
 
-			created, err := createTestEntityValue(ctx, mockDAO, "Test Value", createdEntity.Uuid)
+			created, err := createTestEntityValue(ctx, evDAO, "Test Value", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(created, ShouldNotBeNil)
 			So(created.Uuid, ShouldNotBeEmpty)
@@ -145,118 +165,201 @@ func TestEntityValueCrud(t *testing.T) {
 		})
 
 		Convey("Get Entity Values", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Test Entity")
+			createdEntity, err := createTestEntity(ctx, entityDAO, "Test Entity")
 			So(err, ShouldBeNil)
 
-			_, err = createTestEntityValue(ctx, mockDAO, "Value 1", createdEntity.Uuid)
+			_, err = createTestEntityValue(ctx, evDAO, "Value 1", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			_, err = createTestEntityValue(ctx, mockDAO, "Value 2", createdEntity.Uuid)
+			_, err = createTestEntityValue(ctx, evDAO, "Value 2", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			values, err := mockDAO.GetEntityValues(ctx, createdEntity.Uuid)
+			values, err := evDAO.GetEntityValues(ctx, createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(values, ShouldHaveLength, 2)
+		})
+
+		Convey("Create Entity Value with DisplayJSON", t, func() {
+			createdEntity, err := createTestEntity(ctx, entityDAO, "Display JSON Entity")
+			So(err, ShouldBeNil)
+
+			value := &idm.EntityValue{
+				Label:       "JSON Value",
+				EntityUuid:  createdEntity.Uuid,
+				DisplayJSON: `{"color":"red","icon":"star"}`,
+			}
+
+			created, err := evDAO.CreateEntityValue(ctx, value)
+			So(err, ShouldBeNil)
+			So(created.DisplayJSON, ShouldEqual, value.DisplayJSON)
+		})
+
+		Convey("Update Entity Value When Duplicate Label", t, func() {
+			createdEntity, err := createTestEntity(ctx, entityDAO, "Update Entity")
+			So(err, ShouldBeNil)
+
+			value1 := &idm.EntityValue{
+				Label:       "Duplicate Label",
+				EntityUuid:  createdEntity.Uuid,
+				DisplayJSON: `{"version":"1"}`,
+			}
+
+			created, err := evDAO.CreateEntityValue(ctx, value1)
+			So(err, ShouldBeNil)
+			originalUuid := created.Uuid
+
+			// Try creating with same label - should update
+			value2 := &idm.EntityValue{
+				Label:       "Duplicate Label",
+				EntityUuid:  createdEntity.Uuid,
+				DisplayJSON: `{"version":"2"}`,
+			}
+
+			updated, err := evDAO.CreateEntityValue(ctx, value2)
+			So(err, ShouldBeNil)
+			So(updated.Uuid, ShouldEqual, originalUuid)
+			So(updated.DisplayJSON, ShouldEqual, `{"version":"2"}`)
+
+			// Verify only one value exists
+			values, err := evDAO.GetEntityValues(ctx, createdEntity.Uuid)
+			So(err, ShouldBeNil)
+			So(values, ShouldHaveLength, 1)
+		})
+
+		Convey("Update Entity Value When UUID Provided", t, func() {
+			createdEntity, err := createTestEntity(ctx, entityDAO, "UUID Update Entity")
+			So(err, ShouldBeNil)
+
+			value1 := &idm.EntityValue{
+				Label:      "Original",
+				EntityUuid: createdEntity.Uuid,
+			}
+
+			created, err := evDAO.CreateEntityValue(ctx, value1)
+			So(err, ShouldBeNil)
+
+			// Update by providing the UUID
+			value2 := &idm.EntityValue{
+				Uuid:        created.Uuid,
+				Label:       "Updated",
+				EntityUuid:  createdEntity.Uuid,
+				DisplayJSON: `{"updated":true}`,
+			}
+
+			updated, err := evDAO.CreateEntityValue(ctx, value2)
+			So(err, ShouldBeNil)
+			So(updated.Uuid, ShouldEqual, created.Uuid)
+			So(updated.Label, ShouldEqual, "Updated")
+			So(updated.DisplayJSON, ShouldEqual, `{"updated":true}`)
+		})
+
+		Convey("Get Entity Values Returns Empty For Non-existent Entity", t, func() {
+			values, err := evDAO.GetEntityValues(ctx, "00000000-0000-0000-0000-000000000000")
+			So(err, ShouldBeNil)
+			So(values, ShouldHaveLength, 0)
 		})
 	})
 }
 
 func TestMetaValueLinking(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
+
+		sqlDAO := mockDAO.(*sqlimpl)
+		eDAO := sqlDAO.entityDAO
+		evDAO := sqlDAO.entityValueDAO
 
 		Convey("Link Meta to Values", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Link Entity")
+			createdEntity, err := createTestEntity(ctx, eDAO, "Link Entity")
 			So(err, ShouldBeNil)
 
-			value1, err := createTestEntityValue(ctx, mockDAO, "Value 1", createdEntity.Uuid)
+			value1, err := createTestEntityValue(ctx, evDAO, "Value 1", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			value2, err := createTestEntityValue(ctx, mockDAO, "Value 2", createdEntity.Uuid)
+			value2, err := createTestEntityValue(ctx, evDAO, "Value 2", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			metaWithId, err := createTestMeta(ctx, "test-node", "test-namespace")
+			metaWithId, err := createTestMeta(ctx, mockDAO, "test-node", "test-namespace")
 			So(err, ShouldBeNil)
 
-			linked, err := mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value1.Uuid)
-			So(err, ShouldBeNil)
-			So(linked, ShouldBeTrue)
-
-			linked, err = mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value2.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value1.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
-			linkedValues, err := mockDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
+			linked, err = evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value2.Uuid)
+			So(err, ShouldBeNil)
+			So(linked, ShouldBeTrue)
+
+			linkedValues, err := evDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
 			So(err, ShouldBeNil)
 			So(linkedValues, ShouldHaveLength, 2)
 		})
 
 		Convey("Get Meta Entity Values", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Get Entity")
+			createdEntity, err := createTestEntity(ctx, eDAO, "Get Entity")
 			So(err, ShouldBeNil)
 
-			value, err := createTestEntityValue(ctx, mockDAO, "Test Value", createdEntity.Uuid)
+			value, err := createTestEntityValue(ctx, evDAO, "Test Value", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			metaWithId, err := createTestMeta(ctx, "test-node-get", "test-namespace")
+			metaWithId, err := createTestMeta(ctx, mockDAO, "test-node-get", "test-namespace")
 			So(err, ShouldBeNil)
 
-			linked, err := mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
-			values, err := mockDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
+			values, err := evDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
 			So(err, ShouldBeNil)
 			So(values, ShouldHaveLength, 1)
 			So(values[0].Label, ShouldEqual, "Test Value")
 		})
 
 		Convey("Unlink Meta Value", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Unlink Entity")
+			createdEntity, err := createTestEntity(ctx, eDAO, "Unlink Entity")
 			So(err, ShouldBeNil)
 
-			value, err := createTestEntityValue(ctx, mockDAO, "Unlink Value", createdEntity.Uuid)
+			value, err := createTestEntityValue(ctx, evDAO, "Unlink Value", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			metaWithId, err := createTestMeta(ctx, "test-node-unlink", "test-namespace")
+			metaWithId, err := createTestMeta(ctx, mockDAO, "test-node-unlink", "test-namespace")
 			So(err, ShouldBeNil)
 
-			linked, err := mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
-			values, err := mockDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
+			values, err := evDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
 			So(err, ShouldBeNil)
 			So(values, ShouldHaveLength, 1)
 
-			unlinked, err := mockDAO.UnlinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
+			unlinked, err := evDAO.UnlinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
 			So(err, ShouldBeNil)
 			So(unlinked, ShouldBeTrue)
 
-			values, err = mockDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
+			values, err = evDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
 			So(err, ShouldBeNil)
 			So(values, ShouldHaveLength, 0)
 		})
 
 		Convey("Link Duplicate Meta Value Returns False", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Duplicate Entity")
+			createdEntity, err := createTestEntity(ctx, eDAO, "Duplicate Entity")
 			So(err, ShouldBeNil)
 
-			value, err := createTestEntityValue(ctx, mockDAO, "Duplicate Value", createdEntity.Uuid)
+			value, err := createTestEntityValue(ctx, evDAO, "Duplicate Value", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			metaWithId, err := createTestMeta(ctx, "test-node-duplicate", "test-namespace")
+			metaWithId, err := createTestMeta(ctx, mockDAO, "test-node-duplicate", "test-namespace")
 			So(err, ShouldBeNil)
 
-			linked, err := mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
-			linked, err = mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
+			linked, err = evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeFalse)
 		})
@@ -264,15 +367,17 @@ func TestMetaValueLinking(t *testing.T) {
 }
 
 func TestBatchOperations(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
+		sqlDAO := mockDAO.(*sqlimpl)
+		eDAO := sqlDAO.entityDAO
+		evDAO := sqlDAO.entityValueDAO
 
 		Convey("Create Entity Values Batch", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Batch Entity")
+			createdEntity, err := createTestEntity(ctx, eDAO, "Batch Entity")
 			So(err, ShouldBeNil)
 
 			values := []*idm.EntityValue{
@@ -281,7 +386,7 @@ func TestBatchOperations(t *testing.T) {
 				{Label: "Batch Value 3", EntityUuid: createdEntity.Uuid},
 			}
 
-			created, err := mockDAO.CreateEntityValues(ctx, values)
+			created, err := evDAO.CreateEntityValues(ctx, values)
 			So(err, ShouldBeNil)
 			So(created, ShouldHaveLength, 3)
 			for i, val := range created {
@@ -292,7 +397,7 @@ func TestBatchOperations(t *testing.T) {
 		})
 
 		Convey("Create Entity Values Batch Empty", t, func() {
-			created, err := mockDAO.CreateEntityValues(ctx, []*idm.EntityValue{})
+			created, err := evDAO.CreateEntityValues(ctx, []*idm.EntityValue{})
 			So(err, ShouldBeNil)
 			So(created, ShouldHaveLength, 0)
 		})
@@ -300,150 +405,161 @@ func TestBatchOperations(t *testing.T) {
 }
 
 func TestDeleteOperations(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
+		sqlDAO := mockDAO.(*sqlimpl)
+		eDAO := sqlDAO.entityDAO
+		evDAO := sqlDAO.entityValueDAO
 
 		Convey("Delete Entity Cascade", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Delete Entity")
+			createdEntity, err := createTestEntity(ctx, eDAO, "Delete Entity")
 			So(err, ShouldBeNil)
 
-			value1, err := createTestEntityValue(ctx, mockDAO, "Delete Value 1", createdEntity.Uuid)
+			value1, err := createTestEntityValue(ctx, evDAO, "Delete Value 1", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			value2, err := createTestEntityValue(ctx, mockDAO, "Delete Value 2", createdEntity.Uuid)
+			value2, err := createTestEntityValue(ctx, evDAO, "Delete Value 2", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			metaWithId, err := createTestMeta(ctx, "test-node-delete", "test-namespace")
+			metaWithId, err := createTestMeta(ctx, mockDAO, "test-node-delete", "test-namespace")
 			So(err, ShouldBeNil)
 
-			linked, err := mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value1.Uuid)
-			So(err, ShouldBeNil)
-			So(linked, ShouldBeTrue)
-
-			linked, err = mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value2.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value1.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
-			valuesBefore, err := mockDAO.GetEntityValues(ctx, createdEntity.Uuid)
+			linked, err = evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value2.Uuid)
+			So(err, ShouldBeNil)
+			So(linked, ShouldBeTrue)
+
+			valuesBefore, err := evDAO.GetEntityValues(ctx, createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(valuesBefore, ShouldHaveLength, 2)
 
-			linkedValuesBefore, err := mockDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
+			linkedValuesBefore, err := evDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
 			So(err, ShouldBeNil)
 			So(linkedValuesBefore, ShouldHaveLength, 2)
 
-			deleteResp, err := mockDAO.DeleteEntity(ctx, createdEntity.Uuid)
+			deleteResp, err := eDAO.DeleteEntity(ctx, createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(deleteResp, ShouldNotBeNil)
 			So(deleteResp.RowsDeleted, ShouldEqual, 1)
 
-			retrieved, err := mockDAO.GetEntity(ctx, createdEntity.Uuid)
+			retrieved, err := eDAO.GetEntity(ctx, createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(retrieved, ShouldBeNil)
 
-			valuesAfter, err := mockDAO.GetEntityValues(ctx, createdEntity.Uuid)
+			valuesAfter, err := evDAO.GetEntityValues(ctx, createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(valuesAfter, ShouldHaveLength, 0)
 
-			linkedValuesAfter, err := mockDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
+			linkedValuesAfter, err := evDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
 			So(err, ShouldBeNil)
 			So(linkedValuesAfter, ShouldHaveLength, 0)
 		})
 
 		Convey("Delete Non-existent Entity", t, func() {
-			deleteResp, err := mockDAO.DeleteEntity(ctx, "00000000-0000-0000-0000-000000000000")
+			deleteResp, err := eDAO.DeleteEntity(ctx, "00000000-0000-0000-0000-000000000000")
 			So(err, ShouldBeNil)
 			So(deleteResp, ShouldNotBeNil)
 			So(deleteResp.RowsDeleted, ShouldEqual, 0)
 		})
 
 		Convey("Delete Entity with Invalid UUID", t, func() {
-			_, err := mockDAO.DeleteEntity(ctx, "invalid-uuid")
+			_, err := eDAO.DeleteEntity(ctx, "invalid-uuid")
 			So(err, ShouldNotBeNil)
 		})
 	})
 }
 
 func TestValidation(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
+		sqlDAO := mockDAO.(*sqlimpl)
+		evDAO := sqlDAO.entityValueDAO
 
 		Convey("Link with Invalid UUIDs", t, func() {
-			_, err := mockDAO.LinkMetaValue(ctx, "invalid-uuid", "valid-uuid")
+			_, err := evDAO.LinkMetaValue(ctx, "invalid-uuid", "valid-uuid")
 			So(err, ShouldNotBeNil)
 
-			_, err = mockDAO.LinkMetaValue(ctx, "00000000-0000-0000-0000-000000000000", "invalid-uuid")
+			_, err = evDAO.LinkMetaValue(ctx, "00000000-0000-0000-0000-000000000000", "invalid-uuid")
 			So(err, ShouldNotBeNil)
 
-			_, err = mockDAO.LinkMetaValue(ctx, "", "00000000-0000-0000-0000-000000000000")
+			_, err = evDAO.LinkMetaValue(ctx, "", "00000000-0000-0000-0000-000000000000")
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Unlink with Invalid UUIDs", t, func() {
-			_, err := mockDAO.UnlinkMetaValue(ctx, "invalid-uuid", "valid-uuid")
+			_, err := evDAO.UnlinkMetaValue(ctx, "invalid-uuid", "valid-uuid")
 			So(err, ShouldNotBeNil)
 
-			_, err = mockDAO.UnlinkMetaValue(ctx, "00000000-0000-0000-0000-000000000000", "invalid-uuid")
+			_, err = evDAO.UnlinkMetaValue(ctx, "00000000-0000-0000-0000-000000000000", "invalid-uuid")
 			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Unlink Non-existent Link Returns False", t, func() {
+			unlinked, err := evDAO.UnlinkMetaValue(ctx, "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002")
+			So(err, ShouldBeNil)
+			So(unlinked, ShouldBeFalse)
 		})
 	})
 }
 
 func TestGetMetaEntityValuesMap(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
+		sqlDAO := mockDAO.(*sqlimpl)
+		eDAO := sqlDAO.entityDAO
+		evDAO := sqlDAO.entityValueDAO
 
 		Convey("Get Meta Entity Values For Multiple Metas", t, func() {
 			// Create test entities
-			entity1, err := createTestEntity(ctx, mockDAO, "Test Entity 1")
+			entity1, err := createTestEntity(ctx, eDAO, "Test Entity 1")
 			So(err, ShouldBeNil)
 
-			entity2, err := createTestEntity(ctx, mockDAO, "Test Entity 2")
+			entity2, err := createTestEntity(ctx, eDAO, "Test Entity 2")
 			So(err, ShouldBeNil)
 
 			// Create entity values
-			value1, err := createTestEntityValue(ctx, mockDAO, "Value 1", entity1.Uuid)
+			value1, err := createTestEntityValue(ctx, evDAO, "Value 1", entity1.Uuid)
 			So(err, ShouldBeNil)
 
-			value2, err := createTestEntityValue(ctx, mockDAO, "Value 2", entity1.Uuid)
+			value2, err := createTestEntityValue(ctx, evDAO, "Value 2", entity1.Uuid)
 			So(err, ShouldBeNil)
 
-			value3, err := createTestEntityValue(ctx, mockDAO, "Value 3", entity2.Uuid)
+			value3, err := createTestEntityValue(ctx, evDAO, "Value 3", entity2.Uuid)
 			So(err, ShouldBeNil)
 
 			// Create metas
-			meta1, err := createTestMeta(ctx, "node-1", "namespace-1")
+			meta1, err := createTestMeta(ctx, mockDAO, "node-1", "namespace-1")
 			So(err, ShouldBeNil)
 
-			meta2, err := createTestMeta(ctx, "node-2", "namespace-2")
+			meta2, err := createTestMeta(ctx, mockDAO, "node-2", "namespace-2")
 			So(err, ShouldBeNil)
 
-			meta3, err := createTestMeta(ctx, "node-3", "namespace-3")
+			meta3, err := createTestMeta(ctx, mockDAO, "node-3", "namespace-3")
 			So(err, ShouldBeNil)
 
 			// Link meta1 to value1 and value2
-			linked, err := mockDAO.LinkMetaValue(ctx, meta1.Uuid, value1.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, meta1.Uuid, value1.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
-			linked, err = mockDAO.LinkMetaValue(ctx, meta1.Uuid, value2.Uuid)
+			linked, err = evDAO.LinkMetaValue(ctx, meta1.Uuid, value2.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
 			// Link meta2 to value3
-			linked, err = mockDAO.LinkMetaValue(ctx, meta2.Uuid, value3.Uuid)
+			linked, err = evDAO.LinkMetaValue(ctx, meta2.Uuid, value3.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
@@ -451,7 +567,7 @@ func TestGetMetaEntityValuesMap(t *testing.T) {
 
 			// Test with all three metas
 			metaUuids := []string{meta1.Uuid, meta2.Uuid, meta3.Uuid}
-			result, err := mockDAO.GetMetaEntityValuesMap(ctx, metaUuids)
+			result, err := evDAO.GetMetaEntityValuesMap(ctx, metaUuids)
 			So(err, ShouldBeNil)
 			So(result, ShouldNotBeNil)
 
@@ -471,14 +587,14 @@ func TestGetMetaEntityValuesMap(t *testing.T) {
 		})
 
 		Convey("Get Meta Entity Values For Empty Input", t, func() {
-			result, err := mockDAO.GetMetaEntityValuesMap(ctx, []string{})
+			result, err := evDAO.GetMetaEntityValuesMap(ctx, []string{})
 
 			So(err, ShouldBeNil)
 			So(result, ShouldBeNil)
 		})
 
 		Convey("Get Meta Entity Values For Nil Input", t, func() {
-			result, err := mockDAO.GetMetaEntityValuesMap(ctx, nil)
+			result, err := evDAO.GetMetaEntityValuesMap(ctx, nil)
 			So(err, ShouldBeNil)
 			So(result, ShouldBeNil)
 		})
@@ -487,7 +603,7 @@ func TestGetMetaEntityValuesMap(t *testing.T) {
 			fakeUuid1 := "00000000-0000-0000-0000-000000000001"
 			fakeUuid2 := "00000000-0000-0000-0000-000000000002"
 
-			result, err := mockDAO.GetMetaEntityValuesMap(ctx, []string{fakeUuid1, fakeUuid2})
+			result, err := evDAO.GetMetaEntityValuesMap(ctx, []string{fakeUuid1, fakeUuid2})
 			So(err, ShouldBeNil)
 			So(result, ShouldNotBeNil)
 
@@ -498,22 +614,22 @@ func TestGetMetaEntityValuesMap(t *testing.T) {
 
 		Convey("Get Meta Entity Values Preserves Entity UUID", t, func() {
 			// Create entity and value
-			entity, err := createTestEntity(ctx, mockDAO, "UUID Test Entity")
+			entity, err := createTestEntity(ctx, eDAO, "UUID Test Entity")
 			So(err, ShouldBeNil)
 
-			value, err := createTestEntityValue(ctx, mockDAO, "UUID Test Value", entity.Uuid)
+			value, err := createTestEntityValue(ctx, evDAO, "UUID Test Value", entity.Uuid)
 			So(err, ShouldBeNil)
 
 			// Create meta and link
-			meta, err := createTestMeta(ctx, "uuid-test-node", "uuid-test-namespace")
+			meta, err := createTestMeta(ctx, mockDAO, "uuid-test-node", "uuid-test-namespace")
 			So(err, ShouldBeNil)
 
-			linked, err := mockDAO.LinkMetaValue(ctx, meta.Uuid, value.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, meta.Uuid, value.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
 			// Retrieve and verify all fields are populated correctly
-			result, err := mockDAO.GetMetaEntityValuesMap(ctx, []string{meta.Uuid})
+			result, err := evDAO.GetMetaEntityValuesMap(ctx, []string{meta.Uuid})
 			So(err, ShouldBeNil)
 			So(result[meta.Uuid], ShouldHaveLength, 1)
 

--- a/idm/meta/dao/sql/ev-sql_test.go
+++ b/idm/meta/dao/sql/ev-sql_test.go
@@ -35,7 +35,9 @@ import (
 )
 
 var (
-	evTestcases = test.TemplateSQL(NewDAO)
+	mainTestcases = test.TemplateSQL(NewDAO)            // Main meta DAO
+	eTestcases    = test.TemplateSQL(NewEntityDAO)      // Entity DAO
+	evTestcases   = test.TemplateSQL(NewEntityValueDAO) // Entity value DAO
 )
 
 // Test fixtures
@@ -52,24 +54,20 @@ var (
 )
 
 // Helper functions
-func createTestEntity(ctx context.Context, mockDAO meta.EntityValueDAO, label string) (*idm.MetaEntity, error) {
+func createTestEntity(ctx context.Context, dao meta.MetaEntityDAO, label string) (*idm.MetaEntity, error) {
 	entity := &idm.MetaEntity{Label: label}
-	return mockDAO.CreateEntity(ctx, entity)
+	return dao.CreateEntity(ctx, entity)
 }
 
-func createTestEntityValue(ctx context.Context, mockDAO meta.EntityValueDAO, label, entityUuid string) (*idm.EntityValue, error) {
+func createTestEntityValue(ctx context.Context, dao meta.MetaEntityValueDAO, label, entityUuid string) (*idm.EntityValue, error) {
 	value := &idm.EntityValue{
 		Label:      label,
 		EntityUuid: entityUuid,
 	}
-	return mockDAO.CreateEntityValue(ctx, value)
+	return dao.CreateEntityValue(ctx, value)
 }
 
-func createTestMeta(ctx context.Context, nodeUuid, namespace string) (*idm.UserMeta, error) {
-	metaDAO, err := manager.Resolve[meta.DAO](ctx)
-	if err != nil {
-		return nil, err
-	}
+func createTestMeta(ctx context.Context, metaDAO meta.DAO, nodeUuid, namespace string) (*idm.UserMeta, error) {
 	metaWithId, _, err := metaDAO.Set(ctx, &idm.UserMeta{
 		NodeUuid:  nodeUuid,
 		Namespace: namespace,
@@ -79,15 +77,14 @@ func createTestMeta(ctx context.Context, nodeUuid, namespace string) (*idm.UserM
 }
 
 func TestEntityCrud(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+	test.RunStorageTests(eTestcases, t, func(ctx context.Context) {
+		entityDAO, err := manager.Resolve[meta.MetaEntityDAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
 
 		Convey("Create Entity", t, func() {
-			created, err := mockDAO.CreateEntity(ctx, fixtureEntityCity)
+			created, err := entityDAO.CreateEntity(ctx, fixtureEntityCity)
 			So(err, ShouldBeNil)
 			So(created, ShouldNotBeNil)
 			So(created.Uuid, ShouldNotBeEmpty)
@@ -96,10 +93,10 @@ func TestEntityCrud(t *testing.T) {
 		})
 
 		Convey("Get Entity", t, func() {
-			created, err := mockDAO.CreateEntity(ctx, fixtureEntitySimple)
+			created, err := entityDAO.CreateEntity(ctx, fixtureEntitySimple)
 			So(err, ShouldBeNil)
 
-			retrieved, err := mockDAO.GetEntity(ctx, created.Uuid)
+			retrieved, err := entityDAO.GetEntity(ctx, created.Uuid)
 			So(err, ShouldBeNil)
 			So(retrieved, ShouldNotBeNil)
 			So(retrieved.Uuid, ShouldEqual, created.Uuid)
@@ -113,7 +110,7 @@ func TestEntityCrud(t *testing.T) {
 				{Label: "Entity 3", Description: "Description 3"},
 			}
 
-			created, err := mockDAO.SetEntities(ctx, entities)
+			created, err := entityDAO.SetEntities(ctx, entities)
 			So(err, ShouldBeNil)
 			So(created, ShouldHaveLength, 3)
 			for i, e := range created {
@@ -125,18 +122,20 @@ func TestEntityCrud(t *testing.T) {
 }
 
 func TestEntityValueCrud(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
+		sqlDAO := mockDAO.(*sqlimpl)
+		entityDAO := sqlDAO.entityDAO
+		evDAO := sqlDAO.entityValueDAO
 
 		Convey("Create Entity Value", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Test Entity")
+			createdEntity, err := createTestEntity(ctx, entityDAO, "Test Entity")
 			So(err, ShouldBeNil)
 
-			created, err := createTestEntityValue(ctx, mockDAO, "Test Value", createdEntity.Uuid)
+			created, err := createTestEntityValue(ctx, evDAO, "Test Value", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(created, ShouldNotBeNil)
 			So(created.Uuid, ShouldNotBeEmpty)
@@ -145,16 +144,16 @@ func TestEntityValueCrud(t *testing.T) {
 		})
 
 		Convey("Get Entity Values", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Test Entity")
+			createdEntity, err := createTestEntity(ctx, entityDAO, "Test Entity")
 			So(err, ShouldBeNil)
 
-			_, err = createTestEntityValue(ctx, mockDAO, "Value 1", createdEntity.Uuid)
+			_, err = createTestEntityValue(ctx, evDAO, "Value 1", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			_, err = createTestEntityValue(ctx, mockDAO, "Value 2", createdEntity.Uuid)
+			_, err = createTestEntityValue(ctx, evDAO, "Value 2", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			values, err := mockDAO.GetEntityValues(ctx, createdEntity.Uuid)
+			values, err := evDAO.GetEntityValues(ctx, createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(values, ShouldHaveLength, 2)
 		})
@@ -162,101 +161,104 @@ func TestEntityValueCrud(t *testing.T) {
 }
 
 func TestMetaValueLinking(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
+
+		sqlDAO := mockDAO.(*sqlimpl)
+		eDAO := sqlDAO.entityDAO
+		evDAO := sqlDAO.entityValueDAO
 
 		Convey("Link Meta to Values", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Link Entity")
+			createdEntity, err := createTestEntity(ctx, eDAO, "Link Entity")
 			So(err, ShouldBeNil)
 
-			value1, err := createTestEntityValue(ctx, mockDAO, "Value 1", createdEntity.Uuid)
+			value1, err := createTestEntityValue(ctx, evDAO, "Value 1", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			value2, err := createTestEntityValue(ctx, mockDAO, "Value 2", createdEntity.Uuid)
+			value2, err := createTestEntityValue(ctx, evDAO, "Value 2", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			metaWithId, err := createTestMeta(ctx, "test-node", "test-namespace")
+			metaWithId, err := createTestMeta(ctx, mockDAO, "test-node", "test-namespace")
 			So(err, ShouldBeNil)
 
-			linked, err := mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value1.Uuid)
-			So(err, ShouldBeNil)
-			So(linked, ShouldBeTrue)
-
-			linked, err = mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value2.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value1.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
-			linkedValues, err := mockDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
+			linked, err = evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value2.Uuid)
+			So(err, ShouldBeNil)
+			So(linked, ShouldBeTrue)
+
+			linkedValues, err := evDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
 			So(err, ShouldBeNil)
 			So(linkedValues, ShouldHaveLength, 2)
 		})
 
 		Convey("Get Meta Entity Values", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Get Entity")
+			createdEntity, err := createTestEntity(ctx, eDAO, "Get Entity")
 			So(err, ShouldBeNil)
 
-			value, err := createTestEntityValue(ctx, mockDAO, "Test Value", createdEntity.Uuid)
+			value, err := createTestEntityValue(ctx, evDAO, "Test Value", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			metaWithId, err := createTestMeta(ctx, "test-node-get", "test-namespace")
+			metaWithId, err := createTestMeta(ctx, mockDAO, "test-node-get", "test-namespace")
 			So(err, ShouldBeNil)
 
-			linked, err := mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
-			values, err := mockDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
+			values, err := evDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
 			So(err, ShouldBeNil)
 			So(values, ShouldHaveLength, 1)
 			So(values[0].Label, ShouldEqual, "Test Value")
 		})
 
 		Convey("Unlink Meta Value", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Unlink Entity")
+			createdEntity, err := createTestEntity(ctx, eDAO, "Unlink Entity")
 			So(err, ShouldBeNil)
 
-			value, err := createTestEntityValue(ctx, mockDAO, "Unlink Value", createdEntity.Uuid)
+			value, err := createTestEntityValue(ctx, evDAO, "Unlink Value", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			metaWithId, err := createTestMeta(ctx, "test-node-unlink", "test-namespace")
+			metaWithId, err := createTestMeta(ctx, mockDAO, "test-node-unlink", "test-namespace")
 			So(err, ShouldBeNil)
 
-			linked, err := mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
-			values, err := mockDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
+			values, err := evDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
 			So(err, ShouldBeNil)
 			So(values, ShouldHaveLength, 1)
 
-			unlinked, err := mockDAO.UnlinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
+			unlinked, err := evDAO.UnlinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
 			So(err, ShouldBeNil)
 			So(unlinked, ShouldBeTrue)
 
-			values, err = mockDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
+			values, err = evDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
 			So(err, ShouldBeNil)
 			So(values, ShouldHaveLength, 0)
 		})
 
 		Convey("Link Duplicate Meta Value Returns False", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Duplicate Entity")
+			createdEntity, err := createTestEntity(ctx, eDAO, "Duplicate Entity")
 			So(err, ShouldBeNil)
 
-			value, err := createTestEntityValue(ctx, mockDAO, "Duplicate Value", createdEntity.Uuid)
+			value, err := createTestEntityValue(ctx, evDAO, "Duplicate Value", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			metaWithId, err := createTestMeta(ctx, "test-node-duplicate", "test-namespace")
+			metaWithId, err := createTestMeta(ctx, mockDAO, "test-node-duplicate", "test-namespace")
 			So(err, ShouldBeNil)
 
-			linked, err := mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
-			linked, err = mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
+			linked, err = evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeFalse)
 		})
@@ -264,15 +266,17 @@ func TestMetaValueLinking(t *testing.T) {
 }
 
 func TestBatchOperations(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
+		sqlDAO := mockDAO.(*sqlimpl)
+		eDAO := sqlDAO.entityDAO
+		evDAO := sqlDAO.entityValueDAO
 
 		Convey("Create Entity Values Batch", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Batch Entity")
+			createdEntity, err := createTestEntity(ctx, eDAO, "Batch Entity")
 			So(err, ShouldBeNil)
 
 			values := []*idm.EntityValue{
@@ -281,7 +285,7 @@ func TestBatchOperations(t *testing.T) {
 				{Label: "Batch Value 3", EntityUuid: createdEntity.Uuid},
 			}
 
-			created, err := mockDAO.CreateEntityValues(ctx, values)
+			created, err := evDAO.CreateEntityValues(ctx, values)
 			So(err, ShouldBeNil)
 			So(created, ShouldHaveLength, 3)
 			for i, val := range created {
@@ -292,7 +296,7 @@ func TestBatchOperations(t *testing.T) {
 		})
 
 		Convey("Create Entity Values Batch Empty", t, func() {
-			created, err := mockDAO.CreateEntityValues(ctx, []*idm.EntityValue{})
+			created, err := evDAO.CreateEntityValues(ctx, []*idm.EntityValue{})
 			So(err, ShouldBeNil)
 			So(created, ShouldHaveLength, 0)
 		})
@@ -300,69 +304,71 @@ func TestBatchOperations(t *testing.T) {
 }
 
 func TestDeleteOperations(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
+		sqlDAO := mockDAO.(*sqlimpl)
+		eDAO := sqlDAO.entityDAO
+		evDAO := sqlDAO.entityValueDAO
 
 		Convey("Delete Entity Cascade", t, func() {
-			createdEntity, err := createTestEntity(ctx, mockDAO, "Delete Entity")
+			createdEntity, err := createTestEntity(ctx, eDAO, "Delete Entity")
 			So(err, ShouldBeNil)
 
-			value1, err := createTestEntityValue(ctx, mockDAO, "Delete Value 1", createdEntity.Uuid)
+			value1, err := createTestEntityValue(ctx, evDAO, "Delete Value 1", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			value2, err := createTestEntityValue(ctx, mockDAO, "Delete Value 2", createdEntity.Uuid)
+			value2, err := createTestEntityValue(ctx, evDAO, "Delete Value 2", createdEntity.Uuid)
 			So(err, ShouldBeNil)
 
-			metaWithId, err := createTestMeta(ctx, "test-node-delete", "test-namespace")
+			metaWithId, err := createTestMeta(ctx, mockDAO, "test-node-delete", "test-namespace")
 			So(err, ShouldBeNil)
 
-			linked, err := mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value1.Uuid)
-			So(err, ShouldBeNil)
-			So(linked, ShouldBeTrue)
-
-			linked, err = mockDAO.LinkMetaValue(ctx, metaWithId.Uuid, value2.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value1.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
-			valuesBefore, err := mockDAO.GetEntityValues(ctx, createdEntity.Uuid)
+			linked, err = evDAO.LinkMetaValue(ctx, metaWithId.Uuid, value2.Uuid)
+			So(err, ShouldBeNil)
+			So(linked, ShouldBeTrue)
+
+			valuesBefore, err := evDAO.GetEntityValues(ctx, createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(valuesBefore, ShouldHaveLength, 2)
 
-			linkedValuesBefore, err := mockDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
+			linkedValuesBefore, err := evDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
 			So(err, ShouldBeNil)
 			So(linkedValuesBefore, ShouldHaveLength, 2)
 
-			deleteResp, err := mockDAO.DeleteEntity(ctx, createdEntity.Uuid)
+			deleteResp, err := evDAO.DeleteEntity(ctx, createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(deleteResp, ShouldNotBeNil)
 			So(deleteResp.RowsDeleted, ShouldEqual, 1)
 
-			retrieved, err := mockDAO.GetEntity(ctx, createdEntity.Uuid)
+			retrieved, err := eDAO.GetEntity(ctx, createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(retrieved, ShouldBeNil)
 
-			valuesAfter, err := mockDAO.GetEntityValues(ctx, createdEntity.Uuid)
+			valuesAfter, err := evDAO.GetEntityValues(ctx, createdEntity.Uuid)
 			So(err, ShouldBeNil)
 			So(valuesAfter, ShouldHaveLength, 0)
 
-			linkedValuesAfter, err := mockDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
+			linkedValuesAfter, err := evDAO.GetMetaEntityValues(ctx, metaWithId.Uuid)
 			So(err, ShouldBeNil)
 			So(linkedValuesAfter, ShouldHaveLength, 0)
 		})
 
 		Convey("Delete Non-existent Entity", t, func() {
-			deleteResp, err := mockDAO.DeleteEntity(ctx, "00000000-0000-0000-0000-000000000000")
+			deleteResp, err := evDAO.DeleteEntity(ctx, "00000000-0000-0000-0000-000000000000")
 			So(err, ShouldBeNil)
 			So(deleteResp, ShouldNotBeNil)
 			So(deleteResp.RowsDeleted, ShouldEqual, 0)
 		})
 
 		Convey("Delete Entity with Invalid UUID", t, func() {
-			_, err := mockDAO.DeleteEntity(ctx, "invalid-uuid")
+			_, err := evDAO.DeleteEntity(ctx, "invalid-uuid")
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -370,80 +376,81 @@ func TestDeleteOperations(t *testing.T) {
 
 func TestValidation(t *testing.T) {
 	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+		evDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
 
 		Convey("Link with Invalid UUIDs", t, func() {
-			_, err := mockDAO.LinkMetaValue(ctx, "invalid-uuid", "valid-uuid")
+			_, err := evDAO.LinkMetaValue(ctx, "invalid-uuid", "valid-uuid")
 			So(err, ShouldNotBeNil)
 
-			_, err = mockDAO.LinkMetaValue(ctx, "00000000-0000-0000-0000-000000000000", "invalid-uuid")
+			_, err = evDAO.LinkMetaValue(ctx, "00000000-0000-0000-0000-000000000000", "invalid-uuid")
 			So(err, ShouldNotBeNil)
 
-			_, err = mockDAO.LinkMetaValue(ctx, "", "00000000-0000-0000-0000-000000000000")
+			_, err = evDAO.LinkMetaValue(ctx, "", "00000000-0000-0000-0000-000000000000")
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Unlink with Invalid UUIDs", t, func() {
-			_, err := mockDAO.UnlinkMetaValue(ctx, "invalid-uuid", "valid-uuid")
+			_, err := evDAO.UnlinkMetaValue(ctx, "invalid-uuid", "valid-uuid")
 			So(err, ShouldNotBeNil)
 
-			_, err = mockDAO.UnlinkMetaValue(ctx, "00000000-0000-0000-0000-000000000000", "invalid-uuid")
+			_, err = evDAO.UnlinkMetaValue(ctx, "00000000-0000-0000-0000-000000000000", "invalid-uuid")
 			So(err, ShouldNotBeNil)
 		})
 	})
 }
 
 func TestGetMetaEntityValuesMap(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		mainDAO, err := manager.Resolve[meta.DAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
-		mockDAO := mainDAO.GetEntityValueDao()
+		sqlDAO := mockDAO.(*sqlimpl)
+		eDAO := sqlDAO.entityDAO
+		evDAO := sqlDAO.entityValueDAO
 
 		Convey("Get Meta Entity Values For Multiple Metas", t, func() {
 			// Create test entities
-			entity1, err := createTestEntity(ctx, mockDAO, "Test Entity 1")
+			entity1, err := createTestEntity(ctx, eDAO, "Test Entity 1")
 			So(err, ShouldBeNil)
 
-			entity2, err := createTestEntity(ctx, mockDAO, "Test Entity 2")
+			entity2, err := createTestEntity(ctx, eDAO, "Test Entity 2")
 			So(err, ShouldBeNil)
 
 			// Create entity values
-			value1, err := createTestEntityValue(ctx, mockDAO, "Value 1", entity1.Uuid)
+			value1, err := createTestEntityValue(ctx, evDAO, "Value 1", entity1.Uuid)
 			So(err, ShouldBeNil)
 
-			value2, err := createTestEntityValue(ctx, mockDAO, "Value 2", entity1.Uuid)
+			value2, err := createTestEntityValue(ctx, evDAO, "Value 2", entity1.Uuid)
 			So(err, ShouldBeNil)
 
-			value3, err := createTestEntityValue(ctx, mockDAO, "Value 3", entity2.Uuid)
+			value3, err := createTestEntityValue(ctx, evDAO, "Value 3", entity2.Uuid)
 			So(err, ShouldBeNil)
 
 			// Create metas
-			meta1, err := createTestMeta(ctx, "node-1", "namespace-1")
+			meta1, err := createTestMeta(ctx, mockDAO, "node-1", "namespace-1")
 			So(err, ShouldBeNil)
 
-			meta2, err := createTestMeta(ctx, "node-2", "namespace-2")
+			meta2, err := createTestMeta(ctx, mockDAO, "node-2", "namespace-2")
 			So(err, ShouldBeNil)
 
-			meta3, err := createTestMeta(ctx, "node-3", "namespace-3")
+			meta3, err := createTestMeta(ctx, mockDAO, "node-3", "namespace-3")
 			So(err, ShouldBeNil)
 
 			// Link meta1 to value1 and value2
-			linked, err := mockDAO.LinkMetaValue(ctx, meta1.Uuid, value1.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, meta1.Uuid, value1.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
-			linked, err = mockDAO.LinkMetaValue(ctx, meta1.Uuid, value2.Uuid)
+			linked, err = evDAO.LinkMetaValue(ctx, meta1.Uuid, value2.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
 			// Link meta2 to value3
-			linked, err = mockDAO.LinkMetaValue(ctx, meta2.Uuid, value3.Uuid)
+			linked, err = evDAO.LinkMetaValue(ctx, meta2.Uuid, value3.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
@@ -451,7 +458,7 @@ func TestGetMetaEntityValuesMap(t *testing.T) {
 
 			// Test with all three metas
 			metaUuids := []string{meta1.Uuid, meta2.Uuid, meta3.Uuid}
-			result, err := mockDAO.GetMetaEntityValuesMap(ctx, metaUuids)
+			result, err := evDAO.GetMetaEntityValuesMap(ctx, metaUuids)
 			So(err, ShouldBeNil)
 			So(result, ShouldNotBeNil)
 
@@ -471,14 +478,14 @@ func TestGetMetaEntityValuesMap(t *testing.T) {
 		})
 
 		Convey("Get Meta Entity Values For Empty Input", t, func() {
-			result, err := mockDAO.GetMetaEntityValuesMap(ctx, []string{})
+			result, err := evDAO.GetMetaEntityValuesMap(ctx, []string{})
 
 			So(err, ShouldBeNil)
 			So(result, ShouldBeNil)
 		})
 
 		Convey("Get Meta Entity Values For Nil Input", t, func() {
-			result, err := mockDAO.GetMetaEntityValuesMap(ctx, nil)
+			result, err := evDAO.GetMetaEntityValuesMap(ctx, nil)
 			So(err, ShouldBeNil)
 			So(result, ShouldBeNil)
 		})
@@ -487,7 +494,7 @@ func TestGetMetaEntityValuesMap(t *testing.T) {
 			fakeUuid1 := "00000000-0000-0000-0000-000000000001"
 			fakeUuid2 := "00000000-0000-0000-0000-000000000002"
 
-			result, err := mockDAO.GetMetaEntityValuesMap(ctx, []string{fakeUuid1, fakeUuid2})
+			result, err := evDAO.GetMetaEntityValuesMap(ctx, []string{fakeUuid1, fakeUuid2})
 			So(err, ShouldBeNil)
 			So(result, ShouldNotBeNil)
 
@@ -498,22 +505,22 @@ func TestGetMetaEntityValuesMap(t *testing.T) {
 
 		Convey("Get Meta Entity Values Preserves Entity UUID", t, func() {
 			// Create entity and value
-			entity, err := createTestEntity(ctx, mockDAO, "UUID Test Entity")
+			entity, err := createTestEntity(ctx, eDAO, "UUID Test Entity")
 			So(err, ShouldBeNil)
 
-			value, err := createTestEntityValue(ctx, mockDAO, "UUID Test Value", entity.Uuid)
+			value, err := createTestEntityValue(ctx, evDAO, "UUID Test Value", entity.Uuid)
 			So(err, ShouldBeNil)
 
 			// Create meta and link
-			meta, err := createTestMeta(ctx, "uuid-test-node", "uuid-test-namespace")
+			meta, err := createTestMeta(ctx, mockDAO, "uuid-test-node", "uuid-test-namespace")
 			So(err, ShouldBeNil)
 
-			linked, err := mockDAO.LinkMetaValue(ctx, meta.Uuid, value.Uuid)
+			linked, err := evDAO.LinkMetaValue(ctx, meta.Uuid, value.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
 			// Retrieve and verify all fields are populated correctly
-			result, err := mockDAO.GetMetaEntityValuesMap(ctx, []string{meta.Uuid})
+			result, err := evDAO.GetMetaEntityValuesMap(ctx, []string{meta.Uuid})
 			So(err, ShouldBeNil)
 			So(result[meta.Uuid], ShouldHaveLength, 1)
 

--- a/idm/meta/dao/sql/ev-sql_test.go
+++ b/idm/meta/dao/sql/ev-sql_test.go
@@ -54,12 +54,12 @@ var (
 )
 
 // Helper functions
-func createTestEntity(ctx context.Context, dao meta.MetaEntityDAO, label string) (*idm.MetaEntity, error) {
+func createTestEntity(ctx context.Context, dao meta.EntityDAO, label string) (*idm.MetaEntity, error) {
 	entity := &idm.MetaEntity{Label: label}
 	return dao.CreateEntity(ctx, entity)
 }
 
-func createTestEntityValue(ctx context.Context, dao meta.MetaEntityValueDAO, label, entityUuid string) (*idm.EntityValue, error) {
+func createTestEntityValue(ctx context.Context, dao meta.EntityValueDAO, label, entityUuid string) (*idm.EntityValue, error) {
 	value := &idm.EntityValue{
 		Label:      label,
 		EntityUuid: entityUuid,
@@ -77,11 +77,14 @@ func createTestMeta(ctx context.Context, metaDAO meta.DAO, nodeUuid, namespace s
 }
 
 func TestEntityCrud(t *testing.T) {
-	test.RunStorageTests(eTestcases, t, func(ctx context.Context) {
-		entityDAO, err := manager.Resolve[meta.MetaEntityDAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
+		sqlDAO := mockDAO.(*sqlimpl)
+		entityDAO := sqlDAO.entityDAO
+		// evDAO := sqlDAO.entityValueDAO
 
 		Convey("Create Entity", t, func() {
 			created, err := entityDAO.CreateEntity(ctx, fixtureEntityCity)
@@ -375,11 +378,13 @@ func TestDeleteOperations(t *testing.T) {
 }
 
 func TestValidation(t *testing.T) {
-	test.RunStorageTests(evTestcases, t, func(ctx context.Context) {
-		evDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx)
+	test.RunStorageTests(mainTestcases, t, func(ctx context.Context) {
+		mockDAO, err := manager.Resolve[meta.DAO](ctx)
 		if err != nil {
 			panic(err)
 		}
+		sqlDAO := mockDAO.(*sqlimpl)
+		evDAO := sqlDAO.entityValueDAO
 
 		Convey("Link with Invalid UUIDs", t, func() {
 			_, err := evDAO.LinkMetaValue(ctx, "invalid-uuid", "valid-uuid")

--- a/idm/meta/dao/sql/ns-sql.go
+++ b/idm/meta/dao/sql/ns-sql.go
@@ -57,6 +57,7 @@ type MetaNamespace struct {
 	JsonSchema     *datatypes.JSON `gorm:"column:json_schema"`
 	Description    string          `gorm:"column:description;type:varchar(255)"`
 	FieldType      string          `gorm:"column:field_type;type:varchar(255)"`
+	EntityUUID     string          `gorm:"foreignKey:EntityUUID;references:UUID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL"`
 }
 
 func (*MetaNamespace) TableName(namer schema.Namer) string {
@@ -78,7 +79,9 @@ func (u *MetaNamespace) As(res *idm.UserMetaNamespace) *idm.UserMetaNamespace {
 	res.JsonSchema = schema
 	res.Description = u.Description
 	res.FieldType = u.FieldType
-
+	if u.EntityUUID != "" {
+		res.EntityUUID = u.EntityUUID
+	}
 	return res
 }
 
@@ -94,6 +97,11 @@ func (u *MetaNamespace) From(res *idm.UserMetaNamespace) *MetaNamespace {
 	u.JsonSchema = js
 	u.Description = res.Description
 	u.FieldType = res.FieldType
+	if res.EntityUUID != "" {
+		u.EntityUUID = res.EntityUUID
+	} else {
+		u.EntityUUID = ""
+	}
 	return u
 }
 
@@ -114,6 +122,11 @@ func (u *MetaNamespace) FromExisting(res *idm.UserMetaNamespace) (*MetaNamespace
 	u.JsonSchema = js
 	u.Description = res.Description
 	u.FieldType = res.FieldType
+	if res.EntityUUID != "" {
+		u.EntityUUID = res.EntityUUID
+	} else {
+		u.EntityUUID = ""
+	}
 	return u, nil
 }
 

--- a/idm/meta/dao/sql/sql.go
+++ b/idm/meta/dao/sql/sql.go
@@ -57,10 +57,11 @@ func tag(err error) error {
 
 func NewDAO(db *gorm.DB) meta.DAO {
 	return &sqlimpl{
-		Abstract:     sql.NewAbstract(db),
-		resourcesDAO: resources2.NewDAO(db),
-		nsDAO:        NewNSDAO(db),
-		evDAO:        NewEntityValueDAO(db),
+		Abstract:       sql.NewAbstract(db),
+		resourcesDAO:   resources2.NewDAO(db),
+		nsDAO:          NewNSDAO(db),
+		entityDAO:      NewEntityDAO(db),
+		entityValueDAO: NewEntityValueDAO(db),
 	}
 }
 
@@ -68,8 +69,9 @@ func NewDAO(db *gorm.DB) meta.DAO {
 type sqlimpl struct {
 	*sql.Abstract
 	resourcesDAO
-	nsDAO meta.NamespaceDAO
-	evDAO meta.EntityValueDAO
+	nsDAO          meta.NamespaceDAO
+	entityDAO      meta.MetaEntityDAO
+	entityValueDAO meta.MetaEntityValueDAO
 }
 
 type Meta struct {
@@ -116,10 +118,6 @@ func (s *sqlimpl) GetNamespaceDao() meta.NamespaceDAO {
 	return s.nsDAO
 }
 
-func (s *sqlimpl) GetEntityValueDao() meta.EntityValueDAO {
-	return s.evDAO
-}
-
 func (s *sqlimpl) Migrate(ctx context.Context) error {
 	if err := s.Session(ctx).AutoMigrate(&Meta{}, &MetaNamespace{}); err != nil {
 		return err
@@ -133,7 +131,11 @@ func (s *sqlimpl) Migrate(ctx context.Context) error {
 		return err
 	}
 
-	if err := s.evDAO.Migrate(ctx); err != nil {
+	if err := s.entityDAO.MigrateEntity(ctx); err != nil {
+		return err
+	}
+
+	if err := s.entityValueDAO.MigrateEV(ctx); err != nil {
 		return err
 	}
 
@@ -255,7 +257,7 @@ func (s *sqlimpl) Search(ctx context.Context, query service.Enquirer) ([]*idm.Us
 
 	entityValuesMap := make(map[string][]string)
 	if len(metaUUIDs) > 0 {
-		evMap, err := s.evDAO.GetMetaEntityValuesMap(ctx, metaUUIDs)
+		evMap, err := s.entityValueDAO.GetMetaEntityValuesMap(ctx, metaUUIDs)
 		if err == nil { // Ignoring the error since it's not guaranteed to have entity values for all metas
 			for metaUUID, entityValues := range evMap {
 				labels := make([]string, len(entityValues))

--- a/idm/meta/dao/sql/sql.go
+++ b/idm/meta/dao/sql/sql.go
@@ -57,10 +57,11 @@ func tag(err error) error {
 
 func NewDAO(db *gorm.DB) meta.DAO {
 	return &sqlimpl{
-		Abstract:     sql.NewAbstract(db),
-		resourcesDAO: resources2.NewDAO(db),
-		nsDAO:        NewNSDAO(db),
-		evDAO:        NewEntityValueDAO(db),
+		Abstract:       sql.NewAbstract(db),
+		resourcesDAO:   resources2.NewDAO(db),
+		nsDAO:          NewNSDAO(db),
+		entityDAO:      NewEntityDAO(db),
+		entityValueDAO: NewEntityValueDAO(db),
 	}
 }
 
@@ -68,8 +69,9 @@ func NewDAO(db *gorm.DB) meta.DAO {
 type sqlimpl struct {
 	*sql.Abstract
 	resourcesDAO
-	nsDAO meta.NamespaceDAO
-	evDAO meta.EntityValueDAO
+	nsDAO          meta.NamespaceDAO
+	entityDAO      meta.EntityDAO
+	entityValueDAO meta.EntityValueDAO
 }
 
 type Meta struct {
@@ -116,10 +118,6 @@ func (s *sqlimpl) GetNamespaceDao() meta.NamespaceDAO {
 	return s.nsDAO
 }
 
-func (s *sqlimpl) GetEntityValueDao() meta.EntityValueDAO {
-	return s.evDAO
-}
-
 func (s *sqlimpl) Migrate(ctx context.Context) error {
 	if err := s.Session(ctx).AutoMigrate(&Meta{}, &MetaNamespace{}); err != nil {
 		return err
@@ -133,7 +131,11 @@ func (s *sqlimpl) Migrate(ctx context.Context) error {
 		return err
 	}
 
-	if err := s.evDAO.Migrate(ctx); err != nil {
+	if err := s.entityDAO.MigrateEntity(ctx); err != nil {
+		return err
+	}
+
+	if err := s.entityValueDAO.MigrateEV(ctx); err != nil {
 		return err
 	}
 
@@ -147,6 +149,16 @@ func (s *sqlimpl) Set(ctx context.Context, meta *idm.UserMeta) (*idm.UserMeta, s
 	prev := ""
 	update := false
 
+	// Check if record already exists
+	var existing Meta
+	existsQuery := s.Session(ctx).Where(&Meta{
+		NodeUUID:  old.NodeUUID,
+		Namespace: old.Namespace,
+		Owner:     old.Owner,
+	}).First(&existing)
+
+	recordExists := existsQuery.Error == nil
+
 	// Attempting to create
 	tx := s.Session(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "node_uuid"}, {Name: "namespace"}, {Name: "owner"}},
@@ -156,19 +168,15 @@ func (s *sqlimpl) Set(ctx context.Context, meta *idm.UserMeta) (*idm.UserMeta, s
 		return nil, "", tag(tx.Error)
 	}
 
-	if tx.RowsAffected == 0 {
-		target.UUID = old.UUID
-
-		prev = string(target.Data)
-
+	if recordExists {
+		// This was an update - use the existing UUID
+		old.UUID = existing.UUID
+		target.UUID = existing.UUID
+		prev = string(existing.Data)
 		update = true
-		if tx2 := s.Session(ctx).Where(&Meta{UUID: old.UUID}).Updates(target); tx2.Error != nil {
-			return nil, "", tag(tx2.Error)
-		}
-	} else {
-		target = old
 	}
 
+	target = old
 	meta = target.As(meta)
 
 	var err error
@@ -255,7 +263,7 @@ func (s *sqlimpl) Search(ctx context.Context, query service.Enquirer) ([]*idm.Us
 
 	entityValuesMap := make(map[string][]string)
 	if len(metaUUIDs) > 0 {
-		evMap, err := s.evDAO.GetMetaEntityValuesMap(ctx, metaUUIDs)
+		evMap, err := s.entityValueDAO.GetMetaEntityValuesMap(ctx, metaUUIDs)
 		if err == nil { // Ignoring the error since it's not guaranteed to have entity values for all metas
 			for metaUUID, entityValues := range evMap {
 				labels := make([]string, len(entityValues))

--- a/idm/meta/dao/sql/sql.go
+++ b/idm/meta/dao/sql/sql.go
@@ -149,6 +149,16 @@ func (s *sqlimpl) Set(ctx context.Context, meta *idm.UserMeta) (*idm.UserMeta, s
 	prev := ""
 	update := false
 
+	// Check if record already exists
+	var existing Meta
+	existsQuery := s.Session(ctx).Where(&Meta{
+		NodeUUID:  old.NodeUUID,
+		Namespace: old.Namespace,
+		Owner:     old.Owner,
+	}).First(&existing)
+
+	recordExists := existsQuery.Error == nil
+
 	// Attempting to create
 	tx := s.Session(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "node_uuid"}, {Name: "namespace"}, {Name: "owner"}},
@@ -158,19 +168,15 @@ func (s *sqlimpl) Set(ctx context.Context, meta *idm.UserMeta) (*idm.UserMeta, s
 		return nil, "", tag(tx.Error)
 	}
 
-	if tx.RowsAffected == 0 {
-		target.UUID = old.UUID
-
-		prev = string(target.Data)
-
+	if recordExists {
+		// This was an update - use the existing UUID
+		old.UUID = existing.UUID
+		target.UUID = existing.UUID
+		prev = string(existing.Data)
 		update = true
-		if tx2 := s.Session(ctx).Where(&Meta{UUID: old.UUID}).Updates(target); tx2.Error != nil {
-			return nil, "", tag(tx2.Error)
-		}
-	} else {
-		target = old
 	}
 
+	target = old
 	meta = target.As(meta)
 
 	var err error

--- a/idm/meta/dao/sql/sql.go
+++ b/idm/meta/dao/sql/sql.go
@@ -70,8 +70,8 @@ type sqlimpl struct {
 	*sql.Abstract
 	resourcesDAO
 	nsDAO          meta.NamespaceDAO
-	entityDAO      meta.MetaEntityDAO
-	entityValueDAO meta.MetaEntityValueDAO
+	entityDAO      meta.EntityDAO
+	entityValueDAO meta.EntityValueDAO
 }
 
 type Meta struct {

--- a/idm/meta/dao/sql/sql_test.go
+++ b/idm/meta/dao/sql/sql_test.go
@@ -294,24 +294,28 @@ func TestSearchWithTagCloudEntityValues(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		evDAO := mockDAO.GetEntityValueDao()
-		nsDAO := mockDAO.GetNamespaceDao()
+
+		// Access internal entity DAOs from the main DAO
+		sqlDAO := mockDAO.(*sqlimpl)
+		entityDAO := sqlDAO.entityDAO
+		entityValueDAO := sqlDAO.entityValueDAO
+		nsDAO := sqlDAO.nsDAO
 
 		Convey("Search Returns Entity Values for Tag Cloud Namespace", t, func() {
 			// Create an entity and values
-			entity, err := evDAO.CreateEntity(ctx, &idm.MetaEntity{
+			entity, err := entityDAO.CreateEntity(ctx, &idm.MetaEntity{
 				Label:       "Tags",
 				Description: "Tag entity for tag cloud",
 			})
 			So(err, ShouldBeNil)
 
-			tag1, err := evDAO.CreateEntityValue(ctx, &idm.EntityValue{
+			tag1, err := entityValueDAO.CreateEntityValue(ctx, &idm.EntityValue{
 				Label:      "important",
 				EntityUuid: entity.Uuid,
 			})
 			So(err, ShouldBeNil)
 
-			tag2, err := evDAO.CreateEntityValue(ctx, &idm.EntityValue{
+			tag2, err := entityValueDAO.CreateEntityValue(ctx, &idm.EntityValue{
 				Label:      "urgent",
 				EntityUuid: entity.Uuid,
 			})
@@ -343,11 +347,11 @@ func TestSearchWithTagCloudEntityValues(t *testing.T) {
 			})
 			So(err, ShouldBeNil)
 
-			linked, err := evDAO.LinkMetaValue(ctx, meta.Uuid, tag1.Uuid)
+			linked, err := entityValueDAO.LinkMetaValue(ctx, meta.Uuid, tag1.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
-			linked, err = evDAO.LinkMetaValue(ctx, meta.Uuid, tag2.Uuid)
+			linked, err = entityValueDAO.LinkMetaValue(ctx, meta.Uuid, tag2.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 
@@ -373,7 +377,7 @@ func TestSearchWithTagCloudEntityValues(t *testing.T) {
 
 		Convey("Search Returns Original Value When No Entity Values Linked", t, func() {
 			// Create entity and namespace
-			entity, err := evDAO.CreateEntity(ctx, &idm.MetaEntity{
+			entity, err := entityDAO.CreateEntity(ctx, &idm.MetaEntity{
 				Label: "Status",
 			})
 			So(err, ShouldBeNil)
@@ -419,12 +423,12 @@ func TestSearchWithTagCloudEntityValues(t *testing.T) {
 
 		Convey("Search Handles Mixed Namespace Types", t, func() {
 			// Create tag_cloud namespace with entity values
-			entity, err := evDAO.CreateEntity(ctx, &idm.MetaEntity{
+			entity, err := entityDAO.CreateEntity(ctx, &idm.MetaEntity{
 				Label: "Tags",
 			})
 			So(err, ShouldBeNil)
 
-			tag1, err := evDAO.CreateEntityValue(ctx, &idm.EntityValue{
+			tag1, err := entityValueDAO.CreateEntityValue(ctx, &idm.EntityValue{
 				Label:      "featured",
 				EntityUuid: entity.Uuid,
 			})
@@ -468,7 +472,7 @@ func TestSearchWithTagCloudEntityValues(t *testing.T) {
 			})
 			So(err, ShouldBeNil)
 
-			linked, err := evDAO.LinkMetaValue(ctx, metaTags.Uuid, tag1.Uuid)
+			linked, err := entityValueDAO.LinkMetaValue(ctx, metaTags.Uuid, tag1.Uuid)
 			So(err, ShouldBeNil)
 			So(linked, ShouldBeTrue)
 

--- a/idm/meta/entity-dao.go
+++ b/idm/meta/entity-dao.go
@@ -44,4 +44,6 @@ type EntityDAO interface {
 	CreateEntity(ctx context.Context, entity *idm.MetaEntity) (*idm.MetaEntity, error)
 	SetEntities(ctx context.Context, entities []*idm.MetaEntity) ([]*idm.MetaEntity, error)
 	GetEntity(ctx context.Context, entityUuid string) (*idm.MetaEntity, error)
+	ListEntities(ctx context.Context) ([]*idm.MetaEntity, error)
+	DeleteEntity(ctx context.Context, entityUuid string) (*idm.DeleteEntityResponse, error)
 }

--- a/idm/meta/entity-dao.go
+++ b/idm/meta/entity-dao.go
@@ -28,37 +28,22 @@ import (
 	"context"
 
 	"github.com/pydio/cells/v5/common/proto/idm"
-	service2 "github.com/pydio/cells/v5/common/proto/service"
 	"github.com/pydio/cells/v5/common/service"
 	"github.com/pydio/cells/v5/common/storage/sql/resources"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
-var Drivers = service.StorageDrivers{}
+var EntityDrivers = service.StorageDrivers{}
 
-// DAO interface
-type DAO interface {
-	resources.DAO
-	GetNamespaceDao() NamespaceDAO
-
-	Migrate(ctx context.Context) error
-	Set(ctx context.Context, meta *idm.UserMeta) (*idm.UserMeta, string, error)
-	Del(ctx context.Context, meta *idm.UserMeta) (prevValue string, e error)
-	Search(ctx context.Context, query service2.Enquirer) ([]*idm.UserMeta, error)
-	GetMeta(ctx context.Context, nodeUuid string, namespace string) (*idm.UserMeta, error)
-}
-
-const (
-	ReservedNamespaceBookmark = "bookmark"
-)
-
-// NamespaceDAO interface
-type NamespaceDAO interface {
+// EntityDAO interface for managing meta entities and their values
+type EntityDAO interface {
 	resources.DAO
 
-	Upsert(ctx context.Context, ns *idm.UserMetaNamespace) (error, bool)
-	Del(ctx context.Context, ns *idm.UserMetaNamespace) (e error)
-	List(ctx context.Context) (map[string]*idm.UserMetaNamespace, error)
-	GetJSONSchema(ctx context.Context) (*structpb.Struct, error)
-	GetNamespaceSchemaSample(ctx context.Context, fieldType string, namespace string, format string) (*structpb.Struct, error)
+	MigrateEntity(ctx context.Context) error
+
+	// CreateEntity Entity operations
+	CreateEntity(ctx context.Context, entity *idm.MetaEntity) (*idm.MetaEntity, error)
+	SetEntities(ctx context.Context, entities []*idm.MetaEntity) ([]*idm.MetaEntity, error)
+	GetEntity(ctx context.Context, entityUuid string) (*idm.MetaEntity, error)
+	ListEntities(ctx context.Context) ([]*idm.MetaEntity, error)
+	DeleteEntity(ctx context.Context, entityUuid string) (*idm.DeleteEntityResponse, error)
 }

--- a/idm/meta/entity-dao.go
+++ b/idm/meta/entity-dao.go
@@ -28,38 +28,20 @@ import (
 	"context"
 
 	"github.com/pydio/cells/v5/common/proto/idm"
-	service2 "github.com/pydio/cells/v5/common/proto/service"
 	"github.com/pydio/cells/v5/common/service"
 	"github.com/pydio/cells/v5/common/storage/sql/resources"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
-var Drivers = service.StorageDrivers{}
+var EntityDrivers = service.StorageDrivers{}
 
-// DAO interface
-type DAO interface {
-	resources.DAO
-	GetNamespaceDao() NamespaceDAO
-	// GetEntityValueDao() EntityValueDAO
-
-	Migrate(ctx context.Context) error
-	Set(ctx context.Context, meta *idm.UserMeta) (*idm.UserMeta, string, error)
-	Del(ctx context.Context, meta *idm.UserMeta) (prevValue string, e error)
-	Search(ctx context.Context, query service2.Enquirer) ([]*idm.UserMeta, error)
-	GetMeta(ctx context.Context, nodeUuid string, namespace string) (*idm.UserMeta, error)
-}
-
-const (
-	ReservedNamespaceBookmark = "bookmark"
-)
-
-// NamespaceDAO interface
-type NamespaceDAO interface {
+// MetaEntityDAO interface for managing meta entities and their values
+type MetaEntityDAO interface {
 	resources.DAO
 
-	Upsert(ctx context.Context, ns *idm.UserMetaNamespace) (error, bool)
-	Del(ctx context.Context, ns *idm.UserMetaNamespace) (e error)
-	List(ctx context.Context) (map[string]*idm.UserMetaNamespace, error)
-	GetJSONSchema(ctx context.Context) (*structpb.Struct, error)
-	GetNamespaceSchemaSample(ctx context.Context, fieldType string, namespace string, format string) (*structpb.Struct, error)
+	MigrateEntity(ctx context.Context) error
+
+	// Entity operations
+	CreateEntity(ctx context.Context, entity *idm.MetaEntity) (*idm.MetaEntity, error)
+	SetEntities(ctx context.Context, entities []*idm.MetaEntity) ([]*idm.MetaEntity, error)
+	GetEntity(ctx context.Context, entityUuid string) (*idm.MetaEntity, error)
 }

--- a/idm/meta/entity-dao.go
+++ b/idm/meta/entity-dao.go
@@ -34,13 +34,13 @@ import (
 
 var EntityDrivers = service.StorageDrivers{}
 
-// MetaEntityDAO interface for managing meta entities and their values
-type MetaEntityDAO interface {
+// EntityDAO interface for managing meta entities and their values
+type EntityDAO interface {
 	resources.DAO
 
 	MigrateEntity(ctx context.Context) error
 
-	// Entity operations
+	// CreateEntity Entity operations
 	CreateEntity(ctx context.Context, entity *idm.MetaEntity) (*idm.MetaEntity, error)
 	SetEntities(ctx context.Context, entities []*idm.MetaEntity) ([]*idm.MetaEntity, error)
 	GetEntity(ctx context.Context, entityUuid string) (*idm.MetaEntity, error)

--- a/idm/meta/ev-dao.go
+++ b/idm/meta/ev-dao.go
@@ -28,38 +28,27 @@ import (
 	"context"
 
 	"github.com/pydio/cells/v5/common/proto/idm"
-	service2 "github.com/pydio/cells/v5/common/proto/service"
 	"github.com/pydio/cells/v5/common/service"
 	"github.com/pydio/cells/v5/common/storage/sql/resources"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
-var Drivers = service.StorageDrivers{}
+var EntityValueDrivers = service.StorageDrivers{}
 
-// DAO interface
-type DAO interface {
-	resources.DAO
-	GetNamespaceDao() NamespaceDAO
-	// GetEntityValueDao() EntityValueDAO
-
-	Migrate(ctx context.Context) error
-	Set(ctx context.Context, meta *idm.UserMeta) (*idm.UserMeta, string, error)
-	Del(ctx context.Context, meta *idm.UserMeta) (prevValue string, e error)
-	Search(ctx context.Context, query service2.Enquirer) ([]*idm.UserMeta, error)
-	GetMeta(ctx context.Context, nodeUuid string, namespace string) (*idm.UserMeta, error)
-}
-
-const (
-	ReservedNamespaceBookmark = "bookmark"
-)
-
-// NamespaceDAO interface
-type NamespaceDAO interface {
+// MetaEntityValueDAO interface for managing meta entities and their values
+type MetaEntityValueDAO interface {
 	resources.DAO
 
-	Upsert(ctx context.Context, ns *idm.UserMetaNamespace) (error, bool)
-	Del(ctx context.Context, ns *idm.UserMetaNamespace) (e error)
-	List(ctx context.Context) (map[string]*idm.UserMetaNamespace, error)
-	GetJSONSchema(ctx context.Context) (*structpb.Struct, error)
-	GetNamespaceSchemaSample(ctx context.Context, fieldType string, namespace string, format string) (*structpb.Struct, error)
+	MigrateEV(ctx context.Context) error
+
+	// Entity Value operations
+	CreateEntityValues(ctx context.Context, values []*idm.EntityValue) ([]*idm.EntityValue, error)
+	CreateEntityValue(ctx context.Context, value *idm.EntityValue) (*idm.EntityValue, error)
+	GetEntityValues(ctx context.Context, entityUuid string) ([]*idm.EntityValue, error)
+	DeleteEntity(ctx context.Context, entityUuid string) (*idm.DeleteEntityValuesResponse, error)
+
+	// Link operations
+	LinkMetaValue(ctx context.Context, metaUuid string, valueUuid string) (bool, error)
+	UnlinkMetaValue(ctx context.Context, metaUuid string, valueUuid string) (bool, error)
+	GetMetaEntityValues(ctx context.Context, metaUuid string) ([]*idm.EntityValue, error)
+	GetMetaEntityValuesMap(ctx context.Context, metaUuids []string) (map[string][]*idm.EntityValue, error)
 }

--- a/idm/meta/ev-dao.go
+++ b/idm/meta/ev-dao.go
@@ -28,37 +28,26 @@ import (
 	"context"
 
 	"github.com/pydio/cells/v5/common/proto/idm"
-	service2 "github.com/pydio/cells/v5/common/proto/service"
 	"github.com/pydio/cells/v5/common/service"
 	"github.com/pydio/cells/v5/common/storage/sql/resources"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
-var Drivers = service.StorageDrivers{}
+var EntityValueDrivers = service.StorageDrivers{}
 
-// DAO interface
-type DAO interface {
-	resources.DAO
-	GetNamespaceDao() NamespaceDAO
-
-	Migrate(ctx context.Context) error
-	Set(ctx context.Context, meta *idm.UserMeta) (*idm.UserMeta, string, error)
-	Del(ctx context.Context, meta *idm.UserMeta) (prevValue string, e error)
-	Search(ctx context.Context, query service2.Enquirer) ([]*idm.UserMeta, error)
-	GetMeta(ctx context.Context, nodeUuid string, namespace string) (*idm.UserMeta, error)
-}
-
-const (
-	ReservedNamespaceBookmark = "bookmark"
-)
-
-// NamespaceDAO interface
-type NamespaceDAO interface {
+// EntityValueDAO interface for managing meta entities and their values
+type EntityValueDAO interface {
 	resources.DAO
 
-	Upsert(ctx context.Context, ns *idm.UserMetaNamespace) (error, bool)
-	Del(ctx context.Context, ns *idm.UserMetaNamespace) (e error)
-	List(ctx context.Context) (map[string]*idm.UserMetaNamespace, error)
-	GetJSONSchema(ctx context.Context) (*structpb.Struct, error)
-	GetNamespaceSchemaSample(ctx context.Context, fieldType string, namespace string, format string) (*structpb.Struct, error)
+	MigrateEV(ctx context.Context) error
+
+	// CreateEntityValues Entity Value operations
+	CreateEntityValues(ctx context.Context, values []*idm.EntityValue) ([]*idm.EntityValue, error)
+	CreateEntityValue(ctx context.Context, value *idm.EntityValue) (*idm.EntityValue, error)
+	GetEntityValues(ctx context.Context, entityUuid string) ([]*idm.EntityValue, error)
+
+	// LinkMetaValue Link operations
+	LinkMetaValue(ctx context.Context, metaUuid string, valueUuid string) (bool, error)
+	UnlinkMetaValue(ctx context.Context, metaUuid string, valueUuid string) (bool, error)
+	GetMetaEntityValues(ctx context.Context, metaUuid string) ([]*idm.EntityValue, error)
+	GetMetaEntityValuesMap(ctx context.Context, metaUuids []string) (map[string][]*idm.EntityValue, error)
 }

--- a/idm/meta/ev-dao.go
+++ b/idm/meta/ev-dao.go
@@ -44,7 +44,6 @@ type EntityValueDAO interface {
 	CreateEntityValues(ctx context.Context, values []*idm.EntityValue) ([]*idm.EntityValue, error)
 	CreateEntityValue(ctx context.Context, value *idm.EntityValue) (*idm.EntityValue, error)
 	GetEntityValues(ctx context.Context, entityUuid string) ([]*idm.EntityValue, error)
-	DeleteEntity(ctx context.Context, entityUuid string) (*idm.DeleteEntityValuesResponse, error)
 
 	// LinkMetaValue Link operations
 	LinkMetaValue(ctx context.Context, metaUuid string, valueUuid string) (bool, error)

--- a/idm/meta/ev-dao.go
+++ b/idm/meta/ev-dao.go
@@ -34,19 +34,19 @@ import (
 
 var EntityValueDrivers = service.StorageDrivers{}
 
-// MetaEntityValueDAO interface for managing meta entities and their values
-type MetaEntityValueDAO interface {
+// EntityValueDAO interface for managing meta entities and their values
+type EntityValueDAO interface {
 	resources.DAO
 
 	MigrateEV(ctx context.Context) error
 
-	// Entity Value operations
+	// CreateEntityValues Entity Value operations
 	CreateEntityValues(ctx context.Context, values []*idm.EntityValue) ([]*idm.EntityValue, error)
 	CreateEntityValue(ctx context.Context, value *idm.EntityValue) (*idm.EntityValue, error)
 	GetEntityValues(ctx context.Context, entityUuid string) ([]*idm.EntityValue, error)
 	DeleteEntity(ctx context.Context, entityUuid string) (*idm.DeleteEntityValuesResponse, error)
 
-	// Link operations
+	// LinkMetaValue Link operations
 	LinkMetaValue(ctx context.Context, metaUuid string, valueUuid string) (bool, error)
 	UnlinkMetaValue(ctx context.Context, metaUuid string, valueUuid string) (bool, error)
 	GetMetaEntityValues(ctx context.Context, metaUuid string) ([]*idm.EntityValue, error)

--- a/idm/meta/grpc/ev-resolver.go
+++ b/idm/meta/grpc/ev-resolver.go
@@ -1,0 +1,130 @@
+package grpc
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/pydio/cells/v5/common/proto/idm"
+	"github.com/pydio/cells/v5/common/runtime/manager"
+	"github.com/pydio/cells/v5/idm/meta"
+)
+
+// namespaces whose values are backed by entity values
+var entityBackedFieldTypes = []string{"tag_cloud", "choice", "auto_complete"}
+
+// EvResolver owns exactly one responsibility:
+// keeping meta <-> entity-value links (meta_values_rel) consistent with a
+// desired set of labels for a persisted meta row.
+//
+// Precondition: the meta already exists (real MetaUuid). Idempotent.
+type EvResolver interface {
+	Resolve(ctx context.Context, m *idm.UserMeta, ns *idm.UserMetaNamespace, labels []string) ([]*idm.EntityValue, error)
+	Applies(ns *idm.UserMetaNamespace) bool
+}
+
+// entityBacked implements EvResolver using manager-resolved DAOs.
+type entityBacked struct{}
+
+// NewEvResolver creates the resolver (DAOs resolved at call time).
+func NewEvResolver() EvResolver {
+	return &entityBacked{}
+}
+
+func (r *entityBacked) Applies(ns *idm.UserMetaNamespace) bool {
+	return ns != nil && slices.Contains(entityBackedFieldTypes, ns.FieldType)
+}
+
+func (r *entityBacked) Resolve(ctx context.Context, m *idm.UserMeta, ns *idm.UserMetaNamespace, labels []string) ([]*idm.EntityValue, error) {
+	if !r.Applies(ns) {
+		return nil, nil
+	}
+
+	// Resolve EntityValueDAO at call time
+	evDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
+	if err != nil {
+		return nil, err
+	}
+
+	def, err := ns.UnmarshallDefinition()
+	if err != nil || def == nil {
+		return nil, err
+	}
+	entityID := def.GetEntityId()
+	if entityID == "" {
+		return nil, nil
+	}
+
+	// normalize desired set
+	desired := map[string]struct{}{}
+	for _, l := range labels {
+		if l = strings.TrimSpace(l); l != "" {
+			desired[l] = struct{}{}
+		}
+	}
+
+	// 1. existing vocabulary for this entity
+	existing, err := evDAO.GetEntityValues(ctx, entityID)
+	if err != nil {
+		return nil, err
+	}
+	byLabel := make(map[string]*idm.EntityValue, len(existing))
+	for _, ev := range existing {
+		byLabel[ev.Label] = ev
+	}
+
+	// 2. currently linked values for this meta
+	linked, err := evDAO.GetMetaEntityValues(ctx, m.Uuid)
+	if err != nil {
+		return nil, err
+	}
+	linkedByLabel := make(map[string]*idm.EntityValue, len(linked))
+	for _, ev := range linked {
+		linkedByLabel[ev.Label] = ev
+	}
+
+	// 3. unlink removed
+	for label, ev := range linkedByLabel {
+		if _, keep := desired[label]; !keep {
+			if _, e := evDAO.UnlinkMetaValue(ctx, m.Uuid, ev.Uuid); e != nil {
+				return nil, e
+			}
+		}
+	}
+
+	// 4. create missing vocabulary
+	var toCreate []*idm.EntityValue
+	for label := range desired {
+		if _, ok := byLabel[label]; !ok {
+			toCreate = append(toCreate, &idm.EntityValue{EntityUuid: entityID, Label: label})
+		}
+	}
+	if len(toCreate) > 0 {
+		created, e := evDAO.CreateEntityValues(ctx, toCreate)
+		if e != nil {
+			return nil, e
+		}
+		// Add newly created entity values to byLabel map
+		// Use the returned values directly - they have the correct UUIDs
+		for _, ev := range created {
+			byLabel[ev.Label] = ev
+		}
+	}
+
+	// 5. link all desired (idempotent via OnConflict DoNothing in LinkMetaValue)
+	var result []*idm.EntityValue
+	for label := range desired {
+		ev := byLabel[label]
+		if ev == nil || ev.Uuid == "" {
+			// Entity value not in vocabulary or has no UUID - skip
+			continue
+		}
+
+		if _, e := evDAO.LinkMetaValue(ctx, m.Uuid, ev.Uuid); e != nil {
+			return nil, e
+		}
+		result = append(result, ev)
+	}
+
+	return result, nil
+}

--- a/idm/meta/grpc/ev-resolver.go
+++ b/idm/meta/grpc/ev-resolver.go
@@ -1,0 +1,170 @@
+package grpc
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/pydio/cells/v5/common/proto/idm"
+	"github.com/pydio/cells/v5/common/runtime/manager"
+	"github.com/pydio/cells/v5/idm/meta"
+)
+
+// namespaces whose values are backed by entity values
+var entityBackedFieldTypes = []string{"tag_cloud", "choice", "auto_complete"}
+
+// EvResolver keeps meta ↔ entity-value links (meta_values_rel) consistent
+// with a desired set of labels for a persisted meta row.
+//
+// Precondition: the meta already exists (real MetaUuid). All operations are idempotent.
+type EvResolver interface {
+	// Resolve detaches removed labels, creates missing vocabulary, and links
+	// Used in the PUT path.
+	Resolve(ctx context.Context, m *idm.UserMeta, ns *idm.UserMetaNamespace, labels []string) ([]*idm.EntityValue, error)
+	// Detach unlinks entity values not present in labels. Empty/nil labels = unlink all.
+	// Used standalone in the DELETE path.
+	Detach(ctx context.Context, m *idm.UserMeta, labels []string) error
+	// Applies returns true if this resolver is applicable to the given namespace.
+	Applies(ns *idm.UserMetaNamespace) bool
+}
+
+// entityBacked implements EvResolver using manager-resolved DAOs.
+type entityBacked struct{}
+
+// NewEvResolver creates the resolver (DAOs resolved at call time).
+func NewEvResolver() EvResolver {
+	return &entityBacked{}
+}
+
+func (r *entityBacked) Applies(ns *idm.UserMetaNamespace) bool {
+	return slices.Contains(entityBackedFieldTypes, ns.FieldType) && ns.EntityUUID != ""
+}
+
+// normalizeLabels trims whitespace and deduplicates, dropping empty entries.
+func normalizeLabels(labels []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		if l = strings.TrimSpace(l); l != "" {
+			out[l] = struct{}{}
+		}
+	}
+	return out
+}
+
+func (r *entityBacked) Resolve(ctx context.Context, m *idm.UserMeta, ns *idm.UserMetaNamespace, labels []string) ([]*idm.EntityValue, error) {
+	if !r.Applies(ns) {
+		return nil, nil
+	}
+
+	evDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
+	if err != nil {
+		return nil, err
+	}
+	EntityUUID := ns.EntityUUID
+	if EntityUUID == "" {
+		def, err := ns.UnmarshallDefinition()
+		if err != nil || def == nil {
+			return nil, err
+		}
+		EntityUUID = def.GetEntityId()
+		if EntityUUID == "" {
+			return nil, nil
+		}
+	}
+
+	desired := normalizeLabels(labels)
+
+	// Fetch currently linked values once — reused for both detach and link-skip.
+	linked, err := evDAO.GetMetaEntityValues(ctx, m.Uuid)
+	if err != nil {
+		return nil, err
+	}
+
+	// Detach: unlink values no longer desired, and record what is still linked.
+	alreadyLinked := make(map[string]struct{}, len(linked))
+	for _, ev := range linked {
+		if _, keep := desired[ev.Label]; !keep {
+			if _, err := evDAO.UnlinkMetaValue(ctx, m.Uuid, ev.Uuid); err != nil {
+				return nil, err
+			}
+		} else {
+			alreadyLinked[ev.Label] = struct{}{}
+		}
+	}
+
+	if len(desired) == 0 {
+		return nil, nil
+	}
+
+	// Fetch existing vocabulary for this entity.
+	existing, err := evDAO.GetEntityValues(ctx, EntityUUID)
+	if err != nil {
+		return nil, err
+	}
+	byLabel := make(map[string]*idm.EntityValue, len(existing))
+	for _, ev := range existing {
+		byLabel[ev.Label] = ev
+	}
+
+	// Create vocabulary entries that don't exist yet.
+	var toCreate []*idm.EntityValue
+	for label := range desired {
+		if _, ok := byLabel[label]; !ok {
+			toCreate = append(toCreate, &idm.EntityValue{EntityUuid: EntityUUID, Label: label})
+		}
+	}
+	if len(toCreate) > 0 {
+		created, e := evDAO.CreateEntityValues(ctx, toCreate)
+		if e != nil {
+			return nil, e
+		}
+
+		for _, ev := range created {
+			byLabel[ev.Label] = ev
+		}
+	}
+
+	// Link desired values, skipping those that are already linked.
+	var result []*idm.EntityValue
+	for label := range desired {
+		ev := byLabel[label]
+		if ev == nil || ev.Uuid == "" {
+			continue
+		}
+
+		if _, linked := alreadyLinked[label]; !linked {
+			if _, e := evDAO.LinkMetaValue(ctx, m.Uuid, ev.Uuid); e != nil {
+				return nil, e
+			}
+		}
+		result = append(result, ev)
+	}
+
+	return result, nil
+}
+
+func (r *entityBacked) Detach(ctx context.Context, m *idm.UserMeta, labels []string) error {
+	evDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
+	if err != nil {
+		return err
+	}
+
+	linked, err := evDAO.GetMetaEntityValues(ctx, m.Uuid)
+	if err != nil {
+		return err
+	}
+
+	// Build the set of labels that should remain linked.
+	// An empty/nil labels slice means "keep nothing" — all links are removed.
+	keepLabels := normalizeLabels(labels)
+
+	for _, ev := range linked {
+		if _, keep := keepLabels[ev.Label]; !keep {
+			if _, err := evDAO.UnlinkMetaValue(ctx, m.Uuid, ev.Uuid); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/idm/meta/grpc/handler.go
+++ b/idm/meta/grpc/handler.go
@@ -430,13 +430,12 @@ func (h *Handler) GetNamespaceSchema(ctx context.Context, req *idm.GetNamespaceS
 }
 
 func (h *Handler) GetEntityValues(ctx context.Context, req *idm.GetMetaEntityValuesRequest) (*idm.MetaEntityValueResponse, error) {
-	dao, err := manager.Resolve[meta.DAO](ctx)
+	entityValueDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}
-	entityDAO := dao.GetEntityValueDao()
 
-	values, err := entityDAO.GetEntityValues(ctx, req.EntityUuid)
+	values, err := entityValueDAO.GetEntityValues(ctx, req.EntityUuid)
 	if err != nil {
 		return nil, err
 	}
@@ -447,13 +446,12 @@ func (h *Handler) GetEntityValues(ctx context.Context, req *idm.GetMetaEntityVal
 }
 
 func (h *Handler) DeleteEntity(ctx context.Context, req *idm.GetMetaEntityValuesRequest) (*idm.DeleteEntityValuesResponse, error) {
-	dao, err := manager.Resolve[meta.DAO](ctx)
+	entityValueDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}
-	evDAO := dao.GetEntityValueDao()
 
-	resp, err := evDAO.DeleteEntity(ctx, req.EntityUuid)
+	resp, err := entityValueDAO.DeleteEntity(ctx, req.EntityUuid)
 	if err != nil {
 		return nil, err
 	}
@@ -462,13 +460,12 @@ func (h *Handler) DeleteEntity(ctx context.Context, req *idm.GetMetaEntityValues
 }
 
 func (h *Handler) CreateEntity(ctx context.Context, req *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error) {
-	dao, err := manager.Resolve[meta.DAO](ctx)
+	entityDAO, err := manager.Resolve[meta.MetaEntityDAO](ctx, manager.WithName("meta-entities"))
 	if err != nil {
 		return nil, err
 	}
-	evDAO := dao.GetEntityValueDao()
 
-	entity, err := evDAO.CreateEntity(ctx, req.Entity)
+	entity, err := entityDAO.CreateEntity(ctx, req.Entity)
 	if err != nil {
 		return nil, err
 	}
@@ -479,13 +476,12 @@ func (h *Handler) CreateEntity(ctx context.Context, req *idm.CreateEntityRequest
 }
 
 func (h *Handler) CreateEntityValues(ctx context.Context, req *idm.CreateEntityValueRequest) (*idm.CreateEntityValueResponse, error) {
-	dao, err := manager.Resolve[meta.DAO](ctx)
+	entityValueDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}
-	evDAO := dao.GetEntityValueDao()
 
-	values, err := evDAO.CreateEntityValues(ctx, req.EntityValue)
+	values, err := entityValueDAO.CreateEntityValues(ctx, req.EntityValue)
 	if err != nil {
 		return nil, err
 	}
@@ -496,12 +492,11 @@ func (h *Handler) CreateEntityValues(ctx context.Context, req *idm.CreateEntityV
 }
 
 func (h *Handler) LinkMetaToEntityValue(ctx context.Context, req *idm.MetaToEntityValueRequest) (*idm.MetaToEntityValueResponse, error) {
-	dao, err := manager.Resolve[meta.DAO](ctx)
+	entityValueDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}
-	evDAO := dao.GetEntityValueDao()
-	link, er := evDAO.LinkMetaValue(ctx, req.MetaUuid, req.EntityValueUuid)
+	link, er := entityValueDAO.LinkMetaValue(ctx, req.MetaUuid, req.EntityValueUuid)
 	if er != nil {
 		return nil, er
 	}
@@ -525,12 +520,11 @@ func (h *Handler) GetMetadata(ctx context.Context, req *idm.GetMetadataRequest) 
 }
 
 func (h *Handler) UnlinkMetaFromEntityValue(ctx context.Context, req *idm.MetaToEntityValueRequest) (*idm.MetaToEntityValueResponse, error) {
-	dao, err := manager.Resolve[meta.DAO](ctx)
+	entityValueDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}
-	evDAO := dao.GetEntityValueDao()
-	unlink, er := evDAO.UnlinkMetaValue(ctx, req.MetaUuid, req.EntityValueUuid)
+	unlink, er := entityValueDAO.UnlinkMetaValue(ctx, req.MetaUuid, req.EntityValueUuid)
 	if er != nil {
 		return nil, er
 	}

--- a/idm/meta/grpc/handler.go
+++ b/idm/meta/grpc/handler.go
@@ -92,6 +92,20 @@ func (h *Handler) UpdateUserMeta(ctx context.Context, request *idm.UpdateUserMet
 			}
 			// ADD / UPDATE
 			if newMeta, prev, err := dao.Set(ctx, metaData); err == nil {
+				// Reconcile entity values if namespace is entity-backed
+				if ns, exists := namespaces[newMeta.Namespace]; exists {
+					resolver := NewEvResolver()
+					if resolver.Applies(ns) {
+						// Parse labels from JsonValue (comma-separated)
+						var labelsStr string
+						if e := json.Unmarshal([]byte(newMeta.JsonValue), &labelsStr); e == nil && labelsStr != "" {
+							labels := strings.Split(labelsStr, ",")
+							if _, e := resolver.Resolve(ctx, newMeta, ns, labels); e != nil {
+								return nil, e
+							}
+						}
+					}
+				}
 				response.MetaDatas = append(response.MetaDatas, newMeta)
 				prevValue = prev
 			} else {
@@ -445,18 +459,46 @@ func (h *Handler) GetEntityValues(ctx context.Context, req *idm.GetMetaEntityVal
 	}, nil
 }
 
-func (h *Handler) DeleteEntity(ctx context.Context, req *idm.GetMetaEntityValuesRequest) (*idm.DeleteEntityValuesResponse, error) {
-	entityValueDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
+func (h *Handler) DeleteEntity(ctx context.Context, req *idm.DeleteEntityRequest) (*idm.DeleteEntityResponse, error) {
+	entityDAO, err := manager.Resolve[meta.EntityDAO](ctx, manager.WithName("meta-entities"))
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := entityValueDAO.DeleteEntity(ctx, req.EntityUuid)
+	resp, err := entityDAO.DeleteEntity(ctx, req.EntityId)
 	if err != nil {
 		return nil, err
 	}
 
 	return resp, nil
+}
+
+func (h *Handler) ListEntities(ctx context.Context, req *idm.ListEntitiesRequest) (*idm.ListEntitiesResponse, error) {
+	entityDAO, err := manager.Resolve[meta.EntityDAO](ctx, manager.WithName("meta-entities"))
+	if err != nil {
+		return nil, err
+	}
+
+	entities, err := entityDAO.ListEntities(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &idm.ListEntitiesResponse{Entity: entities}, nil
+}
+
+func (h *Handler) GetEntity(ctx context.Context, req *idm.GetEntityRequest) (*idm.GetEntityResponse, error) {
+	entityDAO, err := manager.Resolve[meta.EntityDAO](ctx, manager.WithName("meta-entities"))
+	if err != nil {
+		return nil, err
+	}
+
+	entity, err := entityDAO.GetEntity(ctx, req.EntityUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	return &idm.GetEntityResponse{Entity: entity}, nil
 }
 
 func (h *Handler) CreateEntity(ctx context.Context, req *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error) {

--- a/idm/meta/grpc/handler.go
+++ b/idm/meta/grpc/handler.go
@@ -81,8 +81,10 @@ func (h *Handler) UpdateUserMeta(ctx context.Context, request *idm.UpdateUserMet
 	namespaces, _ := dao.GetNamespaceDao().List(ctx)
 	nodes := make(map[string]*tree.Node)
 	sources := make(map[string]*tree.Node)
+	resolver := NewEvResolver()
 	for _, metaData := range request.MetaDatas {
 		var prevValue string
+
 		if request.Operation == idm.UpdateUserMetaRequest_PUT {
 			// Check JsonValue is valid json
 			var data interface{}
@@ -91,14 +93,37 @@ func (h *Handler) UpdateUserMeta(ctx context.Context, request *idm.UpdateUserMet
 				return nil, fmt.Errorf("make sure to use JSON format for metadata: %s", er.Error())
 			}
 			// ADD / UPDATE
-			if newMeta, prev, err := dao.Set(ctx, metaData); err == nil {
-				response.MetaDatas = append(response.MetaDatas, newMeta)
-				prevValue = prev
-			} else {
+			newMeta, prev, err := dao.Set(ctx, metaData)
+			if err != nil {
 				return nil, err
 			}
+
+			if err := resolveEntityValues(ctx, resolver, namespaces, newMeta); err != nil {
+				return nil, err
+			}
+			response.MetaDatas = append(response.MetaDatas, newMeta)
+			prevValue = prev
 		} else {
 			// DELETE
+			if ns, exists := namespaces[metaData.Namespace]; exists && resolver.Applies(ns) {
+				// Always detach all entity value relations before deleting the meta record.
+				// Passing empty labels means "keep nothing" — all links are removed,
+				// preventing a FK violation when Del() runs next.
+				var labels []string
+				var labelsStr string
+				if e := json.Unmarshal([]byte(metaData.JsonValue), &labelsStr); e == nil && labelsStr != "" {
+					labels = strings.Split(labelsStr, ",")
+				}
+				// UUID is not provided by the client - resolve it from the DB.
+				if resolved, e := dao.GetMeta(ctx, metaData.NodeUuid, metaData.Namespace); e == nil && resolved != nil {
+					metaData.Uuid = resolved.Uuid
+				}
+				if e := resolver.Detach(ctx, metaData, labels); e != nil {
+					return nil, e
+				}
+			}
+			// This statement returns a foreign key violation
+			//violates foreign key constraint [0.916ms] [rows:0] [source] DELETE FROM `idm_usr_meta` WHERE `idm_usr_meta`.`uuid` = '70ce6aec-f02a-4b9a-b615-deab67ffdff7'  {"file": "/cells/common/storage/sql/logger.go:82", "layer": "sql", "tag": "idm"}
 			if prev, err := dao.Del(ctx, metaData); err == nil {
 				prevValue = prev
 				// Remove this namespace from ResolvedNode as it will used for targets later on
@@ -430,13 +455,12 @@ func (h *Handler) GetNamespaceSchema(ctx context.Context, req *idm.GetNamespaceS
 }
 
 func (h *Handler) GetEntityValues(ctx context.Context, req *idm.GetMetaEntityValuesRequest) (*idm.MetaEntityValueResponse, error) {
-	dao, err := manager.Resolve[meta.DAO](ctx)
+	entityValueDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}
-	entityDAO := dao.GetEntityValueDao()
 
-	values, err := entityDAO.GetEntityValues(ctx, req.EntityUuid)
+	values, err := entityValueDAO.GetEntityValues(ctx, req.EntityUuid)
 	if err != nil {
 		return nil, err
 	}
@@ -446,14 +470,13 @@ func (h *Handler) GetEntityValues(ctx context.Context, req *idm.GetMetaEntityVal
 	}, nil
 }
 
-func (h *Handler) DeleteEntity(ctx context.Context, req *idm.GetMetaEntityValuesRequest) (*idm.DeleteEntityValuesResponse, error) {
-	dao, err := manager.Resolve[meta.DAO](ctx)
+func (h *Handler) DeleteEntity(ctx context.Context, req *idm.DeleteEntityRequest) (*idm.DeleteEntityResponse, error) {
+	entityDAO, err := manager.Resolve[meta.EntityDAO](ctx, manager.WithName("meta-entities"))
 	if err != nil {
 		return nil, err
 	}
-	evDAO := dao.GetEntityValueDao()
 
-	resp, err := evDAO.DeleteEntity(ctx, req.EntityUuid)
+	resp, err := entityDAO.DeleteEntity(ctx, req.EntityId)
 	if err != nil {
 		return nil, err
 	}
@@ -461,14 +484,41 @@ func (h *Handler) DeleteEntity(ctx context.Context, req *idm.GetMetaEntityValues
 	return resp, nil
 }
 
-func (h *Handler) CreateEntity(ctx context.Context, req *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error) {
-	dao, err := manager.Resolve[meta.DAO](ctx)
+func (h *Handler) ListEntities(ctx context.Context, req *idm.ListEntitiesRequest) (*idm.ListEntitiesResponse, error) {
+	entityDAO, err := manager.Resolve[meta.EntityDAO](ctx, manager.WithName("meta-entities"))
 	if err != nil {
 		return nil, err
 	}
-	evDAO := dao.GetEntityValueDao()
 
-	entity, err := evDAO.CreateEntity(ctx, req.Entity)
+	entities, err := entityDAO.ListEntities(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &idm.ListEntitiesResponse{Entity: entities}, nil
+}
+
+func (h *Handler) GetEntity(ctx context.Context, req *idm.GetEntityRequest) (*idm.GetEntityResponse, error) {
+	entityDAO, err := manager.Resolve[meta.EntityDAO](ctx, manager.WithName("meta-entities"))
+	if err != nil {
+		return nil, err
+	}
+
+	entity, err := entityDAO.GetEntity(ctx, req.EntityUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	return &idm.GetEntityResponse{Entity: entity}, nil
+}
+
+func (h *Handler) CreateEntity(ctx context.Context, req *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error) {
+	entityDAO, err := manager.Resolve[meta.EntityDAO](ctx, manager.WithName("meta-entities"))
+	if err != nil {
+		return nil, err
+	}
+
+	entity, err := entityDAO.CreateEntity(ctx, req.Entity)
 	if err != nil {
 		return nil, err
 	}
@@ -479,13 +529,12 @@ func (h *Handler) CreateEntity(ctx context.Context, req *idm.CreateEntityRequest
 }
 
 func (h *Handler) CreateEntityValues(ctx context.Context, req *idm.CreateEntityValueRequest) (*idm.CreateEntityValueResponse, error) {
-	dao, err := manager.Resolve[meta.DAO](ctx)
+	entityValueDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}
-	evDAO := dao.GetEntityValueDao()
 
-	values, err := evDAO.CreateEntityValues(ctx, req.EntityValue)
+	values, err := entityValueDAO.CreateEntityValues(ctx, req.EntityValue)
 	if err != nil {
 		return nil, err
 	}
@@ -496,12 +545,11 @@ func (h *Handler) CreateEntityValues(ctx context.Context, req *idm.CreateEntityV
 }
 
 func (h *Handler) LinkMetaToEntityValue(ctx context.Context, req *idm.MetaToEntityValueRequest) (*idm.MetaToEntityValueResponse, error) {
-	dao, err := manager.Resolve[meta.DAO](ctx)
+	entityValueDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}
-	evDAO := dao.GetEntityValueDao()
-	link, er := evDAO.LinkMetaValue(ctx, req.MetaUuid, req.EntityValueUuid)
+	link, er := entityValueDAO.LinkMetaValue(ctx, req.MetaUuid, req.EntityValueUuid)
 	if er != nil {
 		return nil, er
 	}
@@ -525,12 +573,11 @@ func (h *Handler) GetMetadata(ctx context.Context, req *idm.GetMetadataRequest) 
 }
 
 func (h *Handler) UnlinkMetaFromEntityValue(ctx context.Context, req *idm.MetaToEntityValueRequest) (*idm.MetaToEntityValueResponse, error) {
-	dao, err := manager.Resolve[meta.DAO](ctx)
+	entityValueDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}
-	evDAO := dao.GetEntityValueDao()
-	unlink, er := evDAO.UnlinkMetaValue(ctx, req.MetaUuid, req.EntityValueUuid)
+	unlink, er := entityValueDAO.UnlinkMetaValue(ctx, req.MetaUuid, req.EntityValueUuid)
 	if er != nil {
 		return nil, er
 	}
@@ -577,4 +624,28 @@ func (h *Handler) clearCacheForNode(ctx context.Context, nodeId string) {
 		}
 	}
 
+}
+
+// resolveEntityValues keeps meta ↔ entity-value links consistent after a successful PUT.
+// It delegates to Resolve which handles detach, vocabulary creation, and linking in one pass.
+func resolveEntityValues(ctx context.Context, resolver EvResolver, namespaces map[string]*idm.UserMetaNamespace, newMeta *idm.UserMeta) error {
+	ns, exists := namespaces[newMeta.Namespace]
+	if !exists || !resolver.Applies(ns) {
+		return nil
+	}
+
+	// Parse labels from JsonValue (JSON-encoded comma-separated string).
+	var labelsStr string
+	if err := json.Unmarshal([]byte(newMeta.JsonValue), &labelsStr); err != nil {
+		// Not a string value — nothing to resolve.
+		return nil
+	}
+
+	var labels []string
+	if labelsStr != "" {
+		labels = strings.Split(labelsStr, ",")
+	}
+
+	_, err := resolver.Resolve(ctx, newMeta, ns, labels)
+	return err
 }

--- a/idm/meta/grpc/handler.go
+++ b/idm/meta/grpc/handler.go
@@ -430,7 +430,7 @@ func (h *Handler) GetNamespaceSchema(ctx context.Context, req *idm.GetNamespaceS
 }
 
 func (h *Handler) GetEntityValues(ctx context.Context, req *idm.GetMetaEntityValuesRequest) (*idm.MetaEntityValueResponse, error) {
-	entityValueDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx, manager.WithName("meta-entity-values"))
+	entityValueDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}
@@ -446,7 +446,7 @@ func (h *Handler) GetEntityValues(ctx context.Context, req *idm.GetMetaEntityVal
 }
 
 func (h *Handler) DeleteEntity(ctx context.Context, req *idm.GetMetaEntityValuesRequest) (*idm.DeleteEntityValuesResponse, error) {
-	entityValueDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx, manager.WithName("meta-entity-values"))
+	entityValueDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +460,7 @@ func (h *Handler) DeleteEntity(ctx context.Context, req *idm.GetMetaEntityValues
 }
 
 func (h *Handler) CreateEntity(ctx context.Context, req *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error) {
-	entityDAO, err := manager.Resolve[meta.MetaEntityDAO](ctx, manager.WithName("meta-entities"))
+	entityDAO, err := manager.Resolve[meta.EntityDAO](ctx, manager.WithName("meta-entities"))
 	if err != nil {
 		return nil, err
 	}
@@ -476,7 +476,7 @@ func (h *Handler) CreateEntity(ctx context.Context, req *idm.CreateEntityRequest
 }
 
 func (h *Handler) CreateEntityValues(ctx context.Context, req *idm.CreateEntityValueRequest) (*idm.CreateEntityValueResponse, error) {
-	entityValueDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx, manager.WithName("meta-entity-values"))
+	entityValueDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}
@@ -492,7 +492,7 @@ func (h *Handler) CreateEntityValues(ctx context.Context, req *idm.CreateEntityV
 }
 
 func (h *Handler) LinkMetaToEntityValue(ctx context.Context, req *idm.MetaToEntityValueRequest) (*idm.MetaToEntityValueResponse, error) {
-	entityValueDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx, manager.WithName("meta-entity-values"))
+	entityValueDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}
@@ -520,7 +520,7 @@ func (h *Handler) GetMetadata(ctx context.Context, req *idm.GetMetadataRequest) 
 }
 
 func (h *Handler) UnlinkMetaFromEntityValue(ctx context.Context, req *idm.MetaToEntityValueRequest) (*idm.MetaToEntityValueResponse, error) {
-	entityValueDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx, manager.WithName("meta-entity-values"))
+	entityValueDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 	if err != nil {
 		return nil, err
 	}

--- a/idm/meta/grpc/service/service.go
+++ b/idm/meta/grpc/service/service.go
@@ -57,14 +57,27 @@ func init() {
 			service.Metadata(meta2.ServiceMetaProviderRequired, "true"),
 			service.Description("User-defined Metadata"),
 			service.WithStorageDrivers(meta.Drivers),
+			service.WithNamedStorageDrivers("meta-entities", meta.EntityDrivers),
+			service.WithNamedStorageDrivers("meta-entity-values", meta.EntityValueDrivers),
 			service.Migrations([]*service.Migration{
 				{
 					TargetVersion: service.FirstRunOrChange(),
-					Up:            manager.StorageMigration(),
+					Up: func(ctx context.Context) error {
+						return manager.StorageMigration()(ctx)
+					},
 				},
 				{
 					TargetVersion: service.FirstRun(),
 					Up: func(ctx context.Context) error {
+						// Migrate EntityDAO (Entities table)
+						entityDAO, err := manager.Resolve[meta.EntityDAO](ctx, manager.WithName("meta-entities"))
+						if err != nil {
+							return err
+						}
+						if err = entityDAO.Migrate(ctx); err != nil {
+							return err
+						}
+						// Migrate main DAO
 						dao, err := manager.Resolve[meta.DAO](ctx)
 						if err != nil {
 							return err
@@ -72,7 +85,20 @@ func init() {
 						if err = dao.Migrate(ctx); err != nil {
 							return err
 						}
-						return defaultMetas(ctx, dao)
+						// Insert default metas and entities
+						if err = defaultMetas(ctx, dao, entityDAO); err != nil {
+							return err
+						}
+						// Migrate EntityValueDAO (EntityValues table and relations)
+						entityValueDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
+						if err != nil {
+							return err
+						}
+						if err = entityValueDAO.Migrate(ctx); err != nil {
+							return err
+						}
+						return nil
+
 					},
 				},
 			}),
@@ -100,11 +126,12 @@ func init() {
 	})
 }
 
-func defaultMetas(ctx context.Context, dao meta.DAO) error {
+func defaultMetas(ctx context.Context, dao meta.DAO, entityDAO meta.EntityDAO) error {
 	err, _ := dao.GetNamespaceDao().Upsert(ctx, &idm.UserMetaNamespace{
 		Namespace:      common.MetaNamespaceUserspacePrefix + "tags",
 		Label:          "Tags",
 		Indexable:      true,
+		FieldType:      "tags",
 		JsonDefinition: "{\"type\":\"tags\"}",
 		Description:    "Default Tags",
 		Policies: []*service2.ResourcePolicy{
@@ -112,13 +139,10 @@ func defaultMetas(ctx context.Context, dao meta.DAO) error {
 			{Action: service2.ResourcePolicyAction_WRITE, Subject: "*", Effect: service2.ResourcePolicy_allow},
 		},
 	})
-	if err == nil {
-		log.Logger(ctx).Info("Inserted default namespace for metadata")
-		return nil
+	if err != nil && !errors.Is(err, gorm.ErrDuplicatedKey) {
+		return err
 	}
-	if errors.Is(err, gorm.ErrDuplicatedKey) {
-		// This is a duplicate error, we ignore it
-		return nil
-	}
-	return err
+	log.Logger(ctx).Info("Inserted default namespace for metadata")
+
+	return nil
 }

--- a/idm/meta/grpc/service/service.go
+++ b/idm/meta/grpc/service/service.go
@@ -86,16 +86,16 @@ func init() {
 						if err = dao.Migrate(ctx); err != nil {
 							return err
 						}
-						// Insert default metas
-						if err = defaultMetas(ctx, dao); err != nil {
-							return err
-						}
 						// Migrate EntityDAO (Entities table)
 						entityDAO, err := manager.Resolve[meta.EntityDAO](ctx, manager.WithName("meta-entities"))
 						if err != nil {
 							return err
 						}
 						if err = entityDAO.Migrate(ctx); err != nil {
+							return err
+						}
+						// Insert default metas and entities
+						if err = defaultMetas(ctx, dao, entityDAO); err != nil {
 							return err
 						}
 						// Migrate EntityValueDAO (EntityValues table and relations)
@@ -135,7 +135,7 @@ func init() {
 	})
 }
 
-func defaultMetas(ctx context.Context, dao meta.DAO) error {
+func defaultMetas(ctx context.Context, dao meta.DAO, entityDAO meta.EntityDAO) error {
 	err, _ := dao.GetNamespaceDao().Upsert(ctx, &idm.UserMetaNamespace{
 		Namespace:      common.MetaNamespaceUserspacePrefix + "tags",
 		Label:          "Tags",
@@ -147,13 +147,27 @@ func defaultMetas(ctx context.Context, dao meta.DAO) error {
 			{Action: service2.ResourcePolicyAction_WRITE, Subject: "*", Effect: service2.ResourcePolicy_allow},
 		},
 	})
-	if err == nil {
-		log.Logger(ctx).Info("Inserted default namespace for metadata")
-		return nil
+	if err != nil && !errors.Is(err, gorm.ErrDuplicatedKey) {
+		return err
 	}
-	if errors.Is(err, gorm.ErrDuplicatedKey) {
-		// This is a duplicate error, we ignore it
-		return nil
+	log.Logger(ctx).Info("Inserted default namespace for metadata")
+
+	// Insert default entities with admin-only policies
+	defaultEntities := []*idm.MetaEntity{
+		{
+			Label:       "tags",
+			Description: "Default tags entity",
+			Policies: []*service2.ResourcePolicy{
+				{Action: service2.ResourcePolicyAction_READ, Subject: "profile:admin", Effect: service2.ResourcePolicy_allow},
+				{Action: service2.ResourcePolicyAction_WRITE, Subject: "profile:admin", Effect: service2.ResourcePolicy_allow},
+			},
+		},
 	}
-	return err
+	for _, entity := range defaultEntities {
+		if _, err = entityDAO.CreateEntity(ctx, entity); err != nil && !errors.Is(err, gorm.ErrDuplicatedKey) {
+			log.Logger(ctx).Warn("could not insert default entity: " + entity.Label)
+		}
+	}
+	log.Logger(ctx).Info("Inserted default entities")
+	return nil
 }

--- a/idm/meta/grpc/service/service.go
+++ b/idm/meta/grpc/service/service.go
@@ -57,14 +57,28 @@ func init() {
 			service.Metadata(meta2.ServiceMetaProviderRequired, "true"),
 			service.Description("User-defined Metadata"),
 			service.WithStorageDrivers(meta.Drivers),
+			service.WithNamedStorageDrivers("meta-entities", meta.EntityDrivers),
+			service.WithNamedStorageDrivers("meta-entity-values", meta.EntityValueDrivers),
 			service.Migrations([]*service.Migration{
 				{
 					TargetVersion: service.FirstRunOrChange(),
-					Up:            manager.StorageMigration(),
+					Up: func(ctx context.Context) error {
+						// Migrate main storage
+						if err := manager.StorageMigration()(ctx); err != nil {
+							return err
+						}
+						// Migrate entities storage (Entities table)
+						if err := manager.StorageMigration(manager.WithName("meta-entities"))(ctx); err != nil {
+							return err
+						}
+						// Migrate entity values storage (EntityValues table and relations)
+						return manager.StorageMigration(manager.WithName("meta-entity-values"))(ctx)
+					},
 				},
 				{
 					TargetVersion: service.FirstRun(),
 					Up: func(ctx context.Context) error {
+						// Migrate main DAO
 						dao, err := manager.Resolve[meta.DAO](ctx)
 						if err != nil {
 							return err
@@ -72,7 +86,28 @@ func init() {
 						if err = dao.Migrate(ctx); err != nil {
 							return err
 						}
-						return defaultMetas(ctx, dao)
+						// Insert default metas
+						if err = defaultMetas(ctx, dao); err != nil {
+							return err
+						}
+						// Migrate EntityDAO (Entities table)
+						entityDAO, err := manager.Resolve[meta.MetaEntityDAO](ctx, manager.WithName("meta-entities"))
+						if err != nil {
+							return err
+						}
+						if err = entityDAO.Migrate(ctx); err != nil {
+							return err
+						}
+						// Migrate EntityValueDAO (EntityValues table and relations)
+						entityValueDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx, manager.WithName("meta-entity-values"))
+						if err != nil {
+							return err
+						}
+						if err = entityValueDAO.Migrate(ctx); err != nil {
+							return err
+						}
+						return nil
+
 					},
 				},
 			}),

--- a/idm/meta/grpc/service/service.go
+++ b/idm/meta/grpc/service/service.go
@@ -91,7 +91,7 @@ func init() {
 							return err
 						}
 						// Migrate EntityDAO (Entities table)
-						entityDAO, err := manager.Resolve[meta.MetaEntityDAO](ctx, manager.WithName("meta-entities"))
+						entityDAO, err := manager.Resolve[meta.EntityDAO](ctx, manager.WithName("meta-entities"))
 						if err != nil {
 							return err
 						}
@@ -99,7 +99,7 @@ func init() {
 							return err
 						}
 						// Migrate EntityValueDAO (EntityValues table and relations)
-						entityValueDAO, err := manager.Resolve[meta.MetaEntityValueDAO](ctx, manager.WithName("meta-entity-values"))
+						entityValueDAO, err := manager.Resolve[meta.EntityValueDAO](ctx, manager.WithName("meta-entity-values"))
 						if err != nil {
 							return err
 						}

--- a/idm/meta/rest/handler.go
+++ b/idm/meta/rest/handler.go
@@ -22,7 +22,6 @@ package rest
 
 import (
 	"context"
-	"encoding/json"
 	"path"
 	"slices"
 	"strings"
@@ -162,65 +161,6 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 		if !strings.HasPrefix(ns.Namespace, common.MetaNamespaceUserspacePrefix) {
 			return errors.WithMessage(errors.InvalidParameters, "user defined meta must start with "+common.MetaNamespaceUserspacePrefix+" prefix")
 		}
-		// Use the helper to validate and get definition
-		definition, e := ns.UnmarshallDefinition()
-		if e != nil {
-			return errors.WithMessagef(errors.UnmarshalError, "invalid json definition for namespace: %s, %v", ns.Namespace, e)
-		}
-		if input.Operation == idm.UpdateUserMetaNamespaceRequest_PUT {
-			fieldType := definition.GetType()
-			if fieldType != "" {
-				if definition.GetEntityId() == "" {
-					// Set description
-					var desc = ""
-					if ns.Description != "" {
-						desc = ns.Description
-					} else {
-						desc = "Entity for " + fieldType + " namespace"
-					}
-					// Its somewhat dangerous to create before namespace has been created but its more efficient than doing it after
-					entity, err := s.ServiceClient(ctx).CreateEntity(ctx, &idm.CreateEntityRequest{
-						Entity: &idm.MetaEntity{
-							Label:       "ns-entity-" + ns.Namespace,
-							Description: desc,
-						},
-					})
-					if err != nil {
-						return err
-					}
-
-					if def, ok := definition.(*idm.MetaNsDef); ok {
-						def.SetEntityId(entity.Entity.Uuid)
-						updatedJsDef, err := json.Marshal(def)
-						if err != nil {
-							return err
-						}
-						ns.JsonDefinition = string(updatedJsDef)
-					}
-					if slices.Contains(ns_with_ev, fieldType) {
-						// Create empty entity values
-						evs := []*idm.EntityValue{}
-						evs = s.parseEntityValues(definition)
-
-						_, err := s.ServiceClient(ctx).CreateEntityValues(ctx, &idm.CreateEntityValueRequest{
-							EntityValue: evs,
-						})
-						if err != nil {
-							return err
-						}
-					}
-				} else if definition.GetEntityId() != "" && slices.Contains(ns_with_ev, fieldType) {
-					evs := []*idm.EntityValue{}
-					evs = s.parseEntityValues(definition)
-					_, err := s.ServiceClient(ctx).CreateEntityValues(ctx, &idm.CreateEntityValueRequest{
-						EntityValue: evs,
-					})
-					if err != nil {
-						return err
-					}
-				}
-			}
-		}
 	}
 	response, err := s.ServiceClient(ctx).UpdateUserMetaNamespace(ctx, &input)
 	if err != nil {
@@ -232,7 +172,7 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 				if entityID == "" {
 					continue
 				}
-				if _, err := s.DeleteEntity(ctx, entityID); err != nil {
+				if _, err := s.ServiceClient(ctx).DeleteEntity(ctx, &idm.DeleteEntityRequest{EntityId: entityID}); err != nil {
 					return err
 				}
 			}
@@ -247,7 +187,7 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 				if entityID == "" {
 					continue
 				}
-				if _, err := s.DeleteEntity(ctx, entityID); err != nil {
+				if _, err := s.ServiceClient(ctx).DeleteEntity(ctx, &idm.DeleteEntityRequest{EntityId: entityID}); err != nil {
 					return err
 				}
 			}
@@ -273,6 +213,46 @@ func (s *UserMetaHandler) ListUserMetaNamespace(req *restful.Request, rsp *restf
 		return err
 	}
 
+}
+
+// DeleteEntity deletes a meta entity by its ID, after checking WRITE policy
+func (s *UserMetaHandler) DeleteEntity(req *restful.Request, rsp *restful.Response) error {
+	ctx := req.Request.Context()
+	entityId := req.PathParameter("EntityId")
+	if entityId == "" {
+		var request idm.DeleteEntityRequest
+		if err := req.ReadEntity(&request); err != nil {
+			return errors.WithMessagef(errors.StatusBadRequest, "failed to parse request: %v", err)
+		}
+		entityId = request.EntityId
+	}
+
+	response, err := s.PerformDeleteEntity(ctx, &idm.DeleteEntityRequest{EntityId: entityId})
+	if err != nil {
+		return err
+	}
+
+	return rsp.WriteEntity(response)
+}
+
+// PerformDeleteEntity loads the entity, checks WRITE policy, then deletes
+func (s *UserMetaHandler) PerformDeleteEntity(ctx context.Context, request *idm.DeleteEntityRequest) (*idm.DeleteEntityResponse, error) {
+	// Load entity to get its policies
+	entity, err := s.ServiceClient(ctx).GetEntity(ctx, &idm.GetEntityRequest{EntityUuid: request.EntityId})
+	if err != nil {
+		return nil, err
+	}
+	if entity != nil && entity.Entity != nil {
+		if !s.MatchPolicies(ctx, entity.Entity.Uuid, entity.Entity.Policies, serviceproto.ResourcePolicyAction_WRITE) {
+			return nil, errors.WithMessagef(errors.StatusForbidden, "You are not allowed to delete this entity", err)
+		}
+	}
+	response, err := s.ServiceClient(ctx).DeleteEntity(ctx, request)
+	if err != nil {
+		log.Logger(ctx).Error("failed to delete entity", zap.String("entityId", request.EntityId), zap.Error(err))
+		return nil, err
+	}
+	return response, nil
 }
 
 func (s *UserMetaHandler) GetFieldSchema(req *restful.Request, rsp *restful.Response) error {
@@ -415,8 +395,8 @@ func (s *UserMetaHandler) ListAllNamespaces(ctx context.Context, client idm.User
 	return s.Namespaces(ctx)
 }
 
+// TODO remove
 func (s *UserMetaHandler) PoliciesForMeta(ctx context.Context, resourceId string, resourceClient interface{}) (policies []*serviceproto.ResourcePolicy, e error) {
-
 	return
 }
 
@@ -450,4 +430,105 @@ func (h *UserMetaHandler) parseEntityValues(definition idm.MetaNamespaceDefiniti
 		}
 	}
 	return evs
+}
+
+// ListEntities lists all entities the current context has READ access to
+func (s *UserMetaHandler) ListEntities(req *restful.Request, rsp *restful.Response) error {
+	ctx := req.Request.Context()
+
+	entities, err := s.Entities(ctx)
+	if err != nil {
+		return err
+	}
+
+	result := make([]*idm.MetaEntity, 0, len(entities))
+	for _, e := range entities {
+		result = append(result, e)
+	}
+
+	return rsp.WriteEntity(&idm.ListEntitiesResponse{Entity: result})
+}
+
+// PutEntity creates a new meta entity with admin-only policies
+func (s *UserMetaHandler) PutEntity(req *restful.Request, rsp *restful.Response) error {
+	ctx := req.Request.Context()
+
+	var input idm.CreateEntityRequest
+	if err := req.ReadEntity(&input); err != nil {
+		return errors.WithMessagef(errors.StatusBadRequest, "failed to parse request: %v", err)
+	}
+
+	// Attach default admin-only policies if none provided
+	if input.Entity != nil && len(input.Entity.Policies) == 0 {
+		input.Entity.Policies = []*serviceproto.ResourcePolicy{
+			{Action: serviceproto.ResourcePolicyAction_READ, Subject: "profile:admin", Effect: serviceproto.ResourcePolicy_allow},
+			{Action: serviceproto.ResourcePolicyAction_WRITE, Subject: "profile:admin", Effect: serviceproto.ResourcePolicy_allow},
+		}
+	}
+
+	response, err := s.PerformPutEntity(ctx, &input)
+	if err != nil {
+		return err
+	}
+
+	return rsp.WriteEntity(response)
+}
+
+// PerformPutEntity performs the actual entity creation
+func (s *UserMetaHandler) PerformPutEntity(ctx context.Context, request *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error) {
+	response, err := s.ServiceClient(ctx).CreateEntity(ctx, request)
+	if err != nil {
+		log.Logger(ctx).Error("failed to create entity", zap.Error(err))
+		return nil, err
+	}
+	return response, nil
+}
+
+func (s *UserMetaHandler) CreateEntityValues(req *restful.Request, rsp *restful.Response) error {
+	var input idm.CreateEntityValueRequest
+	if err := req.ReadEntity(&input); err != nil {
+		return errors.WithMessagef(errors.StatusBadRequest, "failed to parse request: %v", err)
+	}
+
+	// Attach default policies: READ & WRITE for all users
+	for _, ev := range input.EntityValue {
+		if ev != nil && len(ev.Policies) == 0 {
+			ev.Policies = []*serviceproto.ResourcePolicy{
+				{Action: serviceproto.ResourcePolicyAction_READ, Subject: "*", Effect: serviceproto.ResourcePolicy_allow},
+				{Action: serviceproto.ResourcePolicyAction_WRITE, Subject: "*", Effect: serviceproto.ResourcePolicy_allow},
+			}
+		}
+	}
+
+	ctx := req.Request.Context()
+
+	response, err := s.PerformCreateEntityValues(ctx, &input)
+	if err != nil {
+		return err
+	}
+
+	if len(input.EntityValue) > 0 {
+		// Update the namespace definition with the new entity values
+		for _, ev := range input.EntityValue {
+			if ev == nil {
+				continue
+			}
+			if ev.MetaUuid != "" {
+				//link logic
+
+			}
+		}
+	}
+
+	return rsp.WriteEntity(response)
+}
+
+// PerformCreateEntityValues performs the actual entity values creation
+func (s *UserMetaHandler) PerformCreateEntityValues(ctx context.Context, request *idm.CreateEntityValueRequest) (*idm.CreateEntityValueResponse, error) {
+	response, err := s.ServiceClient(ctx).CreateEntityValues(ctx, request)
+	if err != nil {
+		log.Logger(ctx).Error("failed to create entity values", zap.Error(err))
+		return nil, err
+	}
+	return response, nil
 }

--- a/idm/meta/rest/handler.go
+++ b/idm/meta/rest/handler.go
@@ -22,7 +22,6 @@ package rest
 
 import (
 	"context"
-	"encoding/json"
 	"path"
 	"slices"
 	"strings"
@@ -162,65 +161,6 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 		if !strings.HasPrefix(ns.Namespace, common.MetaNamespaceUserspacePrefix) {
 			return errors.WithMessage(errors.InvalidParameters, "user defined meta must start with "+common.MetaNamespaceUserspacePrefix+" prefix")
 		}
-		// Use the helper to validate and get definition
-		definition, e := ns.UnmarshallDefinition()
-		if e != nil {
-			return errors.WithMessagef(errors.UnmarshalError, "invalid json definition for namespace: %s, %v", ns.Namespace, e)
-		}
-		if input.Operation == idm.UpdateUserMetaNamespaceRequest_PUT {
-			fieldType := definition.GetType()
-			if fieldType != "" {
-				if definition.GetEntityId() == "" {
-					// Set description
-					var desc = ""
-					if ns.Description != "" {
-						desc = ns.Description
-					} else {
-						desc = "Entity for " + fieldType + " namespace"
-					}
-					// Its somewhat dangerous to create before namespace has been created but its more efficient than doing it after
-					entity, err := s.ServiceClient(ctx).CreateEntity(ctx, &idm.CreateEntityRequest{
-						Entity: &idm.MetaEntity{
-							Label:       "ns-entity-" + ns.Namespace,
-							Description: desc,
-						},
-					})
-					if err != nil {
-						return err
-					}
-
-					if def, ok := definition.(*idm.MetaNsDef); ok {
-						def.SetEntityId(entity.Entity.Uuid)
-						updatedJsDef, err := json.Marshal(def)
-						if err != nil {
-							return err
-						}
-						ns.JsonDefinition = string(updatedJsDef)
-					}
-					if slices.Contains(ns_with_ev, fieldType) {
-						// Create empty entity values
-						evs := []*idm.EntityValue{}
-						evs = s.parseEntityValues(definition)
-
-						_, err := s.ServiceClient(ctx).CreateEntityValues(ctx, &idm.CreateEntityValueRequest{
-							EntityValue: evs,
-						})
-						if err != nil {
-							return err
-						}
-					}
-				} else if definition.GetEntityId() != "" && slices.Contains(ns_with_ev, fieldType) {
-					evs := []*idm.EntityValue{}
-					evs = s.parseEntityValues(definition)
-					_, err := s.ServiceClient(ctx).CreateEntityValues(ctx, &idm.CreateEntityValueRequest{
-						EntityValue: evs,
-					})
-					if err != nil {
-						return err
-					}
-				}
-			}
-		}
 	}
 
 	response, err := s.ServiceClient(ctx).UpdateUserMetaNamespace(ctx, &input)
@@ -233,7 +173,7 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 				if entityID == "" {
 					continue
 				}
-				if _, err := s.DeleteEntity(ctx, entityID); err != nil {
+				if _, err := s.ServiceClient(ctx).DeleteEntity(ctx, &idm.DeleteEntityRequest{EntityId: entityID}); err != nil {
 					return err
 				}
 			}
@@ -242,13 +182,13 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 	} else if input.Operation == idm.UpdateUserMetaNamespaceRequest_DELETE {
 		for _, ns := range input.Namespaces {
 			// Use helper to check if we need to cleanup
-			definition, _ := ns.UnmarshallDefinition()
+			definition, _ := ns.UnmarshallEntityDefinition()
 			if definition != nil && definition.GetType() != "" {
 				entityID := definition.GetEntityId()
 				if entityID == "" {
 					continue
 				}
-				if _, err := s.DeleteEntity(ctx, entityID); err != nil {
+				if _, err := s.ServiceClient(ctx).DeleteEntity(ctx, &idm.DeleteEntityRequest{EntityId: entityID}); err != nil {
 					return err
 				}
 			}
@@ -274,6 +214,46 @@ func (s *UserMetaHandler) ListUserMetaNamespace(req *restful.Request, rsp *restf
 		return err
 	}
 
+}
+
+// DeleteEntity deletes a meta entity by its ID, after checking WRITE policy
+func (s *UserMetaHandler) DeleteEntity(req *restful.Request, rsp *restful.Response) error {
+	ctx := req.Request.Context()
+	entityId := req.PathParameter("EntityId")
+	if entityId == "" {
+		var request idm.DeleteEntityRequest
+		if err := req.ReadEntity(&request); err != nil {
+			return errors.WithMessagef(errors.StatusBadRequest, "failed to parse request: %v", err)
+		}
+		entityId = request.EntityId
+	}
+
+	response, err := s.PerformDeleteEntity(ctx, &idm.DeleteEntityRequest{EntityId: entityId})
+	if err != nil {
+		return err
+	}
+
+	return rsp.WriteEntity(response)
+}
+
+// PerformDeleteEntity loads the entity, checks WRITE policy, then deletes
+func (s *UserMetaHandler) PerformDeleteEntity(ctx context.Context, request *idm.DeleteEntityRequest) (*idm.DeleteEntityResponse, error) {
+	// Load entity to get its policies
+	entity, err := s.ServiceClient(ctx).GetEntity(ctx, &idm.GetEntityRequest{EntityUuid: request.EntityId})
+	if err != nil {
+		return nil, err
+	}
+	if entity != nil && entity.Entity != nil {
+		if !s.MatchPolicies(ctx, entity.Entity.Uuid, entity.Entity.Policies, serviceproto.ResourcePolicyAction_WRITE) {
+			return nil, errors.WithMessagef(errors.StatusForbidden, "You are not allowed to delete this entity", err)
+		}
+	}
+	response, err := s.ServiceClient(ctx).DeleteEntity(ctx, request)
+	if err != nil {
+		log.Logger(ctx).Error("failed to delete entity", zap.String("entityId", request.EntityId), zap.Error(err))
+		return nil, err
+	}
+	return response, nil
 }
 
 func (s *UserMetaHandler) GetFieldSchema(req *restful.Request, rsp *restful.Response) error {
@@ -317,18 +297,23 @@ func (s *UserMetaHandler) ListUserMetaTags(req *restful.Request, rsp *restful.Re
 
 	// Use the helper to get definition
 	if nss[ns].FieldType != "" && slices.Contains(ns_with_ev, nss[ns].FieldType) {
-		definition, err := nsObject.UnmarshallDefinition()
+		definition, err := nsObject.UnmarshallEntityDefinition()
 		if err != nil {
 			return err
 		}
 
-		// Check type through interface
 		if slices.Contains(ns_with_ev, definition.GetType()) {
-			entityID := definition.GetEntityId()
-			if entityID == "" {
-				return err
+			var entityUUID string
+			if nss[ns].EntityUUID != "" {
+				entityUUID = nss[ns].EntityUUID
+
+			} else {
+				entityID := definition.GetEntityId()
+				if entityID == "" {
+					return nil
+				}
 			}
-			entityValues, err := s.GetEntityValues(ctx, entityID)
+			entityValues, err := s.GetEntityValues(ctx, entityUUID)
 			if err != nil {
 				return err
 			}
@@ -418,8 +403,8 @@ func (s *UserMetaHandler) ListAllNamespaces(ctx context.Context, client idm.User
 	return s.Namespaces(ctx)
 }
 
+// TODO remove
 func (s *UserMetaHandler) PoliciesForMeta(ctx context.Context, resourceId string, resourceClient interface{}) (policies []*serviceproto.ResourcePolicy, e error) {
-
 	return
 }
 
@@ -453,4 +438,105 @@ func (h *UserMetaHandler) parseEntityValues(definition idm.MetaNamespaceDefiniti
 		}
 	}
 	return evs
+}
+
+// ListEntities lists all entities the current context has READ access to
+func (s *UserMetaHandler) ListEntities(req *restful.Request, rsp *restful.Response) error {
+	ctx := req.Request.Context()
+
+	entities, err := s.Entities(ctx)
+	if err != nil {
+		return err
+	}
+
+	result := make([]*idm.MetaEntity, 0, len(entities))
+	for _, e := range entities {
+		result = append(result, e)
+	}
+
+	return rsp.WriteEntity(&idm.ListEntitiesResponse{Entity: result})
+}
+
+// PutEntity creates a new meta entity with admin-only policies
+func (s *UserMetaHandler) PutEntity(req *restful.Request, rsp *restful.Response) error {
+	ctx := req.Request.Context()
+
+	var input idm.CreateEntityRequest
+	if err := req.ReadEntity(&input); err != nil {
+		return errors.WithMessagef(errors.StatusBadRequest, "failed to parse request: %v", err)
+	}
+
+	// Attach default admin-only policies if none provided
+	if input.Entity != nil && len(input.Entity.Policies) == 0 {
+		input.Entity.Policies = []*serviceproto.ResourcePolicy{
+			{Action: serviceproto.ResourcePolicyAction_READ, Subject: "profile:admin", Effect: serviceproto.ResourcePolicy_allow},
+			{Action: serviceproto.ResourcePolicyAction_WRITE, Subject: "profile:admin", Effect: serviceproto.ResourcePolicy_allow},
+		}
+	}
+
+	response, err := s.PerformPutEntity(ctx, &input)
+	if err != nil {
+		return err
+	}
+
+	return rsp.WriteEntity(response)
+}
+
+// PerformPutEntity performs the actual entity creation
+func (s *UserMetaHandler) PerformPutEntity(ctx context.Context, request *idm.CreateEntityRequest) (*idm.CreateEntityResponse, error) {
+	response, err := s.ServiceClient(ctx).CreateEntity(ctx, request)
+	if err != nil {
+		log.Logger(ctx).Error("failed to create entity", zap.Error(err))
+		return nil, err
+	}
+	return response, nil
+}
+
+func (s *UserMetaHandler) CreateEntityValues(req *restful.Request, rsp *restful.Response) error {
+	var input idm.CreateEntityValueRequest
+	if err := req.ReadEntity(&input); err != nil {
+		return errors.WithMessagef(errors.StatusBadRequest, "failed to parse request: %v", err)
+	}
+
+	// Attach default policies: READ & WRITE for all users
+	for _, ev := range input.EntityValue {
+		if ev != nil && len(ev.Policies) == 0 {
+			ev.Policies = []*serviceproto.ResourcePolicy{
+				{Action: serviceproto.ResourcePolicyAction_READ, Subject: "*", Effect: serviceproto.ResourcePolicy_allow},
+				{Action: serviceproto.ResourcePolicyAction_WRITE, Subject: "*", Effect: serviceproto.ResourcePolicy_allow},
+			}
+		}
+	}
+
+	ctx := req.Request.Context()
+
+	response, err := s.PerformCreateEntityValues(ctx, &input)
+	if err != nil {
+		return err
+	}
+
+	if len(input.EntityValue) > 0 {
+		// Update the namespace definition with the new entity values
+		for _, ev := range input.EntityValue {
+			if ev == nil {
+				continue
+			}
+			if ev.MetaUuid != "" {
+				//link logic
+
+			}
+		}
+	}
+
+	return rsp.WriteEntity(response)
+}
+
+// PerformCreateEntityValues performs the actual entity values creation
+func (s *UserMetaHandler) PerformCreateEntityValues(ctx context.Context, request *idm.CreateEntityValueRequest) (*idm.CreateEntityValueResponse, error) {
+	response, err := s.ServiceClient(ctx).CreateEntityValues(ctx, request)
+	if err != nil {
+		log.Logger(ctx).Error("failed to create entity values", zap.Error(err))
+		return nil, err
+	}
+	return response, nil
 }

--- a/idm/meta/rest/handler.go
+++ b/idm/meta/rest/handler.go
@@ -23,7 +23,6 @@ package rest
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"path"
 	"slices"
 	"strings"
@@ -166,10 +165,7 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 		// Use the helper to validate and get definition
 
 		definition, e := ns.UnmarshallDefinition()
-		fmt.Println(definition)
-		// fmt.Println(e)
 		if e != nil {
-			fmt.Println(ns.JsonDefinition)
 			return errors.WithMessagef(errors.UnmarshalError, "invalid json definition for namespace: %s, %v", ns.Namespace, e)
 		}
 		if input.Operation == idm.UpdateUserMetaNamespaceRequest_PUT {

--- a/idm/meta/rest/handler.go
+++ b/idm/meta/rest/handler.go
@@ -23,6 +23,7 @@ package rest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path"
 	"slices"
 	"strings"
@@ -163,8 +164,12 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 			return errors.WithMessage(errors.InvalidParameters, "user defined meta must start with "+common.MetaNamespaceUserspacePrefix+" prefix")
 		}
 		// Use the helper to validate and get definition
+
 		definition, e := ns.UnmarshallDefinition()
+		fmt.Println(definition)
+		// fmt.Println(e)
 		if e != nil {
+			fmt.Println(ns.JsonDefinition)
 			return errors.WithMessagef(errors.UnmarshalError, "invalid json definition for namespace: %s, %v", ns.Namespace, e)
 		}
 		if input.Operation == idm.UpdateUserMetaNamespaceRequest_PUT {
@@ -222,7 +227,7 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 			}
 		}
 	}
-
+	// fmt.Println("FAILING TEST", input)
 	response, err := s.ServiceClient(ctx).UpdateUserMetaNamespace(ctx, &input)
 	if err != nil {
 		for _, ns := range input.Namespaces {

--- a/idm/meta/rest/handler.go
+++ b/idm/meta/rest/handler.go
@@ -163,7 +163,6 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 			return errors.WithMessage(errors.InvalidParameters, "user defined meta must start with "+common.MetaNamespaceUserspacePrefix+" prefix")
 		}
 		// Use the helper to validate and get definition
-
 		definition, e := ns.UnmarshallDefinition()
 		if e != nil {
 			return errors.WithMessagef(errors.UnmarshalError, "invalid json definition for namespace: %s, %v", ns.Namespace, e)
@@ -223,7 +222,6 @@ func (s *UserMetaHandler) UpdateUserMetaNamespace(req *restful.Request, rsp *res
 			}
 		}
 	}
-	// fmt.Println("FAILING TEST", input)
 	response, err := s.ServiceClient(ctx).UpdateUserMetaNamespace(ctx, &input)
 	if err != nil {
 		for _, ns := range input.Namespaces {

--- a/idm/policy/defaults.go
+++ b/idm/policy/defaults.go
@@ -191,6 +191,17 @@ var (
 					Effect:  ladon.AllowAccess,
 				}),
 				converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
+					ID:          "user-meta-entity",
+					Description: "PolicyGroup.LoggedUsers.Rule8",
+					Subjects:    []string{"profile:admin"},
+					Resources: []string{
+						"rest:/user-meta/entity",
+						"rest:/user-meta/entity/<.+>",
+					},
+					Actions: []string{"GET", "PUT", "DELETE"},
+					Effect:  ladon.AllowAccess,
+				}),
+				converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
 					ID:          "frontend-read",
 					Description: "PolicyGroup.LoggedUsers.Rule5",
 					Subjects:    []string{"profile:standard", "profile:shared"},

--- a/idm/policy/defaults.go
+++ b/idm/policy/defaults.go
@@ -176,6 +176,8 @@ var (
 						"rest:/user-meta/namespace/<.+>",
 						"rest:/user-meta/search",
 						"rest:/user-meta/tags/<.+>",
+						"rest:/user-meta/entity",
+						"rest:/user-meta/entity/<.+>",
 					},
 					Actions: []string{"GET", "POST"},
 					Effect:  ladon.AllowAccess,
@@ -188,6 +190,17 @@ var (
 						"rest:/user-meta/update",
 					},
 					Actions: []string{"PUT"},
+					Effect:  ladon.AllowAccess,
+				}),
+				converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
+					ID:          "user-meta-entity",
+					Description: "PolicyGroup.LoggedUsers.Rule8",
+					Subjects:    []string{"profile:admin"},
+					Resources: []string{
+						"rest:/user-meta/entity",
+						"rest:/user-meta/entity/<.+>",
+					},
+					Actions: []string{"GET", "PUT", "DELETE"},
 					Effect:  ladon.AllowAccess,
 				}),
 				converter.LadonToProtoPolicy(&ladon.DefaultPolicy{
@@ -899,6 +912,39 @@ func Upgrade4994(ctx context.Context) error {
 	return nil
 }
 
+// Upgrade503 grants standard and shared users GET access to the bare /user-meta/entity
+// path (entity listing). Previously only admins could reach that endpoint; the per-entity
+// path (entity/<id>) was already covered by user-meta-read.
+func Upgrade503(ctx context.Context) error {
+	dao, er := manager.Resolve[DAO](ctx)
+	if er != nil {
+		return er
+	}
+	groups, e := dao.ListPolicyGroups(ctx, nil)
+	if e != nil {
+		return e
+	}
+	for _, group := range groups {
+		if group.GetUuid() != "rest-apis-default-accesses" {
+			continue
+		}
+		for _, p := range group.Policies {
+			if p.GetID() == "user-meta-read" {
+				if !slices.Contains(p.Resources, "rest:/user-meta/entity") {
+					p.Resources = append(p.Resources, "rest:/user-meta/entity")
+				}
+			}
+		}
+		if _, er := dao.StorePolicyGroup(ctx, group); er != nil {
+			log.Logger(ctx).Error("could not update policy group "+group.GetUuid(), zap.Error(er))
+		} else {
+			log.Logger(ctx).Info("Updated policy group " + group.GetUuid())
+		}
+	}
+	log.Logger(ctx).Info("Upgraded policy model to v5.0.3")
+	return nil
+}
+
 var DefaultsServiceMigrationsAfter4416 = []*service.Migration{
 	{
 		TargetVersion: service.ValidVersion("4.5.0"),
@@ -911,6 +957,10 @@ var DefaultsServiceMigrationsAfter4416 = []*service.Migration{
 	{
 		TargetVersion: service.ValidVersion("4.9.94"),
 		Up:            Upgrade4994,
+	},
+	{
+		TargetVersion: service.ValidVersion("5.0.3"),
+		Up:            Upgrade503,
 	},
 }
 


### PR DESCRIPTION
### Changes
- adding policy migrations for Entities and Values models
- refactor Dao initialization for Entities and Values
- use Dao resolution with name in grpc handlers
- Apply dao resolution changes in unit tests 
- Following up with more pull requests to add and resolve new policies for Entities and values

### Migration generates tables:

- `idm_usr_entity_values_policies`
- `idm_usr_entity_policies`

### Ticket: [WPB-22900](https://wearezeta.atlassian.net/browse/WPB-22900?search_id=b52de85e-a134-4ffc-8fb3-8bbb6e32ca5c&referrer=quick-find)

[WPB-22900]: https://wearezeta.atlassian.net/browse/WPB-22900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ