### PR TITLE
fix(convert-tools): ensure /tmp is writable

### DIFF
--- a/tools/kubernetes/cells/templates/deployment-convert-tools.yaml
+++ b/tools/kubernetes/cells/templates/deployment-convert-tools.yaml
@@ -62,4 +62,11 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.convertTools.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp-storage
+              mountPath: /tmp
+      volumes:
+        - name: tmp-storage
+          emptyDir:
+            sizeLimit: 10Gi
 {{- end }}


### PR DESCRIPTION
Ensures that `/tmp` is writable even if `containerSecurityContext.readOnlyRootFilesystem=true`.
`sizeLimit` is set to `10Gi` to have _some_ sort of cap on the node storage usage.

Background: `unoserver` doesn't start up when `/tmp` is not writable.