### PR TITLE
fix(namespace): WPB-26293-Fix add policy for Upsert method update path

### DIFF
--- a/idm/meta/dao/sql/ns-sql.go
+++ b/idm/meta/dao/sql/ns-sql.go
@@ -162,39 +162,42 @@ func (s *nsSqlImpl) Migrate(ctx context.Context) error {
 
 // Add inserts a namespace // Upsert
 func (s *nsSqlImpl) Upsert(ctx context.Context, ns *idm.UserMetaNamespace) (error, bool) {
-	// Update existing
 	var ex *MetaNamespace
 	tx0 := s.Session(ctx).Where(&MetaNamespace{Namespace: ns.Namespace}).First(&ex)
 	if tx0.Error != nil && !errors.Is(tx0.Error, gorm.ErrRecordNotFound) {
 		return nsTag(tx0.Error), false
 	}
-	if tx0.Error == nil {
+
+	isUpdate := tx0.Error == nil
+
+	if isUpdate {
+		// Update existing
 		validNs, er := (&MetaNamespace{}).FromExisting(ns)
 		if er != nil {
 			return nsTag(er), false
 		}
-
 		tx2 := s.Session(ctx).Where("namespace = ?", ns.Namespace).Select("*").Updates(validNs)
 		if tx2.Error != nil {
 			return nsTag(tx2.Error), false
 		}
-		return nil, true
-	}
-	// Insert
-	tx1 := s.Session(ctx).Create((&MetaNamespace{}).From(ns))
-	if tx1.Error != nil {
-		return nsTag(tx1.Error), false
-	}
-
-	if len(ns.Policies) > 0 {
-		if pols, err := s.AddPolicies(ctx, false, ns.Namespace, ns.Policies); err != nil {
-			return nsTag(err), false
-		} else {
-			ns.Policies = pols
+	} else {
+		// Insert
+		tx1 := s.Session(ctx).Create((&MetaNamespace{}).From(ns))
+		if tx1.Error != nil {
+			return nsTag(tx1.Error), false
 		}
 	}
 
-	return nil, false
+	// Handle policies
+	if len(ns.Policies) > 0 {
+		pols, err := s.AddPolicies(ctx, isUpdate, ns.Namespace, ns.Policies)
+		if err != nil {
+			return nsTag(err), false
+		}
+		ns.Policies = pols
+	}
+
+	return nil, isUpdate
 }
 
 // Del removes a namespace

--- a/idm/meta/dao/sql/ns-sql_test.go
+++ b/idm/meta/dao/sql/ns-sql_test.go
@@ -402,3 +402,54 @@ func TestNSDescriptionAndEnforceDefault(t *testing.T) {
 		})
 	})
 }
+
+func TestNSPoliciesOnUpsert(t *testing.T) {
+	test.RunStorageTests(nsTestcases, t, func(ctx context.Context) {
+		mockDAO, er := manager.Resolve[meta.NamespaceDAO](ctx)
+		if er != nil {
+			t.Fatal(er)
+		}
+
+		Convey("Policies added on create and update", t, func() {
+			// Create namespace with policies
+			ns := &idm.UserMetaNamespace{
+				Namespace: "test-policies",
+				Label:     "Test Policies",
+				Policies: []*service.ResourcePolicy{
+					{
+						Action:  service.ResourcePolicyAction_READ,
+						Subject: "user:admin",
+					},
+				},
+			}
+
+			_, isUpdate := mockDAO.Upsert(ctx, ns)
+			So(isUpdate, ShouldBeFalse)
+			So(len(ns.Policies), ShouldEqual, 1)
+
+			// Update same namespace - policies should persist and be reapplied
+			ns.Label = "Test Policies Updated"
+			ns.Policies = append(ns.Policies, &service.ResourcePolicy{
+				Action:  service.ResourcePolicyAction_WRITE,
+				Subject: "user:admin",
+			})
+
+			err, isUpdate := mockDAO.Upsert(ctx, ns)
+			So(err, ShouldBeNil)
+			So(isUpdate, ShouldBeTrue)
+			So(len(ns.Policies), ShouldEqual, 2)
+
+			// Verify policies are persisted
+			list, _ := mockDAO.List(ctx)
+			var found *idm.UserMetaNamespace
+			for _, item := range list {
+				if item.Namespace == "test-policies" {
+					found = item
+					break
+				}
+			}
+			So(found, ShouldNotBeNil)
+			So(len(found.Policies), ShouldEqual, 2)
+		})
+	})
+}


### PR DESCRIPTION
Ticket: [WPB:26293](https://wearezeta.atlassian.net/browse/WPB-26293)
- Due to a refactor adding policies on Namespace update was ignored on Update path
- Moved AddPolicies block outside create and update paths
- Unit test