### PR TITLE
fix(jsonschema): Fixing Get Json Schema error

### DIFF
--- a/idm/meta/json_schema/json_schema.go
+++ b/idm/meta/json_schema/json_schema.go
@@ -350,6 +350,9 @@ func GetJsonSchema(label string, format string) ([]byte, error) {
 }
 
 func GetJsonSchemaSample(label string, name string, format string) (*structpb.Struct, error) {
+	if format == "" {
+		return nil, nil
+	}
 	byte_schema, err := NewJSONSchemaFactory(label).BuildJsonSchema(label, name, format)
 	if err != nil {
 		return nil, err

--- a/idm/meta/rest/handler.go
+++ b/idm/meta/rest/handler.go
@@ -289,13 +289,15 @@ func (s *UserMetaHandler) GetFieldSchema(req *restful.Request, rsp *restful.Resp
 
 func (s *UserMetaHandler) GetNamespaceSchema(req *restful.Request, rsp *restful.Response) error {
 	ctx := req.Request.Context()
-	typeParam := req.QueryParameter("FieldType")
-	nameParam := req.QueryParameter("Namespace")
-	formatParam := req.QueryParameter("Format")
-	schema, err := s.ServiceClient(ctx).GetNamespaceSchema(ctx, &idm.GetNamespaceSchemaRequest{FieldType: typeParam, Namespace: nameParam, Format: formatParam})
+	fd := req.QueryParameter("FieldType")
+	ns := req.QueryParameter("Namespace")
+	fp := req.QueryParameter("Format")
+
+	schema, err := s.ServiceClient(ctx).GetNamespaceSchema(ctx, &idm.GetNamespaceSchemaRequest{FieldType: fd, Namespace: ns, Format: fp})
 
 	if err != nil {
-		return err
+		log.Logger(ctx).Error("Error getting namespace schema", zap.String("fieldType", fd), zap.String("namespace", ns), zap.Error(err))
+		return errors.WithMessagef(errors.UnmarshalError, "failed to generate schema for namespace %s: %v", ns, err)
 	}
 	return rsp.WriteEntity(schema)
 }


### PR DESCRIPTION
Fixes JSON namespace creation

note: Json Namespace will be deprecated
- Request to get JSON schema for JSON type namespace is not necessary 
- Return {} for empty format field
- Validated with Integration tests