### PR TITLE
fix: [WPB-27814] folder named recycle_bin disappears

### DIFF
--- a/common/proto/tree/meta-filter_test.go
+++ b/common/proto/tree/meta-filter_test.go
@@ -70,4 +70,19 @@ func TestMetaFilter(t *testing.T) {
 		So(f.Match("otherExt.jpg", n6), ShouldBeTrue)
 		So(f.Match("otherExt.ext", n6), ShouldBeTrue)
 	})
+
+	Convey("Test no-grep recycle anchoring (WPB-27814)", t, func() {
+		anchored := &MetaFilter{reqNode: &Node{MetaStore: map[string]string{
+			"no-grep": `"^recycle_bin$"`,
+		}}}
+		So(anchored.Parse(), ShouldBeTrue)
+		So(anchored.Match("wpb27814_recycle_bin_folder", &Node{}), ShouldBeTrue)
+		So(anchored.Match("recycle_bin", &Node{}), ShouldBeFalse)
+
+		unanchored := &MetaFilter{reqNode: &Node{MetaStore: map[string]string{
+			"no-grep": `"recycle_bin"`,
+		}}}
+		So(unanchored.Parse(), ShouldBeTrue)
+		So(unanchored.Match("wpb27814_recycle_bin_folder", &Node{}), ShouldBeFalse)
+	})
 }

--- a/common/storage/sql/index/dao_test.go
+++ b/common/storage/sql/index/dao_test.go
@@ -31,6 +31,7 @@ import (
 	"path"
 	"reflect"
 	osruntime "runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -162,6 +163,50 @@ func TestGetNodeChildren(t *testing.T) {
 			for node := range dao.GetNodeChildren(ctx, tree.NewMPath(1, 3289, 8, 18, 4, 1, 1)) {
 				fmt.Println(node.(*tree.TreeNode).MPath)
 			}
+		}
+	})
+}
+
+func TestNoGrepRecycleExactMatch(t *testing.T) {
+	testAll(t, func(ctx context.Context, dao testdao) func(t *testing.T) {
+		return func(t *testing.T) {
+			Convey("no-grep ^recycle_bin$ excludes only the exact recycle folder", t, func() {
+				parent, _, err := dao.GetOrCreateNodeByPath(ctx, "/wpb27814", &tree.Node{
+					Uuid: "wpb27814-parent",
+					Type: tree.NodeType_COLLECTION,
+				})
+				So(err, ShouldBeNil)
+
+				for _, name := range []string{"recycle_bin", "wpb27814_recycle_bin_folder", "other"} {
+					_, _, err = dao.GetOrCreateNodeByPath(ctx, "/wpb27814/"+name, &tree.Node{
+						Uuid: name,
+						Type: tree.NodeType_COLLECTION,
+					})
+					So(err, ShouldBeNil)
+				}
+
+				anchored := tree.NewMetaFilter(&tree.Node{MetaStore: map[string]string{
+					"no-grep": `"^recycle_bin$"`,
+				}})
+				So(anchored.Parse(), ShouldBeTrue)
+				var names []string
+				for node := range dao.GetNodeChildren(ctx, parent.GetMPath(), anchored) {
+					names = append(names, node.(*tree.TreeNode).Name)
+				}
+				sort.Strings(names)
+				So(names, ShouldResemble, []string{"other", "wpb27814_recycle_bin_folder"})
+
+				unanchored := tree.NewMetaFilter(&tree.Node{MetaStore: map[string]string{
+					"no-grep": `"recycle_bin"`,
+				}})
+				So(unanchored.Parse(), ShouldBeTrue)
+				var unanchoredNames []string
+				for node := range dao.GetNodeChildren(ctx, parent.GetMPath(), unanchored) {
+					unanchoredNames = append(unanchoredNames, node.(*tree.TreeNode).Name)
+				}
+				sort.Strings(unanchoredNames)
+				So(unanchoredNames, ShouldResemble, []string{"other"})
+			})
 		}
 	})
 }

--- a/gateway/restv2/api-lookup.go
+++ b/gateway/restv2/api-lookup.go
@@ -185,7 +185,7 @@ func (h *Handler) Lookup(req *restful.Request, resp *restful.Response) error {
 					bulkRequest.Filters["type"] = filter.Type.String()
 				}
 				if deletedStatus == rest.LookupFilter_StatusFilter_Not {
-					bulkRequest.Filters[tree.MetaFilterNoGrep] = common.RecycleBinName
+					bulkRequest.Filters[tree.MetaFilterNoGrep] = "^" + common.RecycleBinName + "$"
 				}
 			}
 			bulkRecursive = scope.Recursive


### PR DESCRIPTION
## Problem

Any folder that contain *recycle_bin* is considered deleted and filter by the cells-wire cli

## Fix

Anchor the filter to `^recycle_bin$` → `grepToLike` drops the `%` wrappers → DAO emits `name NOT LIKE 'recycle_bin'` (exact leaf-name). For non-recursive `GetNodeChildren`, leaf-name equality ≡ exact path-segment equality, so the genuine `recycle_bin` folder stays excluded while substring-named live folders reappear. Non-SQL backends already match exactly via the in-memory regex path.


## Replicate script

```bash
#!/usr/bin/env bash
# WPB-27814 — reproduce recycle_bin substring-filter bug.
set -euo pipefail

TOKEN=$(./cells admin user token -u admin -e 1h -q)
H="Authorization: Bearer $TOKEN"
BASE=https://localhost:8080

# create test tree
curl -sk -X POST -H "$H" -H 'Content-Type: application/json' -d '{
  "Inputs":[
    {"Locator":{"Path":"/common-files/wpb27814-test"},"Type":"COLLECTION"},
    {"Locator":{"Path":"/common-files/wpb27814-test/recycle_bin"},"Type":"COLLECTION"},
    {"Locator":{"Path":"/common-files/wpb27814-test/wpb27814_recycle_bin_folder"},"Type":"COLLECTION"},
    {"Locator":{"Path":"/common-files/wpb27814-test/other"},"Type":"COLLECTION"}
  ],"Recursive":true
}' "$BASE/v2/n/nodes/create"

echo "--- list parent (default Status.Deleted=Not) ---"
curl -sk -X POST -H "$H" -H 'Content-Type: application/json' \
  -d '{"Scope":{"Root":{"Path":"/common-files/wpb27814-test"}}}' \
  "$BASE/v2/n/nodes"
```

Ticket: [WPB-27814](https://wearezeta.atlassian.net/browse/WPB-27814)

[WPB-27814]: https://wearezeta.atlassian.net/browse/WPB-27814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ