### PR TITLE
fix(thumbnails): remove omitempty on ThumbnailsMeta.Processing flag for backward compatibility with iOS application.

### DIFF
--- a/scheduler/actions/images/thumbnails.go
+++ b/scheduler/actions/images/thumbnails.go
@@ -71,7 +71,7 @@ type ThumbnailData struct {
 }
 
 type ThumbnailsMeta struct {
-	Processing bool            `json:"Processing,omitempty"`
+	Processing bool            `json:"Processing"`
 	Error      bool            `json:"Error,omitempty"`
 	Thumbnails []ThumbnailData `json:"thumbnails,omitempty"`
 }


### PR DESCRIPTION
Missing flag is creating a crash in the current iOS app. To be fixed later on in the swift code...