### PR TITLE
fix(helm): remove duplicate selector labels in deployment template

### DIFF
--- a/tools/kubernetes/cells/templates/configmap.yaml
+++ b/tools/kubernetes/cells/templates/configmap.yaml
@@ -67,6 +67,9 @@ data:
     dss3bucketbinaries: {{ .Values.externalS3.ds.binaries | default "binaries" }}
     dss3bucketthumbs: {{ .Values.externalS3.ds.thumbnails | default "thumbnails" }}
     dss3bucketversions: {{ .Values.externalS3.ds.versions | default "versions" }}
+    {{- else }}
+    dstype: LOCAL
+    dsfolder: /var/cells/data
     {{- end }}
 
     customconfigs:

--- a/tools/kubernetes/cells/templates/configmap.yaml
+++ b/tools/kubernetes/cells/templates/configmap.yaml
@@ -67,9 +67,6 @@ data:
     dss3bucketbinaries: {{ .Values.externalS3.ds.binaries | default "binaries" }}
     dss3bucketthumbs: {{ .Values.externalS3.ds.thumbnails | default "thumbnails" }}
     dss3bucketversions: {{ .Values.externalS3.ds.versions | default "versions" }}
-    {{- else }}
-    dstype: LOCAL
-    dsfolder: /var/cells/data
     {{- end }}
 
     customconfigs:

--- a/tools/kubernetes/cells/templates/deployment-cells.yaml
+++ b/tools/kubernetes/cells/templates/deployment-cells.yaml
@@ -20,7 +20,6 @@ spec:
   selector:
     {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.podLabels .Values.commonLabels ) "context" . ) }}
     matchLabels: {{- include "common.labels.matchLabels" (dict "customLabels" $podLabels "context" .) | nindent 6 }}
-      {{- include "cells.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
## Problem

The `deployment-cells.yaml` Helm template includes both `common.labels.matchLabels` and `cells.selectorLabels` in `spec.selector.matchLabels`:

```yaml
matchLabels: {{- include "common.labels.matchLabels" (dict "customLabels" $podLabels "context" .) | nindent 6 }}
  {{- include "cells.selectorLabels" . | nindent 6 }}
```

Both helpers output the same two keys (`app.kubernetes.io/name` and `app.kubernetes.io/instance`), producing invalid YAML with duplicate mapping keys.

This causes strict YAML parsers to reject the rendered manifest. For example, Flux's helm-controller (which uses kustomize as a post-renderer) fails with:

```
error while running post render on files: yaml: unmarshal errors:
  line 20: mapping key "app.kubernetes.io/instance" already defined at line 17
  line 19: mapping key "app.kubernetes.io/name" already defined at line 18
```

## Fix

Remove the redundant `cells.selectorLabels` include. `common.labels.matchLabels` already produces the correct selector labels (`app.kubernetes.io/name` and `app.kubernetes.io/instance`).

## Affected versions

The bug is present in `cells-1.0.0` and all `cells-1.0.0-beta.*` chart versions that use the Bitnami common chart.