### PR TITLE
test(sync): Fix pubsub GetWriter on assertion

### DIFF
--- a/common/sync/endpoints/bus/pubsub_test.go
+++ b/common/sync/endpoints/bus/pubsub_test.go
@@ -1257,7 +1257,7 @@ func TestGetWriterOnSuccess(t *testing.T) {
 
 func TestGetWriterOnTargetError(t *testing.T) {
 	ctx := context.Background()
-	Convey("GetWriterOn ignores error from underlying target and returns nil writer anyway", t, func() {
+	Convey("GetWriterOn propagates error from underlying target", t, func() {
 		q := &mockQueue{}
 		snap := newMockSnapshot()
 		tgt := &mockDataSyncTarget{writerErr: fmt.Errorf("target error")}
@@ -1273,9 +1273,8 @@ func TestGetWriterOnTargetError(t *testing.T) {
 
 		node := &tree.Node{Path: "/test", Uuid: "uuid"}
 		out, _, _, err := ep.GetWriterOn(ctx, "/path", 1024, node)
-		// Note: Implementation swallows error from target and returns wrapped nil writer
-		So(err, ShouldBeNil)    // Returns nil error even though target had error
-		So(out, ShouldNotBeNil) // But returns wrapped writer (wrapping nil)
+		So(err, ShouldNotBeNil)
+		So(out, ShouldBeNil)
 	})
 }
 


### PR DESCRIPTION
Test: Changed test assertion as the blocking pattern introduced in [this commit ](https://github.com/pydio/cells/pull/947/changes/cb133bc1e0dd63d152b355031285ee3ce3ff9270) was removed in [this commit](https://github.com/pydio/cells/pull/947/changes/62d7993e31a002eae1b66a2b580d6ae1c514d6be) from the sync diff fix