### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Please read the [CONTRIBUTING.md](CONTRIBUTING.md) document if you wish to add m
 
 Binaries are currently provided for [Linux, macOS and Windows distributions](https://pydio.com/en/download). To deploy them on a live system, please see the [Installation Guide](https://docs.pydio.com/cells-v4/admin-guide/quick-start/cells-installation/index/) instructions.
 
+If you would rather not run a server yourself, Cells can also be deployed as a managed instance:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/pydio-cells)
+
 
 ## Contributing
 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Pydio Cells to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Pre-built Binaries (links to https://zenith.hosting/host/pydio-cells).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

docs-only change, no code touched, so there is nothing to test or build.