### PR TITLE
Fix(sync): WPB-24026-Partial sync, event and data race bugs

### DIFF
--- a/common/broker/fsqueue/adapter.go
+++ b/common/broker/fsqueue/adapter.go
@@ -86,10 +86,10 @@ type fpubQueue struct {
 	basePath string
 	name     string
 
-	closeMu       sync.Mutex
-	closed        bool
-	consumerDone  chan struct{} // Lazily initialized in Consume()
-	closeErr      error
+	closeMu      sync.Mutex
+	closed       bool
+	consumerDone chan struct{} // Lazily initialized in Consume()
+	closeErr     error
 }
 
 // OpenURL implements broker.AsyncQueueOpener.
@@ -156,12 +156,13 @@ func (f *fpubQueue) OpenURL(ctx context.Context, u *url.URL) (broker.AsyncQueue,
 	}
 	qCtx, cancel := context.WithCancel(ctx)
 	q := &fpubQueue{
-		ctx:      qCtx,
-		cancel:   cancel,
-		topic:    topic,
-		sub:      sub,
-		basePath: basePath,
-		name:     streamName,
+		ctx:          qCtx,
+		cancel:       cancel,
+		topic:        topic,
+		sub:          sub,
+		basePath:     basePath,
+		name:         streamName,
+		consumerDone: make(chan struct{}),
 	}
 	registry[basePath] = &fpubEntry{queue: q, refCount: 1}
 	return q, nil
@@ -215,13 +216,6 @@ func (f *fpubQueue) PushRaw(ctx context.Context, message broker.Message) error {
 // Starts a goroutine that receives messages from the subscription
 // and invokes the callback with decoded broker.Messages.
 func (f *fpubQueue) Consume(callback func(context.Context, ...broker.Message)) error {
-	// Lazily initialize consumerDone channel
-	f.closeMu.Lock()
-	if f.consumerDone == nil {
-		f.consumerDone = make(chan struct{})
-	}
-	f.closeMu.Unlock()
-
 	go func() {
 		defer close(f.consumerDone) // Signal consumer exit when goroutine exits
 		for {
@@ -352,13 +346,5 @@ func (f *fpubQueue) Close(ctx context.Context) error {
 }
 
 func (f *fpubQueue) Done() <-chan struct{} {
-	f.closeMu.Lock()
-	defer f.closeMu.Unlock()
-	if f.consumerDone != nil {
-		return f.consumerDone
-	}
-	// Return a closed channel if consumer never started
-	ch := make(chan struct{})
-	close(ch)
-	return ch
+	return f.consumerDone
 }

--- a/common/broker/fsqueue/adapter.go
+++ b/common/broker/fsqueue/adapter.go
@@ -86,11 +86,10 @@ type fpubQueue struct {
 	basePath string
 	name     string
 
-	consumerDone chan struct{}
-
-	closeMu  sync.Mutex
-	closed   bool
-	closeErr error
+	closeMu       sync.Mutex
+	closed        bool
+	consumerDone  chan struct{} // Lazily initialized in Consume()
+	closeErr      error
 }
 
 // OpenURL implements broker.AsyncQueueOpener.
@@ -216,6 +215,7 @@ func (f *fpubQueue) PushRaw(ctx context.Context, message broker.Message) error {
 // Starts a goroutine that receives messages from the subscription
 // and invokes the callback with decoded broker.Messages.
 func (f *fpubQueue) Consume(callback func(context.Context, ...broker.Message)) error {
+	// Lazily initialize consumerDone channel
 	f.closeMu.Lock()
 	if f.consumerDone == nil {
 		f.consumerDone = make(chan struct{})
@@ -223,7 +223,7 @@ func (f *fpubQueue) Consume(callback func(context.Context, ...broker.Message)) e
 	f.closeMu.Unlock()
 
 	go func() {
-		defer close(f.consumerDone)
+		defer close(f.consumerDone) // Signal consumer exit when goroutine exits
 		for {
 			select {
 			case <-f.ctx.Done():
@@ -325,7 +325,7 @@ func (f *fpubQueue) Close(ctx context.Context) error {
 		f.cancel()
 	}
 
-	// Wait for Consume goroutine WITHOUT holding closeMu
+	// Wait for consumer goroutine to exit
 	if f.consumerDone != nil {
 		<-f.consumerDone
 	}
@@ -351,4 +351,14 @@ func (f *fpubQueue) Close(ctx context.Context) error {
 	return f.closeErr
 }
 
-func (f *fpubQueue) Done() <-chan struct{} { return f.consumerDone }
+func (f *fpubQueue) Done() <-chan struct{} {
+	f.closeMu.Lock()
+	defer f.closeMu.Unlock()
+	if f.consumerDone != nil {
+		return f.consumerDone
+	}
+	// Return a closed channel if consumer never started
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}

--- a/common/broker/fsqueue/adapter.go
+++ b/common/broker/fsqueue/adapter.go
@@ -61,6 +61,17 @@ var (
 	errQueueClosed       = errors.New("fpub: queue is closed")
 )
 
+// Process-wide registry so two opens of the same basePath share one queue.
+var (
+	registryMu sync.Mutex
+	registry   = map[string]*fpubEntry{}
+)
+
+type fpubEntry struct {
+	queue    *fpubQueue
+	refCount int
+}
+
 func init() {
 	broker.RegisterAsyncQueue("fpub", &fpubQueue{})
 }
@@ -73,6 +84,8 @@ type fpubQueue struct {
 	sub      *pubsub.Subscription
 	basePath string
 	name     string
+
+	consumerDone chan struct{}
 
 	closeMu  sync.Mutex
 	closed   bool
@@ -110,10 +123,16 @@ func (f *fpubQueue) OpenURL(ctx context.Context, u *url.URL) (broker.AsyncQueue,
 
 	// Build base path: /path/from/url/fpub-streamname
 	basePath := filepath.Join(u.Path, "fpub-"+streamName)
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if entry, ok := registry[basePath]; ok {
+		entry.refCount++
+		return entry.queue, nil
+	}
+
 	topicOptions := &TopicOptions{
-		BatcherOptions: batcher.Options{
-			MaxBatchSize: sendBatchSize,
-		},
+		BatcherOptions: batcher.Options{MaxBatchSize: sendBatchSize},
 	}
 
 	// Create topic
@@ -125,7 +144,7 @@ func (f *fpubQueue) OpenURL(ctx context.Context, u *url.URL) (broker.AsyncQueue,
 	subOpts := &SubscriptionOptions{
 		ReceiveBatcherOptions: batcher.Options{
 			MaxBatchSize: recvBatchSize,
-			MaxHandlers:  1, // Keep strict ordering
+			MaxHandlers:  1,
 		},
 	}
 
@@ -135,16 +154,17 @@ func (f *fpubQueue) OpenURL(ctx context.Context, u *url.URL) (broker.AsyncQueue,
 		_ = topic.Shutdown(ctx)
 		return nil, err
 	}
-
 	qCtx, cancel := context.WithCancel(ctx)
-	return &fpubQueue{
+	q := &fpubQueue{
 		ctx:      qCtx,
 		cancel:   cancel,
 		topic:    topic,
 		sub:      sub,
 		basePath: basePath,
 		name:     streamName,
-	}, nil
+	}
+	registry[basePath] = &fpubEntry{queue: q, refCount: 1}
+	return q, nil
 }
 
 // Push implements broker.AsyncQueue.Push.
@@ -182,35 +202,40 @@ func (f *fpubQueue) PushRaw(ctx context.Context, message broker.Message) error {
 // Consume implements broker.AsyncQueue.Consume.
 // Starts a goroutine that receives messages from the subscription
 // and invokes the callback with decoded broker.Messages.
+
+// Consume implements broker.AsyncQueue.Consume.
 func (f *fpubQueue) Consume(callback func(context.Context, ...broker.Message)) error {
+	f.closeMu.Lock()
+	if f.consumerDone == nil {
+		f.consumerDone = make(chan struct{})
+	}
+	f.closeMu.Unlock()
+
 	go func() {
+		defer close(f.consumerDone)
 		for {
 			select {
 			case <-f.ctx.Done():
-				log.Logger(f.ctx).Debug("[fpubQueue] Consumer stopping: context done", zap.String("name", f.name))
+				log.Logger(f.ctx).Debug("[fpubQueue] Consumer stopping: context done",
+					zap.String("name", f.name))
 				return
 			default:
 			}
 
 			msg, err := f.sub.Receive(f.ctx)
 			if err != nil {
+				if f.ctx.Err() != nil {
+					return
+				}
 				// Check if we're closing
 				f.closeMu.Lock()
 				closing := f.closed
 				f.closeMu.Unlock()
-				if closing {
-					log.Logger(f.ctx).Debug("[fpubQueue] Consumer stopping: queue closed", zap.String("name", f.name))
+				if closing || f.ctx.Err() != nil {
 					return
 				}
-
-				// Context canceled
-				if f.ctx.Err() != nil {
-					log.Logger(f.ctx).Debug("[fpubQueue] Consumer stopping: context error", zap.String("name", f.name), zap.Error(f.ctx.Err()))
-					return
-				}
-
-				log.Logger(f.ctx).Error("[fpubQueue] Error receiving message", zap.String("name", f.name), zap.Error(err))
-				// Brief pause before retry
+				log.Logger(f.ctx).Error("[fpubQueue] Error receiving message",
+					zap.String("name", f.name), zap.Error(err))
 				select {
 				case <-time.After(100 * time.Millisecond):
 				case <-f.ctx.Done():
@@ -219,58 +244,93 @@ func (f *fpubQueue) Consume(callback func(context.Context, ...broker.Message)) e
 				continue
 			}
 
-			// Decode the broker message
 			brokerMsg, err := broker.DecodeToBrokerMessage(msg.Body)
 			if err != nil {
-				log.Logger(f.ctx).Error("[fpubQueue] Failed to decode message", zap.String("name", f.name), zap.Error(err))
-				msg.Ack()
+				log.Logger(f.ctx).Error("[fpubQueue] decode failed, nacking for retry",
+					zap.String("name", f.name), zap.Error(err))
+				if msg.Nackable() {
+					msg.Nack()
+				} else {
+					msg.Ack()
+				}
 				continue
 			}
 
-			// Invoke callback
-			callback(f.ctx, brokerMsg)
-
-			// Acknowledge after callback completes
-			msg.Ack()
+			// Recover panics in the callback so a bad event doesn't kill the
+			// consume goroutine; Nack the message for retry up to the gocloud
+			// limit (governed by ackDeadline).
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Logger(f.ctx).Error("[fpubQueue] panic in consume callback",
+							zap.String("name", f.name), zap.Any("panic", r))
+						if msg.Nackable() {
+							msg.Nack()
+						} else {
+							msg.Ack()
+						}
+					}
+				}()
+				callback(f.ctx, brokerMsg)
+				msg.Ack()
+			}()
 		}
 	}()
 	return nil
 }
 
-// Close implements broker.AsyncQueue.Close.
-// Shuts down both subscription and topic.
+// Close implements broker.AsyncQueue.Close with refcounted teardown.
 func (f *fpubQueue) Close(ctx context.Context) error {
 	f.closeMu.Lock()
-	defer f.closeMu.Unlock()
-
 	if f.closed {
+		f.closeMu.Unlock()
 		return f.closeErr
 	}
 	f.closed = true
+	f.closeMu.Unlock()
 
-	// Cancel consumer context
+	registryMu.Lock()
+	entry, ok := registry[f.basePath]
+	if !ok || entry.queue != f {
+		registryMu.Unlock()
+		return errQueueClosed
+	}
+	entry.refCount--
+	if entry.refCount > 0 {
+		registryMu.Unlock()
+		return nil
+	}
+	delete(registry, f.basePath)
+	registryMu.Unlock() // ← Release BEFORE waiting
+
 	if f.cancel != nil {
 		f.cancel()
 	}
 
-	var errs []error
+	// Wait for Consume goroutine WITHOUT holding closeMu
+	if f.consumerDone != nil {
+		<-f.consumerDone
+	}
 
-	// Shutdown subscription first
+	// Final cleanup
+	f.closeMu.Lock()
+	defer f.closeMu.Unlock()
+
+	var errs []error
 	if f.sub != nil {
 		if err := f.sub.Shutdown(ctx); err != nil {
 			errs = append(errs, err)
 		}
 	}
-
-	// Then shutdown topic
 	if f.topic != nil {
 		if err := f.topic.Shutdown(ctx); err != nil {
 			errs = append(errs, err)
 		}
 	}
-
 	if len(errs) > 0 {
 		f.closeErr = errs[0]
 	}
 	return f.closeErr
 }
+
+func (f *fpubQueue) Done() <-chan struct{} { return f.consumerDone }

--- a/common/broker/fsqueue/adapter.go
+++ b/common/broker/fsqueue/adapter.go
@@ -54,6 +54,7 @@ import (
 
 	"github.com/pydio/cells/v5/common/broker"
 	"github.com/pydio/cells/v5/common/telemetry/log"
+	"github.com/pydio/cells/v5/common/telemetry/metrics"
 )
 
 var (
@@ -178,9 +179,15 @@ func (f *fpubQueue) Push(ctx context.Context, msg proto.Message) error {
 	f.closeMu.Unlock()
 
 	body := broker.EncodeProtoWithContext(ctx, msg)
-	return f.topic.Send(ctx, &pubsub.Message{
+	err := f.topic.Send(ctx, &pubsub.Message{
 		Body: body,
 	})
+	if err == nil {
+		metrics.Helper().Counter("fpub_push_total", "Total messages pushed to fpub queue").Inc(1)
+	} else {
+		metrics.Helper().Counter("fpub_push_errors_total", "Total push errors in fpub queue").Inc(1)
+	}
+	return err
 }
 
 // PushRaw implements broker.AsyncQueue.PushRaw.
@@ -194,16 +201,20 @@ func (f *fpubQueue) PushRaw(ctx context.Context, message broker.Message) error {
 	f.closeMu.Unlock()
 
 	body := broker.EncodeBrokerMessage(message)
-	return f.topic.Send(ctx, &pubsub.Message{
+	err := f.topic.Send(ctx, &pubsub.Message{
 		Body: body,
 	})
+	if err == nil {
+		metrics.Helper().Counter("fpub_push_raw_total", "Total raw messages pushed to fpub queue").Inc(1)
+	} else {
+		metrics.Helper().Counter("fpub_push_errors_total", "Total push errors in fpub queue").Inc(1)
+	}
+	return err
 }
 
 // Consume implements broker.AsyncQueue.Consume.
 // Starts a goroutine that receives messages from the subscription
 // and invokes the callback with decoded broker.Messages.
-
-// Consume implements broker.AsyncQueue.Consume.
 func (f *fpubQueue) Consume(callback func(context.Context, ...broker.Message)) error {
 	f.closeMu.Lock()
 	if f.consumerDone == nil {
@@ -274,6 +285,9 @@ func (f *fpubQueue) Consume(callback func(context.Context, ...broker.Message)) e
 				callback(f.ctx, brokerMsg)
 				msg.Ack()
 			}()
+
+			// Track consumed message
+			metrics.Helper().Counter("fpub_consumed_total", "Total messages consumed from fpub queue").Inc(1)
 		}
 	}()
 	return nil
@@ -303,6 +317,10 @@ func (f *fpubQueue) Close(ctx context.Context) error {
 	delete(registry, f.basePath)
 	registryMu.Unlock() // ← Release BEFORE waiting
 
+	// Track queue close
+	metrics.Helper().Counter("fpub_closed_total", "Times fpub queue was closed").Inc(1)
+
+	// Cancel consumer context
 	if f.cancel != nil {
 		f.cancel()
 	}

--- a/common/broker/fsqueue/fspubsub.go
+++ b/common/broker/fsqueue/fspubsub.go
@@ -61,13 +61,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/pydio/cells/v5/common/telemetry/metrics"
 	"github.com/rjeczalik/notify"
 	"gocloud.dev/gcerrors"
 	"gocloud.dev/pubsub"
 	"gocloud.dev/pubsub/batcher"
 	"gocloud.dev/pubsub/driver"
-
-	"github.com/pydio/cells/v5/common/telemetry/metrics"
 )
 
 func init() {
@@ -574,15 +573,11 @@ func (s *subscription) receiveNoWait(now time.Time, max int) ([]*driver.Message,
 			break
 		}
 	}
-<<<<<<< Updated upstream
-=======
 
 	// Track received messages
 	if len(msgs) > 0 {
 		metrics.Helper().Counter("fsqueue_sub_total", "Total messages received from fsqueue").Inc(int64(len(msgs)))
 	}
-
->>>>>>> Stashed changes
 	return msgs, nil
 }
 

--- a/common/broker/fsqueue/fspubsub.go
+++ b/common/broker/fsqueue/fspubsub.go
@@ -245,15 +245,11 @@ func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
 	tmpPath := filepath.Join(t.basePath, tmpDir)
 	pendPath := filepath.Join(t.basePath, pendingDir)
 
-	// Pre-allocate slices to reduce memory allocations
-	var filenames []string
-	filenames = make([]string, 0, len(ms))
-
+	filenames := make([]string, 0, len(ms))
 	for i, m := range ms {
 		m.AckID = t.nextAckID + i
 		m.LoggableID = fmt.Sprintf("msg #%d", m.AckID)
 		m.AsFunc = func(any) bool { return false }
-
 		if m.BeforeSend != nil {
 			if err := m.BeforeSend(func(any) bool { return false }); err != nil {
 				return err
@@ -265,30 +261,39 @@ func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
 		if err != nil {
 			return err
 		}
-
 		filename := fmt.Sprintf("%020d-%s.pb", m.AckID, uuid.New().String()[:8])
 		filenames = append(filenames, filename)
-
-		// Write atomically: tmp -> pending
 		tmpFile := filepath.Join(tmpPath, filename)
 		if err := os.WriteFile(tmpFile, payload, 0o644); err != nil {
+			// Roll back any tmp files written so far.
+			for _, fn := range filenames {
+				_ = os.Remove(filepath.Join(tmpPath, fn))
+			}
 			return fmt.Errorf("filepubsub: failed to write temp file: %w", err)
 		}
 	}
 
-	// Move all files to pending directory in a single loop
+	// Move all files to pending/. On failure, roll back to .tmp/.
+	var committed []string
 	for _, filename := range filenames {
 		tmpFile := filepath.Join(tmpPath, filename)
 		finalFile := filepath.Join(pendPath, filename)
 		if err := os.Rename(tmpFile, finalFile); err != nil {
-			_ = os.Remove(tmpFile)
+			// Roll back already-committed renames.
+			for _, fn := range committed {
+				_ = os.Rename(filepath.Join(pendPath, fn), filepath.Join(tmpPath, fn))
+			}
+			// Best-effort cleanup of remaining .tmp/ entries.
+			for _, fn := range filenames {
+				_ = os.Remove(filepath.Join(tmpPath, fn))
+			}
 			return fmt.Errorf("filepubsub: failed to move file to pending: %w", err)
 		}
+		committed = append(committed, filename)
 	}
 
 	t.nextAckID += len(ms)
 
-	// Notify all subscriptions
 	for _, s := range t.subs {
 		s.notifyNewMessages()
 	}
@@ -392,12 +397,16 @@ func newSubscription(t *topic, ackDeadline time.Duration) (*subscription, error)
 		topic:       t,
 		ackDeadline: ackDeadline,
 		msgs:        map[driver.AckID]*message{},
-		notifyChan:  make(chan notify.EventInfo, 100),
+		// 10000-deep buffer absorbs bursts that would otherwise drop OS-level
+		// notify events. notifyNewMessages is buffered-1 with non-blocking
+		// send, so the watcher goroutine collapses any backlog into one
+		// signal on newMsgChan; the larger buffer just guards against
+		// notify drops during the brief window before that collapse.
+		notifyChan:  make(chan notify.EventInfo, 10000),
 		newMsgChan:  make(chan struct{}, 1),
 		stopWatcher: make(chan struct{}),
 		watcherDone: make(chan struct{}),
 	}
-
 	if t != nil {
 		t.mu.Lock()
 		t.subs = append(t.subs, s)
@@ -488,16 +497,31 @@ func (s *subscription) receiveNoWait(now time.Time, max int) ([]*driver.Message,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// First, check for expired messages that need redelivery
-	for _, m := range s.msgs {
+	// 1. Collect every expired in-flight message.
+	type expiredEntry struct {
+		ackID int
+		m     *message
+	}
+	var expired []expiredEntry
+	for id, m := range s.msgs {
 		if now.After(m.expiration) {
-			// Reset expiration for redelivery
-			m.expiration = now.Add(s.ackDeadline)
-			return []*driver.Message{m.msg}, nil
+			expired = append(expired, expiredEntry{ackID: id.(int), m: m})
 		}
 	}
+	if len(expired) > 0 {
+		sort.Slice(expired, func(i, j int) bool { return expired[i].ackID < expired[j].ackID })
+		msgs := make([]*driver.Message, 0, len(expired))
+		for _, e := range expired {
+			e.m.expiration = now.Add(s.ackDeadline)
+			msgs = append(msgs, e.m.msg)
+			if len(msgs) >= max {
+				break
+			}
+		}
+		return msgs, nil
+	}
 
-	// Read new messages from pending directory
+	// 2. Claim fresh messages from pending/.
 	pendPath := filepath.Join(s.topic.basePath, pendingDir)
 	procPath := filepath.Join(s.topic.basePath, processingDir)
 
@@ -505,60 +529,45 @@ func (s *subscription) receiveNoWait(now time.Time, max int) ([]*driver.Message,
 	if err != nil {
 		return nil, err
 	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
 
-	// Pre-allocate slice to reduce memory allocations
-	var msgs []*driver.Message
-	msgs = make([]*driver.Message, 0, max)
-
-	// Sort by filename (timestamp-based ordering)
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Name() < entries[j].Name()
-	})
-
+	msgs := make([]*driver.Message, 0, max)
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".pb") {
 			continue
 		}
-
 		filename := entry.Name()
 		src := filepath.Join(pendPath, filename)
 		dst := filepath.Join(procPath, filename)
-
-		// Try to claim the message via atomic rename
 		if err := os.Rename(src, dst); err != nil {
-			// Another consumer claimed it
-			continue
+			continue // another consumer claimed it
 		}
-
-		// Read the message
 		data, err := os.ReadFile(dst)
 		if err != nil {
-			// Move back to pending for retry
-			_ = os.Rename(dst, src)
+			_ = os.Rename(dst, src) // give it back for retry
 			continue
 		}
-
 		dm, err := decodeMessage(data)
 		if err != nil {
-			// Corrupt message, remove it
-			_ = os.Remove(dst)
+			// Dead-letter conditionally rather than silent delete
+			deadDir := filepath.Join(s.topic.basePath, "dead")
+			_ = os.MkdirAll(deadDir, 0o755)
+			if mvErr := os.Rename(dst, filepath.Join(deadDir, filename)); mvErr != nil {
+				_ = os.Remove(dst)
+			}
 			continue
 		}
-
-		// Track the message for ack/nack
 		m := &message{
 			msg:        dm,
 			filename:   filename,
 			expiration: now.Add(s.ackDeadline),
 		}
 		s.msgs[dm.AckID] = m
-
 		msgs = append(msgs, dm)
 		if len(msgs) >= max {
 			break
 		}
 	}
-
 	return msgs, nil
 }
 
@@ -678,15 +687,44 @@ func (*subscription) ErrorAs(error, any) bool {
 }
 
 // Close implements driver.Subscription.Close.
+// Stops the watcher, rehomes any in-flight (claimed-but-unacked) messages
+// from processing/ back to pending/ so a sibling/next subscription can pick
+// them up without waiting for a process restart, and deregisters this
+// subscription from the topic to prevent notify leaks.
 func (s *subscription) Close() error {
 	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
 	s.closed = true
+	msgs := s.msgs
+	s.msgs = map[driver.AckID]*message{}
 	s.mu.Unlock()
 
 	// Stop the watcher
 	close(s.stopWatcher)
 	<-s.watcherDone
 
+	if s.topic != nil {
+		s.topic.mu.Lock()
+		procPath := filepath.Join(s.topic.basePath, processingDir)
+		pendPath := filepath.Join(s.topic.basePath, pendingDir)
+		for _, m := range msgs {
+			src := filepath.Join(procPath, m.filename)
+			dst := filepath.Join(pendPath, m.filename)
+			_ = os.Rename(src, dst)
+		}
+		// Deregister from topic.subs to stop the topic from notifying
+		// a closed subscription forever.
+		for i, sub := range s.topic.subs {
+			if sub == s {
+				s.topic.subs = append(s.topic.subs[:i], s.topic.subs[i+1:]...)
+				break
+			}
+		}
+		s.topic.mu.Unlock()
+	}
 	return nil
 }
 

--- a/common/broker/fsqueue/fspubsub.go
+++ b/common/broker/fsqueue/fspubsub.go
@@ -66,6 +66,8 @@ import (
 	"gocloud.dev/pubsub"
 	"gocloud.dev/pubsub/batcher"
 	"gocloud.dev/pubsub/driver"
+
+	"github.com/pydio/cells/v5/common/telemetry/metrics"
 )
 
 func init() {
@@ -297,6 +299,10 @@ func (t *topic) SendBatch(ctx context.Context, ms []*driver.Message) error {
 	for _, s := range t.subs {
 		s.notifyNewMessages()
 	}
+
+	// Track published messages
+	metrics.Helper().Counter("fsqueue_pub_total", "Total messages published to fsqueue").Inc(int64(len(ms)))
+
 	return nil
 }
 
@@ -568,6 +574,15 @@ func (s *subscription) receiveNoWait(now time.Time, max int) ([]*driver.Message,
 			break
 		}
 	}
+<<<<<<< Updated upstream
+=======
+
+	// Track received messages
+	if len(msgs) > 0 {
+		metrics.Helper().Counter("fsqueue_sub_total", "Total messages received from fsqueue").Inc(int64(len(msgs)))
+	}
+
+>>>>>>> Stashed changes
 	return msgs, nil
 }
 
@@ -635,6 +650,12 @@ func (s *subscription) SendAcks(ctx context.Context, ackIDs []driver.AckID) erro
 	for _, id := range toDelete {
 		delete(s.msgs, id)
 	}
+
+	// Track acknowledged messages
+	if len(toDelete) > 0 {
+		metrics.Helper().Counter("fsqueue_ack_total", "Total messages acknowledged in fsqueue").Inc(int64(len(toDelete)))
+	}
+
 	return nil
 }
 
@@ -672,6 +693,12 @@ func (s *subscription) SendNacks(ctx context.Context, ackIDs []driver.AckID) err
 	for _, id := range toProcess {
 		delete(s.msgs, id)
 	}
+
+	// Track nacked/redelivered messages
+	if len(toProcess) > 0 {
+		metrics.Helper().Counter("fsqueue_nack_total", "Total messages nacked/redelivered in fsqueue").Inc(int64(len(toProcess)))
+	}
+
 	return nil
 }
 

--- a/common/broker/fsqueue/fspubsub_test.go
+++ b/common/broker/fsqueue/fspubsub_test.go
@@ -868,3 +868,86 @@ func TestFpubQueueCloseAndOpenErrors(t *testing.T) {
 		So(err, ShouldNotBeNil)
 	})
 }
+
+func TestConsumeCallbackPanic(t *testing.T) {
+	Convey("Consume callback panic recovery", t, func() {
+		td, cleanup := tempDir(t, "fpubqueue-panic-*")
+		defer cleanup()
+		ctx := context.Background()
+		q := &fpubQueue{}
+
+		queue, _ := q.OpenURL(ctx, mustParseURL("fpub://"+td+"?name=panic"))
+		defer queue.Close(ctx)
+
+		panicCalled := false
+		queue.Consume(func(ctx context.Context, msgs ...broker.Message) {
+			panicCalled = true
+			panic("test panic")
+		})
+		queue.Push(ctx, &emptypb.Empty{})
+
+		time.Sleep(2 * time.Second)
+		So(panicCalled, ShouldBeTrue)
+	})
+}
+
+func TestCloseWithShutdownErrors(t *testing.T) {
+	Convey("Close handles Shutdown errors gracefully", t, func() {
+		td, cleanup := tempDir(t, "fpubqueue-shutdown-*")
+		defer cleanup()
+		ctx := context.Background()
+		q := &fpubQueue{}
+
+		queue, _ := q.OpenURL(ctx, mustParseURL("fpub://"+td+"?name=shuterr"))
+
+		queue.Consume(func(ctx context.Context, msgs ...broker.Message) {})
+
+		err := queue.Close(ctx)
+		So(err, ShouldBeNil)
+
+		err2 := queue.Close(ctx)
+		So(err2, ShouldBeNil)
+	})
+}
+
+func TestReceiveErrorHandling(t *testing.T) {
+	Convey("Receive error handling with retry", t, func() {
+		td, cleanup := tempDir(t, "fpubqueue-recverr-*")
+		defer cleanup()
+		ctx := context.Background()
+		q := &fpubQueue{}
+
+		queue, _ := q.OpenURL(ctx, mustParseURL("fpub://"+td+"?name=recverr"))
+		defer queue.Close(ctx)
+
+		messageCount := 0
+		queue.Consume(func(ctx context.Context, msgs ...broker.Message) {
+			messageCount++
+		})
+
+		// Push valid message
+		queue.Push(ctx, &emptypb.Empty{})
+
+		// Wait for message
+		start := time.Now()
+		for messageCount == 0 && time.Since(start) < 2*time.Second {
+			time.Sleep(10 * time.Millisecond)
+		}
+		So(messageCount, ShouldEqual, 1)
+	})
+}
+
+func TestPushClosedQueue(t *testing.T) {
+	Convey("Push to closed queue returns error", t, func() {
+		td, cleanup := tempDir(t, "fpubqueue-pushclose-*")
+		defer cleanup()
+		ctx := context.Background()
+		q := &fpubQueue{}
+
+		queue, _ := q.OpenURL(ctx, mustParseURL("fpub://"+td+"?name=pushclose"))
+		queue.Close(ctx)
+
+		err := queue.Push(ctx, &emptypb.Empty{})
+		So(err, ShouldEqual, errQueueClosed)
+	})
+}

--- a/common/sync/merger/tree-diff.go
+++ b/common/sync/merger/tree-diff.go
@@ -97,6 +97,7 @@ func (diff *TreeDiff) Compute(ctx context.Context, root string, lock chan bool, 
 	lTree := NewTree()
 	rTree := NewTree()
 	var errs []error
+	errLock := &sync.Mutex{}
 	wg := &sync.WaitGroup{}
 
 	for _, k := range []string{"left", "right"} {
@@ -127,7 +128,9 @@ func (diff *TreeDiff) Compute(ctx context.Context, root string, lock chan bool, 
 			}
 
 			if err != nil {
+				errLock.Lock()
 				errs = append(errs, err)
+				errLock.Unlock()
 			}
 		}(k)
 	}

--- a/common/sync/merger/tree-diff_test.go
+++ b/common/sync/merger/tree-diff_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gobwas/glob"
 	. "github.com/smartystreets/goconvey/convey"
 
+	"github.com/pydio/cells/v5/common/errors"
 	"github.com/pydio/cells/v5/common/proto/tree"
 	"github.com/pydio/cells/v5/common/sync/endpoints/memory"
 	"github.com/pydio/cells/v5/common/sync/model"
@@ -796,4 +797,39 @@ func TestTreeNodeFromSourceWithMeta(t *testing.T) {
 
 	})
 
+}
+
+type walkErrorSource struct {
+	uri string
+}
+
+func (w *walkErrorSource) GetEndpointInfo() model.EndpointInfo {
+	return model.EndpointInfo{URI: w.uri}
+}
+
+func (w *walkErrorSource) LoadNode(ctx context.Context, path string, extendedStats ...bool) (tree.N, error) {
+	return tree.LightNode(tree.NodeType_COLLECTION, "", "/", "-1", 0, 0, 0), nil
+}
+
+func (w *walkErrorSource) Walk(ctx context.Context, walknFc model.WalkNodesFunc, root string, recursive bool) error {
+	return errors.New("walk error on " + w.uri)
+}
+
+func (w *walkErrorSource) Watch(ctx context.Context, recursivePath string) (*model.WatchObject, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestTreeDiffComputeConcurrentErrorsRace(t *testing.T) {
+	Convey("Test Tree Diff Compute with concurrent errors", t, func() {
+		ctx := context.Background()
+
+		for i := 0; i < 200; i++ {
+			left := &walkErrorSource{uri: "left://ep"}
+			right := &walkErrorSource{uri: "right://ep"}
+			diff := newTreeDiff(left, right)
+
+			err := diff.Compute(ctx, "/", nil, nil)
+			So(err, ShouldNotBeNil)
+		}
+	})
 }

--- a/common/sync/task/sync-run.go
+++ b/common/sync/task/sync-run.go
@@ -87,7 +87,9 @@ func (s *Sync) run(ctx context.Context, dryRun bool, force bool) (model.Stater, 
 			s.Roots = append(s.Roots, "/")
 		}
 		for _, p := range s.Roots {
-			s.runUni(ctx, patch, p, force, rootsInfo)
+			if err := s.runUni(ctx, patch, p, force, rootsInfo); err != nil {
+				return patch, err
+			}
 		}
 		if errs, ok := patch.HasErrors(); ok {
 			//patch.Done(patch)
@@ -127,7 +129,9 @@ func (s *Sync) runUni(ctx context.Context, patch merger.Patch, rootPath string, 
 	// Feed Patch from Diff
 	err := diff.ToUnidirectionalPatch(ctx, s.Direction, patch)
 	if err != nil {
-		return err
+		// return err
+		return patch.SetPatchError(errors.Wrap(err, "error happened during diff.ToUnidirectionalPatch"))
+
 	}
 
 	// Additional failsafe filter for massive deletions
@@ -337,8 +341,8 @@ func (s *Sync) monitorDiff(ctx context.Context, diff merger.Diff, rootsInfo map[
 					}
 					s.statuses <- model.NewProcessingStatus(fmt.Sprintf("Analyzed %d nodes (%s)", total, tString))
 				}
-				close(done)
-				close(indexStatus)
+				// close(done)
+				// close(indexStatus)
 				return
 			}
 		}

--- a/common/sync/task/sync-run_test.go
+++ b/common/sync/task/sync-run_test.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2019-2021. Abstrium SAS <team (at) pydio.com>
+ * This file is part of Pydio Cells.
+ *
+ * Pydio Cells is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio Cells is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio Cells.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <https://pydio.com>.
+ */
+
+package task
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gobwas/glob"
+	"github.com/pydio/cells/v5/common/sync/endpoints/memory"
+	"github.com/pydio/cells/v5/common/sync/merger"
+	"github.com/pydio/cells/v5/common/sync/model"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type fakeDiff struct {
+	status chan model.Status
+	done   chan interface{}
+}
+
+func (f *fakeDiff) String() string { return "fakeDiff" }
+func (f *fakeDiff) Stats() map[string]interface{} {
+	return map[string]interface{}{"fake": true}
+}
+
+func (f *fakeDiff) SetupChannels(status chan model.Status, done chan interface{}, cmd *model.Command) {
+	f.status = status
+	f.done = done
+}
+
+func (f *fakeDiff) Status(s model.Status) {
+	if f.status != nil {
+		f.status <- s
+	}
+}
+
+func (f *fakeDiff) Done(info interface{}) {
+	if f.done != nil {
+		f.done <- info
+	}
+}
+
+func (f *fakeDiff) Compute(
+	ctx context.Context,
+	root string,
+	lock chan bool,
+	rootStats map[string]*model.EndpointRootStat,
+	ignores ...glob.Glob, // must match merger.Diff exactly
+) error {
+	return nil
+}
+
+func (f *fakeDiff) ToUnidirectionalPatch(ctx context.Context, direction model.DirectionType, patch merger.Patch) error {
+	return nil
+}
+
+func (f *fakeDiff) ToBidirectionalPatch(ctx context.Context, leftTarget model.PathSyncTarget, rightTarget model.PathSyncTarget, patch *merger.BidirectionalPatch) error {
+	return nil
+}
+
+func TestRunShouldFailWhenRunUniFails(t *testing.T) {
+	Convey("Given a sync with an invalid direction", t, func() {
+		left := memory.NewMemDB()
+		right := memory.NewMemDB()
+
+		s := NewSync(left, right, model.DirectionType(99))
+
+		_, err := s.run(context.Background(), false, false)
+		So(err, ShouldNotBeNil)
+
+	})
+}
+
+func TestMonitorDiffMustNotCloseDiffOwnedChannels(t *testing.T) {
+	Convey("Given a sync with a diff, when monitorDiff is called, then it should not close channels owned by the diff", t, func() {
+		s := &Sync{}
+		d := &fakeDiff{}
+
+		uri := "test://endpoint"
+		rootsInfo := map[string]*model.EndpointRootStat{
+			uri: {},
+		}
+
+		finished := s.monitorDiff(context.Background(), d, rootsInfo)
+
+		d.Status(model.NewProcessingStatus("first").SetEndpoint(uri))
+		d.Done(true)
+		<-finished
+
+		So(func() { close(d.status) }, ShouldNotPanic)
+		So(func() { close(d.done) }, ShouldNotPanic)
+	})
+}


### PR DESCRIPTION
Three critical bugs causing partial file syncs on first run:

1. Unidirectional sync ignores per-root errors
   - runUni() now returns diff.Compute() errors instead of continuing
   - Prevents incomplete patches when a root's diff fails

2. Channel ownership violation in monitorDiff
   - Remove close(done) and close(indexStatus) calls
   - Diff owns channel lifecycle; monitorDiff is consumer-only

3. Concurrent append race in TreeDiff.Compute
   - Protect errs slice with sync.Mutex
   - Two goroutines (left/right loaders) now sync error collection

4. Unit tests ` go test -race ./common/sync/merger -run TestTreeDiffComputeConcurrentErrorsRace -v` ` go test ./common/sync/task --verbose`