### PR TITLE
fix: [WPB-26899] Sort by size mixes folders and files

### DIFF
--- a/common/proto/tree/meta-filter.go
+++ b/common/proto/tree/meta-filter.go
@@ -169,9 +169,6 @@ func (m *MetaFilter) Build(builder FilterBuilder) {
 			builder.OrderBy("leaf", "DESC")
 			builder.OrderBy("LOWER(name)", "ASC")
 		} else {
-			if m.sortField == MetaSortSize {
-				builder.OrderBy("leaf", "DESC")
-			}
 			sortDesc := m.sortDesc
 			if m.sortField == MetaSortType { // Switch for backward compat on "leaf" : v4 was 0/1, v5 is 1/2
 				sortDesc = !sortDesc

--- a/common/proto/tree/meta-filter.go
+++ b/common/proto/tree/meta-filter.go
@@ -169,6 +169,9 @@ func (m *MetaFilter) Build(builder FilterBuilder) {
 			builder.OrderBy("leaf", "DESC")
 			builder.OrderBy("LOWER(name)", "ASC")
 		} else {
+			if m.sortField == MetaSortSize {
+				builder.OrderBy("leaf", "DESC")
+			}
 			sortDesc := m.sortDesc
 			if m.sortField == MetaSortType { // Switch for backward compat on "leaf" : v4 was 0/1, v5 is 1/2
 				sortDesc = !sortDesc

--- a/common/proto/tree/meta-filter_test.go
+++ b/common/proto/tree/meta-filter_test.go
@@ -26,7 +26,33 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+type recordingFilterBuilder struct {
+	orders [][2]string
+}
+
+func (r *recordingFilterBuilder) And(_ interface{}, _ ...interface{}) {}
+func (r *recordingFilterBuilder) OrderBy(fieldName string, dir string) {
+	r.orders = append(r.orders, [2]string{fieldName, dir})
+}
+func (r *recordingFilterBuilder) Ors(_ []string, _ []interface{}) interface{} { return nil }
+
 func TestMetaFilter(t *testing.T) {
+	Convey("Sort by size groups folders before files", t, func() {
+		f := &MetaFilter{sortField: MetaSortSize}
+		builder := &recordingFilterBuilder{}
+
+		f.Build(builder)
+
+		So(builder.orders, ShouldResemble, [][2]string{{"leaf", "DESC"}, {"size", "ASC"}})
+
+		f = &MetaFilter{sortField: MetaSortSize, sortDesc: true}
+		builder = &recordingFilterBuilder{}
+
+		f.Build(builder)
+
+		So(builder.orders, ShouldResemble, [][2]string{{"leaf", "DESC"}, {"size", "DESC"}})
+	})
+
 	Convey("Test int filters", t, func() {
 		f := &MetaFilter{
 			reqNode: &Node{MetaStore: map[string]string{

--- a/common/proto/tree/meta-filter_test.go
+++ b/common/proto/tree/meta-filter_test.go
@@ -37,20 +37,20 @@ func (r *recordingFilterBuilder) OrderBy(fieldName string, dir string) {
 func (r *recordingFilterBuilder) Ors(_ []string, _ []interface{}) interface{} { return nil }
 
 func TestMetaFilter(t *testing.T) {
-	Convey("Sort by size groups folders before files", t, func() {
+	Convey("Sort by size uses numeric size without type grouping", t, func() {
 		f := &MetaFilter{sortField: MetaSortSize}
 		builder := &recordingFilterBuilder{}
 
 		f.Build(builder)
 
-		So(builder.orders, ShouldResemble, [][2]string{{"leaf", "DESC"}, {"size", "ASC"}})
+		So(builder.orders, ShouldResemble, [][2]string{{"size", "ASC"}})
 
 		f = &MetaFilter{sortField: MetaSortSize, sortDesc: true}
 		builder = &recordingFilterBuilder{}
 
 		f.Build(builder)
 
-		So(builder.orders, ShouldResemble, [][2]string{{"leaf", "DESC"}, {"size", "DESC"}})
+		So(builder.orders, ShouldResemble, [][2]string{{"size", "DESC"}})
 	})
 
 	Convey("Test int filters", t, func() {

--- a/data/search/dao/bleve/codec.go
+++ b/data/search/dao/bleve/codec.go
@@ -382,9 +382,6 @@ func (b *Codec) BuildQuery(qu interface{}, offset, limit int32, sortFields strin
 		for _, sf := range strings.Split(sortFields, ",") {
 			sf = strings.TrimSpace(sf)
 			if sortField, ok := validSortFields[sf]; ok {
-				if sf == tree.MetaSortSize {
-					sorts = append(sorts, "+NodeType")
-				}
 				if sortDesc {
 					sorts = append(sorts, "-"+sortField)
 				} else {

--- a/data/search/dao/bleve/codec.go
+++ b/data/search/dao/bleve/codec.go
@@ -372,11 +372,19 @@ func (b *Codec) BuildQuery(qu interface{}, offset, limit int32, sortFields strin
 
 	// Handle sorting
 	if sortFields != "" {
-		nss := b.queryNSProvider.Namespaces()
+		nss := map[string]interface{}{}
+		if b.queryNSProvider != nil {
+			for k, v := range b.queryNSProvider.Namespaces() {
+				nss[k] = v
+			}
+		}
 		var sorts []string
 		for _, sf := range strings.Split(sortFields, ",") {
 			sf = strings.TrimSpace(sf)
 			if sortField, ok := validSortFields[sf]; ok {
+				if sf == tree.MetaSortSize {
+					sorts = append(sorts, "+NodeType")
+				}
 				if sortDesc {
 					sorts = append(sorts, "-"+sortField)
 				} else {
@@ -419,20 +427,21 @@ func (b *Codec) BuildQuery(qu interface{}, offset, limit int32, sortFields strin
 	dateFacet := b.makeDateTimeFacet("ModifTime")
 	searchRequest.AddFacet("Date", dateFacet)
 
-	nss := b.queryNSProvider.Namespaces()
-	for metaName := range b.queryNSProvider.IncludedIndexes() {
-		def, _ := nss[metaName].UnmarshallDefinition()
-		if def != nil && (def.GetType() == "integer" || def.GetType() == "boolean" || def.GetType() == "date") {
-			continue
+	if b.queryNSProvider != nil {
+		nss := b.queryNSProvider.Namespaces()
+		for metaName := range b.queryNSProvider.IncludedIndexes() {
+			def, _ := nss[metaName].UnmarshallDefinition()
+			if def != nil && (def.GetType() == "integer" || def.GetType() == "boolean" || def.GetType() == "date") {
+				continue
+			}
+			metaFacet := bleve.NewFacetRequest("Meta."+metaName, 4)
+			//if def != nil && def.GetType() == "date" {
+			// Replace with a date facet - Working, but client-side the facet is not handled properly yet
+			//	fmt.Println("Replacing date facet")
+			//	metaFacet = s.makeDateTimeFacetAsNum("Meta." + metaName)
+			//}
+			searchRequest.AddFacet(metaName, metaFacet)
 		}
-		metaFacet := bleve.NewFacetRequest("Meta."+metaName, 4)
-		//if def != nil && def.GetType() == "date" {
-		// Replace with a date facet - Working, but client-side the facet is not handled properly yet
-		//	fmt.Println("Replacing date facet")
-		//	metaFacet = s.makeDateTimeFacetAsNum("Meta." + metaName)
-		//}
-		searchRequest.AddFacet(metaName, metaFacet)
-
 	}
 
 	return searchRequest, nil, nil

--- a/data/search/dao/bleve/codec_test.go
+++ b/data/search/dao/bleve/codec_test.go
@@ -2,7 +2,6 @@ package bleve
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
 	blevelib "github.com/blevesearch/bleve/v2"
@@ -10,23 +9,23 @@ import (
 	"github.com/pydio/cells/v5/common/proto/tree"
 )
 
-func TestBuildQuerySortSizeGroupsFoldersFirst(t *testing.T) {
+func TestBuildQuerySortSizeUsesNumericSizeOnly(t *testing.T) {
 	codec := &Codec{}
 
 	got, _, err := codec.BuildQuery(&tree.Query{}, 0, 0, tree.MetaSortSize, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertBleveSortContains(t, got, `"NodeType"`, `"Size"`)
+	assertBleveSortEquals(t, got, `["Size"]`)
 
 	got, _, err = codec.BuildQuery(&tree.Query{}, 0, 0, tree.MetaSortSize, true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertBleveSortContains(t, got, `"NodeType"`, `"-Size"`)
+	assertBleveSortEquals(t, got, `["-Size"]`)
 }
 
-func assertBleveSortContains(t *testing.T, got interface{}, parts ...string) {
+func assertBleveSortEquals(t *testing.T, got interface{}, want string) {
 	t.Helper()
 
 	request, ok := got.(*blevelib.SearchRequest)
@@ -37,10 +36,7 @@ func assertBleveSortContains(t *testing.T, got interface{}, parts ...string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	jsonSort := string(payload)
-	for _, part := range parts {
-		if !strings.Contains(jsonSort, part) {
-			t.Fatalf("sort %s does not contain %s", jsonSort, part)
-		}
+	if string(payload) != want {
+		t.Fatalf("unexpected sort\nwant: %s\n got: %s", want, payload)
 	}
 }

--- a/data/search/dao/bleve/codec_test.go
+++ b/data/search/dao/bleve/codec_test.go
@@ -1,0 +1,46 @@
+package bleve
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	blevelib "github.com/blevesearch/bleve/v2"
+
+	"github.com/pydio/cells/v5/common/proto/tree"
+)
+
+func TestBuildQuerySortSizeGroupsFoldersFirst(t *testing.T) {
+	codec := &Codec{}
+
+	got, _, err := codec.BuildQuery(&tree.Query{}, 0, 0, tree.MetaSortSize, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBleveSortContains(t, got, `"NodeType"`, `"Size"`)
+
+	got, _, err = codec.BuildQuery(&tree.Query{}, 0, 0, tree.MetaSortSize, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBleveSortContains(t, got, `"NodeType"`, `"-Size"`)
+}
+
+func assertBleveSortContains(t *testing.T, got interface{}, parts ...string) {
+	t.Helper()
+
+	request, ok := got.(*blevelib.SearchRequest)
+	if !ok {
+		t.Fatalf("expected *bleve.SearchRequest, got %T", got)
+	}
+	payload, err := json.Marshal(request.Sort)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonSort := string(payload)
+	for _, part := range parts {
+		if !strings.Contains(jsonSort, part) {
+			t.Fatalf("sort %s does not contain %s", jsonSort, part)
+		}
+	}
+}

--- a/data/search/dao/mongo/codec.go
+++ b/data/search/dao/mongo/codec.go
@@ -190,11 +190,19 @@ func (m *Codex) BuildQueryOptions(_ interface{}, offset, limit int32, sortFields
 	}
 	if sortFields != "" {
 		// Example: opts{Sort: bson.D{{"ts", -1}, {"nano", -1}}}
-		nss := m.QueryNsProvider.Namespaces()
+		nss := map[string]interface{}{}
+		if m.QueryNsProvider != nil {
+			for k, v := range m.QueryNsProvider.Namespaces() {
+				nss[k] = v
+			}
+		}
 		var sorts []string
 		for _, sf := range strings.Split(sortFields, ",") {
 			sf = strings.TrimSpace(sf)
 			if sortField, ok := validSortFields[sf]; ok {
+				if sf == tree.MetaSortSize {
+					sorts = append(sorts, "node_type")
+				}
 				sorts = append(sorts, sortField)
 			} else if _, ok2 := nss[sf]; ok2 {
 				sorts = append(sorts, "meta."+sf)
@@ -207,7 +215,11 @@ func (m *Codex) BuildQueryOptions(_ interface{}, offset, limit int32, sortFields
 				value = -1
 			}
 			for _, key := range sorts {
-				sorting = append(sorting, bson.E{Key: key, Value: value})
+				sortValue := value
+				if key == "node_type" {
+					sortValue = 1
+				}
+				sorting = append(sorting, bson.E{Key: key, Value: sortValue})
 			}
 			opts.Sort = sorting
 		}

--- a/data/search/dao/mongo/codec.go
+++ b/data/search/dao/mongo/codec.go
@@ -200,9 +200,6 @@ func (m *Codex) BuildQueryOptions(_ interface{}, offset, limit int32, sortFields
 		for _, sf := range strings.Split(sortFields, ",") {
 			sf = strings.TrimSpace(sf)
 			if sortField, ok := validSortFields[sf]; ok {
-				if sf == tree.MetaSortSize {
-					sorts = append(sorts, "node_type")
-				}
 				sorts = append(sorts, sortField)
 			} else if _, ok2 := nss[sf]; ok2 {
 				sorts = append(sorts, "meta."+sf)
@@ -215,11 +212,7 @@ func (m *Codex) BuildQueryOptions(_ interface{}, offset, limit int32, sortFields
 				value = -1
 			}
 			for _, key := range sorts {
-				sortValue := value
-				if key == "node_type" {
-					sortValue = 1
-				}
-				sorting = append(sorting, bson.E{Key: key, Value: sortValue})
+				sorting = append(sorting, bson.E{Key: key, Value: value})
 			}
 			opts.Sort = sorting
 		}

--- a/data/search/dao/mongo/codec_test.go
+++ b/data/search/dao/mongo/codec_test.go
@@ -1,0 +1,50 @@
+package mongo
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/pydio/cells/v5/common/proto/tree"
+)
+
+func TestBuildQueryOptionsSortSizeGroupsFoldersFirst(t *testing.T) {
+	codex := &Codex{}
+
+	got, err := codex.BuildQueryOptions(nil, 0, 0, tree.MetaSortSize, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMongoSort(t, got, bson.D{{Key: "node_type", Value: 1}, {Key: "size", Value: 1}})
+
+	got, err = codex.BuildQueryOptions(nil, 0, 0, tree.MetaSortSize, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMongoSort(t, got, bson.D{{Key: "node_type", Value: 1}, {Key: "size", Value: -1}})
+}
+
+func assertMongoSort(t *testing.T, got interface{}, want bson.D) {
+	t.Helper()
+
+	findOptions, ok := got.(*options.FindOptions)
+	if !ok {
+		t.Fatalf("expected *options.FindOptions, got %T", got)
+	}
+	if !sortsEqual(findOptions.Sort.(bson.D), want) {
+		t.Fatalf("unexpected sort\nwant: %#v\n got: %#v", want, findOptions.Sort)
+	}
+}
+
+func sortsEqual(a, b bson.D) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Key != b[i].Key || a[i].Value != b[i].Value {
+			return false
+		}
+	}
+	return true
+}

--- a/data/search/dao/mongo/codec_test.go
+++ b/data/search/dao/mongo/codec_test.go
@@ -9,20 +9,20 @@ import (
 	"github.com/pydio/cells/v5/common/proto/tree"
 )
 
-func TestBuildQueryOptionsSortSizeGroupsFoldersFirst(t *testing.T) {
+func TestBuildQueryOptionsSortSizeUsesNumericSizeOnly(t *testing.T) {
 	codex := &Codex{}
 
 	got, err := codex.BuildQueryOptions(nil, 0, 0, tree.MetaSortSize, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertMongoSort(t, got, bson.D{{Key: "node_type", Value: 1}, {Key: "size", Value: 1}})
+	assertMongoSort(t, got, bson.D{{Key: "size", Value: 1}})
 
 	got, err = codex.BuildQueryOptions(nil, 0, 0, tree.MetaSortSize, true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertMongoSort(t, got, bson.D{{Key: "node_type", Value: 1}, {Key: "size", Value: -1}})
+	assertMongoSort(t, got, bson.D{{Key: "size", Value: -1}})
 }
 
 func assertMongoSort(t *testing.T, got interface{}, want bson.D) {

--- a/data/search/grpc/search_server.go
+++ b/data/search/grpc/search_server.go
@@ -23,6 +23,7 @@ package grpc
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -159,6 +160,8 @@ func (s *SearchServer) Search(req *tree.SearchRequest, streamer tree.Searcher_Se
 		}
 	}()
 	uniques := make(map[string]bool)
+	sortDetailedBySize := req.Details && req.GetSortField() == tree.MetaSortSize
+	var detailedNodes []*tree.Node
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
@@ -203,7 +206,11 @@ func (s *SearchServer) Search(req *tree.SearchRequest, streamer tree.Searcher_Se
 						}
 
 						if readError == nil && response.GetNode() != nil {
-							_ = streamer.Send(&tree.SearchResponse{Data: &tree.SearchResponse_Node{Node: response.GetNode()}})
+							if sortDetailedBySize {
+								detailedNodes = append(detailedNodes, response.GetNode())
+							} else {
+								_ = streamer.Send(&tree.SearchResponse{Data: &tree.SearchResponse_Node{Node: response.GetNode()}})
+							}
 						} else if errors.Is(readError, errors.StatusNotFound) {
 
 							log.Logger(ctx).Error("Found node that does not exists, send event to make sure all is sync'ed.", zap.String("uuid", node.Uuid))
@@ -219,6 +226,17 @@ func (s *SearchServer) Search(req *tree.SearchRequest, streamer tree.Searcher_Se
 
 				}
 			case <-doneChan:
+				if sortDetailedBySize {
+					sort.SliceStable(detailedNodes, func(i, j int) bool {
+						if req.GetSortDirDesc() {
+							return detailedNodes[i].GetSize() > detailedNodes[j].GetSize()
+						}
+						return detailedNodes[i].GetSize() < detailedNodes[j].GetSize()
+					})
+					for _, detailedNode := range detailedNodes {
+						_ = streamer.Send(&tree.SearchResponse{Data: &tree.SearchResponse_Node{Node: detailedNode}})
+					}
+				}
 				return
 			}
 		}

--- a/data/source/index/grpc/handler_test.go
+++ b/data/source/index/grpc/handler_test.go
@@ -561,7 +561,7 @@ func TestIndex(t *testing.T) {
 			So(resp.(*tree.ReadNodeResponse).Node.Uuid, ShouldEqual, "test_create_delete_create")
 		})
 
-		Convey("Sort by size keeps folders grouped and files ordered by size", t, func() {
+		Convey("Sort by size orders all nodes by numeric size", t, func() {
 			root := &tree.Node{Path: "/sort-by-size-root", Uuid: "sort-by-size-root", Type: tree.NodeType_COLLECTION}
 			folderA := &tree.Node{Path: "/sort-by-size-root/folder-a", Uuid: "sort-by-size-folder-a", Type: tree.NodeType_COLLECTION}
 			folderB := &tree.Node{Path: "/sort-by-size-root/folder-b", Uuid: "sort-by-size-folder-b", Type: tree.NodeType_COLLECTION}
@@ -581,18 +581,24 @@ func TestIndex(t *testing.T) {
 			So(nodes[0].Type, ShouldEqual, tree.NodeType_COLLECTION)
 			So(nodes[1].Type, ShouldEqual, tree.NodeType_COLLECTION)
 			So(nodes[2].Path, ShouldEqual, "/sort-by-size-root/small.txt")
+			So(nodes[2].Size, ShouldEqual, 10)
 			So(nodes[3].Path, ShouldEqual, "/sort-by-size-root/medium.txt")
+			So(nodes[3].Size, ShouldEqual, 20)
 			So(nodes[4].Path, ShouldEqual, "/sort-by-size-root/large.txt")
+			So(nodes[4].Size, ShouldEqual, 30)
 
 			resp, _ = send(ctx, s, "ListNodes", &tree.ListNodesRequest{Node: root, SortField: tree.MetaSortSize, SortDirDesc: true})
 			So(resp, ShouldNotBeNil)
 			nodes = collectListNodes(resp.(*List))
 			So(nodes, ShouldHaveLength, 5)
-			So(nodes[0].Type, ShouldEqual, tree.NodeType_COLLECTION)
-			So(nodes[1].Type, ShouldEqual, tree.NodeType_COLLECTION)
-			So(nodes[2].Path, ShouldEqual, "/sort-by-size-root/large.txt")
-			So(nodes[3].Path, ShouldEqual, "/sort-by-size-root/medium.txt")
-			So(nodes[4].Path, ShouldEqual, "/sort-by-size-root/small.txt")
+			So(nodes[0].Path, ShouldEqual, "/sort-by-size-root/large.txt")
+			So(nodes[0].Size, ShouldEqual, 30)
+			So(nodes[1].Path, ShouldEqual, "/sort-by-size-root/medium.txt")
+			So(nodes[1].Size, ShouldEqual, 20)
+			So(nodes[2].Path, ShouldEqual, "/sort-by-size-root/small.txt")
+			So(nodes[2].Size, ShouldEqual, 10)
+			So(nodes[3].Type, ShouldEqual, tree.NodeType_COLLECTION)
+			So(nodes[4].Type, ShouldEqual, tree.NodeType_COLLECTION)
 		})
 
 		Convey("Test List Nodes Output Pathes", t, func() {

--- a/data/source/index/grpc/handler_test.go
+++ b/data/source/index/grpc/handler_test.go
@@ -561,6 +561,40 @@ func TestIndex(t *testing.T) {
 			So(resp.(*tree.ReadNodeResponse).Node.Uuid, ShouldEqual, "test_create_delete_create")
 		})
 
+		Convey("Sort by size keeps folders grouped and files ordered by size", t, func() {
+			root := &tree.Node{Path: "/sort-by-size-root", Uuid: "sort-by-size-root", Type: tree.NodeType_COLLECTION}
+			folderA := &tree.Node{Path: "/sort-by-size-root/folder-a", Uuid: "sort-by-size-folder-a", Type: tree.NodeType_COLLECTION}
+			folderB := &tree.Node{Path: "/sort-by-size-root/folder-b", Uuid: "sort-by-size-folder-b", Type: tree.NodeType_COLLECTION}
+			fileSmall := &tree.Node{Path: "/sort-by-size-root/small.txt", Uuid: "sort-by-size-small", Type: tree.NodeType_LEAF, Size: 10}
+			fileMedium := &tree.Node{Path: "/sort-by-size-root/medium.txt", Uuid: "sort-by-size-medium", Type: tree.NodeType_LEAF, Size: 20}
+			fileLarge := &tree.Node{Path: "/sort-by-size-root/large.txt", Uuid: "sort-by-size-large", Type: tree.NodeType_LEAF, Size: 30}
+
+			for _, node := range []*tree.Node{root, folderA, folderB, fileMedium, fileLarge, fileSmall} {
+				_, err := send(ctx, s, "CreateNode", &tree.CreateNodeRequest{Node: node})
+				So(err, ShouldBeNil)
+			}
+
+			resp, _ := send(ctx, s, "ListNodes", &tree.ListNodesRequest{Node: root, SortField: tree.MetaSortSize})
+			So(resp, ShouldNotBeNil)
+			nodes := collectListNodes(resp.(*List))
+			So(nodes, ShouldHaveLength, 5)
+			So(nodes[0].Type, ShouldEqual, tree.NodeType_COLLECTION)
+			So(nodes[1].Type, ShouldEqual, tree.NodeType_COLLECTION)
+			So(nodes[2].Path, ShouldEqual, "/sort-by-size-root/small.txt")
+			So(nodes[3].Path, ShouldEqual, "/sort-by-size-root/medium.txt")
+			So(nodes[4].Path, ShouldEqual, "/sort-by-size-root/large.txt")
+
+			resp, _ = send(ctx, s, "ListNodes", &tree.ListNodesRequest{Node: root, SortField: tree.MetaSortSize, SortDirDesc: true})
+			So(resp, ShouldNotBeNil)
+			nodes = collectListNodes(resp.(*List))
+			So(nodes, ShouldHaveLength, 5)
+			So(nodes[0].Type, ShouldEqual, tree.NodeType_COLLECTION)
+			So(nodes[1].Type, ShouldEqual, tree.NodeType_COLLECTION)
+			So(nodes[2].Path, ShouldEqual, "/sort-by-size-root/large.txt")
+			So(nodes[3].Path, ShouldEqual, "/sort-by-size-root/medium.txt")
+			So(nodes[4].Path, ShouldEqual, "/sort-by-size-root/small.txt")
+		})
+
 		Convey("Test List Nodes Output Pathes", t, func() {
 
 			f := &tree.Node{Path: "/proot", Uuid: "output-uuid"}
@@ -773,6 +807,18 @@ func BenchmarkIndexCancel(b *testing.B) {
 
 }
 */
+
+func collectListNodes(list *List) []*tree.Node {
+	var nodes []*tree.Node
+	for {
+		response, err := list.Recv()
+		if err != nil {
+			break
+		}
+		nodes = append(nodes, response.Node)
+	}
+	return nodes
+}
 
 func mustCreateNodeReadResponse(ctx context.Context, s *TreeServer, node *tree.Node) *tree.Node {
 	resp, er := s.CreateNode(ctx, &tree.CreateNodeRequest{Node: node})


### PR DESCRIPTION
Ticket: [WPB:26899](https://wearezeta.atlassian.net/browse/WPB-26899)

- Fix sort by size for mixed folder/file search results.
- Remove folder/file grouping from size sort emission; `SortField=size` now sorts by numeric size across node types.
- Fix detailed search responses: when `Details=true`, live tree detail reads can compute folder sizes after index sorting. Re-sort detailed size results by returned `Node.Size` before streaming.
- Add regression coverage for SQL browse sort and Bleve/Mongo sort emission.

Validation:
Validated via integration tests locally https://github.com/pydio/cells-integration-tests/pull/36
