### PR TITLE
fix(search): WPB-27044 escape special characters in Mongo path filters

### DIFF
--- a/data/search/dao/indexer_test.go
+++ b/data/search/dao/indexer_test.go
@@ -470,6 +470,22 @@ func TestSearchOnPathPrefixes(t *testing.T) {
 				Size:      24,
 				MetaStore: map[string]string{"name": "\"deleted-node.txt\""},
 			},
+			{
+				Uuid:      "docID101",
+				Path:      "/path/Folder E (new)/ReportDocE.docx",
+				MTime:     time.Now().Unix(),
+				Type:      tree.NodeType_LEAF,
+				Size:      24,
+				MetaStore: map[string]string{"name": "\"ReportDocE.docx\""},
+			},
+			{
+				Uuid:      "docID102",
+				Path:      "/path/Folder E [new]/ReportDocE.docx",
+				MTime:     time.Now().Unix(),
+				Type:      tree.NodeType_LEAF,
+				Size:      24,
+				MetaStore: map[string]string{"name": "\"ReportDocE.docx\""},
+			},
 		}
 		if err = createNodes(ctx, server, testNodes...); err != nil {
 			panic(err)
@@ -505,6 +521,17 @@ func TestSearchOnPathPrefixes(t *testing.T) {
 			results, _, e = performSearch(ctx, server, queryObject)
 			So(e, ShouldBeNil)
 			So(results, ShouldHaveLength, 1)
+
+			for _, prefix := range []string{"/path/Folder E (new)/", "/path/Folder E [new]/"} {
+				queryObject = &tree.Query{
+					FileName:   "ReportDocE",
+					PathPrefix: []string{prefix},
+				}
+
+				results, _, e = performSearch(ctx, server, queryObject)
+				So(e, ShouldBeNil)
+				So(results, ShouldHaveLength, 1)
+			}
 
 		})
 

--- a/data/search/dao/mongo/codec.go
+++ b/data/search/dao/mongo/codec.go
@@ -257,6 +257,14 @@ func appendRegexTerm(metaName, term string, not bool, singleTerm bool, filters [
 	})
 }
 
+func anchoredPathRegex(path string, exact bool) string {
+	pattern := "^" + regexp.QuoteMeta(path)
+	if exact {
+		return pattern + "$"
+	}
+	return pattern
+}
+
 // TODO: optimize the regex for multiple terms with OR
 //
 //	parts := strings.Split(terms, "|")
@@ -352,14 +360,14 @@ func (m *Codex) BuildQuery(query interface{}, _, _ int32, _ string, _ bool) (int
 	if len(queryObject.Paths) > 0 {
 		ors := bson.A{}
 		for _, pa := range queryObject.Paths {
-			ors = append(ors, bson.M{"path": primitive.Regex{Pattern: "^" + pa + "$", Options: "i"}})
+			ors = append(ors, bson.M{"path": primitive.Regex{Pattern: anchoredPathRegex(pa, true), Options: "i"}})
 		}
 		filters = append(filters, bson.E{Key: "$or", Value: ors})
 
 	} else if len(queryObject.PathPrefix) > 0 {
 		ors := bson.A{}
 		for _, prefix := range queryObject.PathPrefix {
-			ors = append(ors, bson.M{"path": primitive.Regex{Pattern: "^" + prefix, Options: "i"}})
+			ors = append(ors, bson.M{"path": primitive.Regex{Pattern: anchoredPathRegex(prefix, false), Options: "i"}})
 		}
 		filters = append(filters, bson.E{Key: "$or", Value: ors})
 	}
@@ -367,7 +375,7 @@ func (m *Codex) BuildQuery(query interface{}, _, _ int32, _ string, _ bool) (int
 	if len(queryObject.ExcludedPathPrefix) > 0 {
 		nors := bson.A{}
 		for _, prefix := range queryObject.ExcludedPathPrefix {
-			nors = append(nors, bson.M{"path": primitive.Regex{Pattern: "^" + prefix, Options: "i"}})
+			nors = append(nors, bson.M{"path": primitive.Regex{Pattern: anchoredPathRegex(prefix, false), Options: "i"}})
 		}
 		filters = append(filters, bson.E{Key: "$nor", Value: nors})
 	}

--- a/data/search/dao/mongo/codec_test.go
+++ b/data/search/dao/mongo/codec_test.go
@@ -1,0 +1,24 @@
+package mongo
+
+import "testing"
+
+func TestAnchoredPathRegexEscapesPathCharacters(t *testing.T) {
+	tests := []struct {
+		name  string
+		path  string
+		exact bool
+		want  string
+	}{
+		{name: "prefix with parentheses", path: "/path/Folder E (new)/", want: `^/path/Folder E \(new\)/`},
+		{name: "prefix with brackets", path: "/path/Folder E [new]/", want: `^/path/Folder E \[new\]/`},
+		{name: "exact path", path: "/path/Report[1].docx", exact: true, want: `^/path/Report\[1\]\.docx$`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := anchoredPathRegex(tt.path, tt.exact); got != tt.want {
+				t.Fatalf("anchoredPathRegex() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- escape Mongo path filters before using them as regular expressions
- cover exact paths, included prefixes, and excluded prefixes
- add regression tests for folder names containing parentheses and square brackets

refer to https://wearezeta.atlassian.net/browse/WPB-27044

related to https://github.com/pydio/cells-integration-tests/pull/37